### PR TITLE
FIX #46, also fixes the following issues:

### DIFF
--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -120,6 +120,7 @@ class Scenario(object):
         self.add_argument(name='overall_obj', help=None, default='par10')
         self.add_argument(name='cutoff_time', help=None, default=999999999,
                           dest='cutoff', callback=lambda arg: float(arg))
+        self.add_argument(name='memory_limit', help=None)
         self.add_argument(name='tuner-timeout', help=None, default=numpy.inf,
                           dest='algo_runs_timelimit',
                           callback=lambda arg: float(arg))

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -149,10 +149,6 @@ class SMBO(BaseSolver):
                                             par_factor=scenario.par_factor)
         else:
             self.executor = tae_runner
-        if scenario.memory_limit is not None and \
-                not isinstance(tae_runner, ExecuteTAFunc):
-            raise ValueError('Argument memory limit can only be used together '
-                             'with a python function (ExecuteTAFunc).')
 
         self.inten = Intensifier(executor=self.executor,
                                  stats=self.stats,

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -23,6 +23,7 @@ from smac.smbo.objective import average_cost, total_runtime
 from smac.tae.execute_ta_run import StatusType
 from smac.stats.stats import Stats
 from smac.tae.execute_ta_run_old import ExecuteTARunOld
+from smac.tae.execute_func import ExecuteTAFunc
 from smac.utils.io.traj_logging import TrajLogger
 
 from smac.epm.rfr_imputator import RFRImputator
@@ -148,6 +149,10 @@ class SMBO(BaseSolver):
                                             par_factor=scenario.par_factor)
         else:
             self.executor = tae_runner
+        if scenario.memory_limit is not None and \
+                not isinstance(tae_runner, ExecuteTAFunc):
+            raise ValueError('Argument memory limit can only be used together '
+                             'with a python function (ExecuteTAFunc).')
 
         self.inten = Intensifier(executor=self.executor,
                                  stats=self.stats,

--- a/smac/tae/execute_func.py
+++ b/smac/tae/execute_func.py
@@ -18,35 +18,23 @@ __version__ = "0.0.1"
 
 class ExecuteTAFunc(ExecuteTARun):
 
-    """
-        executes a function  with given inputs (i.e., the configuration)
-        and some resource limitations
+    """Evaluate function for given configuration and resource limit.
 
-        Attributes
-        ----------
-        func : Python function handle 
-            function to be optimized
-        run_obj: str
-            run objective (runtime or quality)
-        par_factor: int
-            penalized average runtime factor
+    Parameters
+    ----------
+    func : callable
+        Function to be optimized. Needs to accept at least a configuration and a
+        seed. Can return a float (the loss) or a tuple (the loss and additional
+        run information in a dictionary).
+    stats : smac.stats.stats.Stats
+        Stats object to collect statistics about runtime etc.
+    run_obj: str
+        Run objective (runtime or quality)
+    par_factor: int
+        Penalized average runtime factor. Only used when `run_obj='runtime'`
     """
 
     def __init__(self, func, stats, run_obj="quality", par_factor=1):
-        """
-        Constructor
-
-        Parameters
-        ----------
-            func: function
-                target algorithm function
-            stats: Stats()
-                 stats object to collect statistics about runtime and so on
-            run_obj: str
-                run objective of SMAC
-            par_factor: int
-                penalized average runtime factor
-        """
         super()
         
         self.func = func
@@ -55,9 +43,9 @@ class ExecuteTAFunc(ExecuteTARun):
         self.run_obj = run_obj
         self.par_factor = par_factor
 
-    
     def run(self, config, instance=None,
-            cutoff=99999999999999.,
+            cutoff=None,
+            memory_limit=None,
             seed=12345,
             instance_specific="0"
             ):
@@ -70,10 +58,14 @@ class ExecuteTAFunc(ExecuteTARun):
             ----------
                 config : dictionary (or similar)
                     dictionary param -> value
-                instance : string
+                instance : str
                     problem instance
-                cutoff : double
-                    runtime cutoff -- will be casted to int
+                cutoff : int, optional
+                    Wallclock time limit of the target algorithm. If no value is
+                    provided no limit will be enforced.
+                memory_limit : int, optional
+                    Memory limit in MB enforced on the target algorithm If no
+                    value is provided no limit will be enforced.
                 seed : int
                     random seed
                 instance_specific: str
@@ -90,20 +82,33 @@ class ExecuteTAFunc(ExecuteTARun):
                     all further additional run information
         """
 
-        obj = pynisher.enforce_limits(
-            cpu_time_in_s=int(math.ceil(cutoff)), logger=logging.getLogger("pynisher"))(self.func)
+        arguments = {'logger': logging.getLogger("pynisher")}
+        if cutoff is not None:
+            arguments['wall_time_in_s'] = int(math.ceil(cutoff))
+        if memory_limit is not None:
+            arguments['mem_in_mb'] = int(math.ceil(memory_limit))
+
+        obj = pynisher.enforce_limits(**arguments)(self.func)
 
         if instance:
-            result = obj(config, instance, seed)
+            rval = obj(config, instance, seed)
         else:
-            result = obj(config, seed)
+            rval = obj(config, seed)
 
-        #self.logger.debug("Function value: %.4f" % (result))
+        if isinstance(rval, tuple):
+            result = rval[0]
+            additional_run_info = rval[1]
+        else:
+            result = rval
+            additional_run_info = {}
 
-        if obj.exit_status is pynisher.CpuTimeoutException:
+        if obj.exit_status is pynisher.TimeoutException:
             status = StatusType.TIMEOUT
             cost = 1234567890
-        elif obj.exit_status == 0:
+        elif obj.exit_status is pynisher.MemorylimitException:
+            status = StatusType.MEMOUT
+            cost = 1234567890
+        elif obj.exit_status == 0 and result is not None:
             status = StatusType.SUCCESS
             cost = result
         else:
@@ -118,4 +123,4 @@ class ExecuteTAFunc(ExecuteTARun):
             else:
                 cost = runtime
 
-        return status, cost, runtime, {}
+        return status, cost, runtime, additional_run_info

--- a/smac/tae/execute_func.py
+++ b/smac/tae/execute_func.py
@@ -43,6 +43,8 @@ class ExecuteTAFunc(ExecuteTARun):
         self.run_obj = run_obj
         self.par_factor = par_factor
 
+        self._supports_memory_limit = True
+
     def run(self, config, instance=None,
             cutoff=None,
             memory_limit=None,

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -19,6 +19,8 @@ from smac.smbo.smbo import SMBO, get_types
 from smac.scenario.scenario import Scenario
 from smac.smbo.acquisition import EI, EIPS
 from smac.smbo.local_search import LocalSearch
+from smac.tae.execute_func import ExecuteTAFunc
+from smac.stats.stats import Stats
 from smac.utils import test_helpers
 from smac.epm.rf_with_instances import RandomForestWithInstances
 from smac.epm.uncorrelated_mo_rf_with_instances import \
@@ -42,6 +44,17 @@ class TestSMBO(unittest.TestCase):
 
     def setUp(self):
         self.scenario = Scenario({'cs': test_helpers.get_branin_config_space()})
+
+    def test_set_memory_limit(self):
+        self.scenario.memory_limit = 1024
+        self.assertRaisesRegex(ValueError, 'Argument memory limit can only be '
+                                           'used together with a python '
+                                           'function \(ExecuteTAFunc\)',
+                               SMBO, self.scenario)
+        stats = Stats(self.scenario)
+        SMBO(tae_runner=ExecuteTAFunc(lambda: 1, stats=stats),
+             scenario=self.scenario,
+             stats=stats)
         
     def branin(self, x):
         y = (x[:, 1] - (5.1 / (4 * np.pi ** 2)) * x[:, 0] ** 2 + 5 * x[:, 0] / np.pi - 6) ** 2

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -44,17 +44,6 @@ class TestSMBO(unittest.TestCase):
 
     def setUp(self):
         self.scenario = Scenario({'cs': test_helpers.get_branin_config_space()})
-
-    def test_set_memory_limit(self):
-        self.scenario.memory_limit = 1024
-        self.assertRaisesRegex(ValueError, 'Argument memory limit can only be '
-                                           'used together with a python '
-                                           'function \(ExecuteTAFunc\)',
-                               SMBO, self.scenario)
-        stats = Stats(self.scenario)
-        SMBO(tae_runner=ExecuteTAFunc(lambda: 1, stats=stats),
-             scenario=self.scenario,
-             stats=stats)
         
     def branin(self, x):
         y = (x[:, 1] - (5.1 / (4 * np.pi ** 2)) * x[:, 0] ** 2 + 5 * x[:, 0] / np.pi - 6) ** 2

--- a/test/test_tae/test_exec_func.py
+++ b/test/test_tae/test_exec_func.py
@@ -78,11 +78,11 @@ class TestExecuteFunc(unittest.TestCase):
         self.assertGreaterEqual(rval[2], 1)
         self.assertEqual(rval[3], dict())
 
-    @unittest.mock.patch('autosklearn.evaluation.eval_holdout')
-    def test_fail_silent(self, pynisher_mock):
-        pynisher_mock.return_value = None
+    def test_fail_silent(self):
+        def function(*args):
+            return
 
-        taf = ExecuteTAFunc(func=pynisher_mock, stats=self.stats)
+        taf = ExecuteTAFunc(func=function, stats=self.stats)
         rval = taf.run(config=None, cutoff=1)
         self.assertEqual(rval[0], StatusType.CRASHED)
         self.assertEqual(rval[1], 1234567890)

--- a/test/test_tae/test_exec_func.py
+++ b/test/test_tae/test_exec_func.py
@@ -1,0 +1,90 @@
+import time
+import unittest
+import unittest.mock
+
+import numpy as np
+import pynisher
+
+from smac.tae.execute_func import ExecuteTAFunc
+from smac.scenario.scenario import Scenario
+from smac.stats.stats import Stats
+from smac.smbo.smbo import StatusType
+
+
+class TestExecuteFunc(unittest.TestCase):
+
+    def setUp(self):
+        self.scenario = Scenario({})
+        self.stats = Stats(scenario=self.scenario)
+
+    def test_run(self):
+        target = lambda x, _: x**2
+        taf = ExecuteTAFunc(func=target, stats=self.stats)
+        rval = taf.run(config=2)
+        self.assertEqual(rval[0], StatusType.SUCCESS)
+        self.assertEqual(rval[1], 4)
+        self.assertGreaterEqual(rval[2], 0.0)
+        self.assertEqual(rval[3], dict())
+
+        target = lambda x, instance, seed: (x ** 2, {'key': seed,
+                                                     'instance': instance})
+        taf = ExecuteTAFunc(func=target, stats=self.stats)
+        rval = taf.run(config=2, instance='test')
+        self.assertEqual(rval[0], StatusType.SUCCESS)
+        self.assertEqual(rval[1], 4)
+        self.assertGreaterEqual(rval[2], 0.0)
+        self.assertEqual(rval[3], {'key': 12345, 'instance': 'test'})
+
+    def test_for_runtime(self):
+        target = lambda x, _: x**2
+        taf = ExecuteTAFunc(func=target, stats=self.stats, run_obj='runtime')
+        rval = taf.run(config=2)
+        self.assertEqual(rval[0], StatusType.SUCCESS)
+        self.assertEqual(rval[1], rval[2])
+        self.assertEqual(rval[3], dict())
+
+    def test_memout(self):
+        def fill_memory(*args):
+            a = np.random.random_sample((10000, 10000)).astype(np.float64)
+            return np.sum(a)
+
+        taf = ExecuteTAFunc(func=fill_memory, stats=self.stats)
+        rval = taf.run(config=None, memory_limit=1024)
+        self.assertEqual(rval[0], StatusType.MEMOUT)
+        self.assertEqual(rval[1], 1234567890)
+        self.assertGreaterEqual(rval[2], 0.0)
+        self.assertEqual(rval[3], dict())
+
+    def test_timeout(self):
+        def run_over_time(*args):
+            time.sleep(5)
+
+        taf = ExecuteTAFunc(func=run_over_time, stats=self.stats)
+        rval = taf.run(config=None, cutoff=1)
+        self.assertEqual(rval[0], StatusType.TIMEOUT)
+        self.assertEqual(rval[1], 1234567890)
+        self.assertGreaterEqual(rval[2], 0.0)
+        self.assertEqual(rval[3], dict())
+
+    def test_timeout_runtime(self):
+        def run_over_time(*args):
+            time.sleep(5)
+
+        taf = ExecuteTAFunc(func=run_over_time, stats=self.stats,
+                            run_obj='runtime', par_factor=11)
+        rval = taf.run(config=None, cutoff=1)
+        self.assertEqual(rval[0], StatusType.TIMEOUT)
+        self.assertGreaterEqual(rval[1], 11)
+        self.assertGreaterEqual(rval[2], 1)
+        self.assertEqual(rval[3], dict())
+
+    @unittest.mock.patch('autosklearn.evaluation.eval_holdout')
+    def test_fail_silent(self, pynisher_mock):
+        pynisher_mock.return_value = None
+
+        taf = ExecuteTAFunc(func=pynisher_mock, stats=self.stats)
+        rval = taf.run(config=None, cutoff=1)
+        self.assertEqual(rval[0], StatusType.CRASHED)
+        self.assertEqual(rval[1], 1234567890)
+        self.assertGreaterEqual(rval[2], 0.0)
+        self.assertEqual(rval[3], dict())

--- a/test/test_tae/test_execute_ta_run.py
+++ b/test/test_tae/test_execute_ta_run.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest import mock
+
+from smac.tae.execute_ta_run import ExecuteTARun
+from smac.stats.stats import Stats
+from smac.scenario.scenario import Scenario
+from smac.smbo.smbo import StatusType
+
+
+class TestExecuteTARun(unittest.TestCase):
+
+    @mock.patch.object(ExecuteTARun, 'run', autospec=True)
+    def test_memory_limit_usage(self, run_mock):
+        run_mock.return_value = StatusType.SUCCESS, 12345.0, 1.2345, {}
+
+        stats = Stats(Scenario({}))
+        stats.start_timing()
+        tae = ExecuteTARun(lambda x : x**2, stats)
+
+        self.assertRaisesRegex(ValueError, 'Target algorithm executor '
+                                           'ExecuteTARun does not support restricting the memory usage.',
+                               tae.start, {'x': 2}, 'a', memory_limit=123)
+        tae._supports_memory_limit = True
+
+        rval = tae.start({'x': 2}, 'a', memory_limit=10)
+        self.assertEqual(rval, run_mock.return_value)


### PR DESCRIPTION
1. limit wallclock time instead of cpu time. I was not able to write
   a unit test which limits cpu time, and I don't see a reason why
   one would only want to limit cpu time
2. allow to enforce a memory limit
3. consider the algorithm run to have failed if the return value is
   None
4. add unittests