### PR TITLE
FIX #62, replace random with self.rng in intensification.py

### DIFF
--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -148,6 +148,7 @@ class SMAC(object):
             intensifier = Intensifier(tae_runner=tae_runner,
                                       stats=self.stats,
                                       traj_logger=traj_logger,
+                                      rng=rng,
                                       instances=scenario.train_insts,
                                       cutoff=scenario.cutoff,
                                       deterministic=scenario.deterministic,

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 import logging
 import sys
 import time
-import random
 from collections import Counter
 
 import numpy as np
@@ -28,10 +27,9 @@ class Intensifier(object):
         takes challenger and incumbents and performs intensify
     '''
 
-    def __init__(self, tae_runner, stats, traj_logger, instances=None,
-                 instance_specifics={},
-                 cutoff=MAXINT, deterministic=False, run_obj_time=True,
-                 run_limit=MAXINT, maxR=2000, rng=0):
+    def __init__(self, tae_runner, stats, traj_logger, rng, instances=None,
+                 instance_specifics={}, cutoff=MAXINT, deterministic=False,
+                 run_obj_time=True, run_limit=MAXINT, maxR=2000):
         '''
         Constructor
 
@@ -43,6 +41,7 @@ class Intensifier(object):
             stats object            
         traj_logger: TrajLogger()
             TrajLogger object to log all new incumbents
+        rng : np.random.RandomState
         instances : list
             list of all instance ids
         instance_specifics : dict
@@ -68,7 +67,7 @@ class Intensifier(object):
         self.logger = logging.getLogger("intensifier")
         self.run_limit = run_limit
         self.maxR = maxR
-        self.rs = np.random.RandomState(rng)
+        self.rs = rng
 
         # scenario info
         self.cutoff = cutoff
@@ -157,7 +156,7 @@ class Intensifier(object):
 
                 if available_insts:
                     # Line 5 (here for easier code)
-                    next_instance = random.choice(list(available_insts))
+                    next_instance = self.rs.choice(list(available_insts))
                     # Line 7
                     status, cost, dur, res = self.tae_runner.start(config=incumbent,
                                                             instance=next_instance,


### PR DESCRIPTION
This PR replaces the use of np.random, which is not seeded, with self.rng, the SMAC-global random number generator. This should make SMAC deterministic (given that the algorithms always take the same amount of time;)).