### PR TITLE
ENH # 42, make runhistory pickleable

### DIFF
--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -14,6 +14,13 @@ __email__ = "lindauer@cs.uni-freiburg.de"
 __version__ = "0.0.1"
 
 
+RunKey = collections.namedtuple(
+    'RunKey', ['config_id', 'instance_id', 'seed'])
+
+RunValue = collections.namedtuple(
+    'RunValue', ['cost', 'time', 'status', 'additional_info'])
+
+
 class RunHistory(object):
 
     '''
@@ -38,12 +45,6 @@ class RunHistory(object):
         # when we serialize the data and can assume it's still in the same
         # order as it was added.
         self.data = collections.OrderedDict()
-
-        self.RunKey = collections.namedtuple(
-            'RunKey', ['config_id', 'instance_id', 'seed'])
-
-        self.RunValue = collections.namedtuple(
-            'RunValue', ['cost', 'time', 'status', 'additional_info'])
 
         self.config_ids = {}  # config -> id
         self.ids_config = {}  # id -> config
@@ -88,8 +89,8 @@ class RunHistory(object):
             config_id = self.config_ids.get(config)
             self.ids_config[self._n_id] = config
 
-        k = self.RunKey(config_id, instance_id, seed)
-        v = self.RunValue(cost, time, status, additional_info)
+        k = RunKey(config_id, instance_id, seed)
+        v = RunValue(cost, time, status, additional_info)
 
         self.data[k] = v
         self.update_cost(config)
@@ -194,8 +195,8 @@ class RunHistory(object):
 
         self._n_id = len(self.config_ids)
         
-        self.data = {self.RunKey(int(k[0]), k[1], int(k[2])):
-                     self.RunValue(float(v[0]), float(v[1]), v[2], v[3])
+        self.data = {RunKey(int(k[0]), k[1], int(k[2])):
+                     RunValue(float(v[0]), float(v[1]), v[2], v[3])
                      for k, v in all_data["data"]}
 
     def update_from_json(self, fn, cs):

--- a/smac/smbo/objective.py
+++ b/smac/smbo/objective.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from smac.utils.constants import MAXINT
+from smac.runhistory.runhistory import RunKey
 
 """Define overall objectives.
 
@@ -35,7 +36,7 @@ def _runtime(config, run_history, instance_seed_pairs=None):
 
     runtimes = []
     for i, r in instance_seed_pairs:
-        k = run_history.RunKey(id_, i, r)
+        k = RunKey(id_, i, r)
         runtimes.append(run_history.data[k].time)
     return runtimes
 
@@ -89,7 +90,7 @@ def _cost(config, run_history, instance_seed_pairs=None):
 
     costs = []
     for i, r in instance_seed_pairs:
-        k = run_history.RunKey(id_, i, r)
+        k = RunKey(id_, i, r)
         costs.append(run_history.data[k].cost)
     return costs
 

--- a/test/test_smbo/test_pSMAC.py
+++ b/test/test_smbo/test_pSMAC.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import unittest
 
-from smac.runhistory.runhistory import RunHistory
+from smac.runhistory.runhistory import RunHistory, RunKey
 from smac.utils import test_helpers
 from smac.tae.execute_ta_run import StatusType
 from smac.smbo import pSMAC
@@ -110,10 +110,10 @@ class TestPSMAC(unittest.TestCase):
         config = configuration_space.sample_configuration()
         runhistory.add(config, 1, 1, StatusType.SUCCESS, seed=1,
                         instance_id='branin')
-        id_before = id(runhistory.data[runhistory.RunKey(1, 'branin', 1)])
+        id_before = id(runhistory.data[RunKey(1, 'branin', 1)])
         runhistory.update_from_json(other_runhistory_filename,
                                     configuration_space)
-        id_after = id(runhistory.data[runhistory.RunKey(1, 'branin', 1)])
+        id_after = id(runhistory.data[RunKey(1, 'branin', 1)])
         self.assertEqual(len(runhistory.data), 6)
         self.assertNotEqual(id_before, id_after)
 
@@ -127,10 +127,10 @@ class TestPSMAC(unittest.TestCase):
         config = configuration_space.sample_configuration()
         runhistory.add(config, 1, 1, StatusType.SUCCESS, seed=1,
                        instance_id='branin')
-        id_before = id(runhistory.data[runhistory.RunKey(1, 'branin', 1)])
+        id_before = id(runhistory.data[RunKey(1, 'branin', 1)])
         runhistory.update_from_json(other_runhistory_filename,
                                     configuration_space)
-        id_after = id(runhistory.data[runhistory.RunKey(1, 'branin', 1)])
+        id_after = id(runhistory.data[RunKey(1, 'branin', 1)])
         self.assertEqual(len(runhistory.data), 7)
         self.assertEqual(id_before, id_after)
         print(runhistory.config_ids)


### PR DESCRIPTION
This PR makes the runhistory pickleable by moving private classes out of the runhistory class.