### PR TITLE
FIX #72, config space now mandatory for scenario

### DIFF
--- a/test/test_runhistory/test_runhistory2epm.py
+++ b/test/test_runhistory/test_runhistory2epm.py
@@ -52,7 +52,7 @@ class RunhistoryTest(unittest.TestCase):
                seed=45,
                additional_info={"start_time": 10})
         
-        scen = Scenario({"cutoff_time": 10})
+        scen = Scenario({"cutoff_time": 10, 'cs': cs})
 
         self.assertRaises(TypeError, runhistory2epm.RunHistory2EPM4LogCost)
 

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -10,6 +10,7 @@ import unittest
 import numpy as np
 
 from smac.scenario.scenario import Scenario
+from smac.configspace import ConfigurationSpace
 
 class ScenarioTest(unittest.TestCase):
 
@@ -22,7 +23,9 @@ class ScenarioTest(unittest.TestCase):
         base_directory = os.path.abspath(os.path.join(base_directory, '..', '..'))
         self.current_dir = os.getcwd()
         os.chdir(base_directory)
-        
+
+        self.cs = ConfigurationSpace()
+
         self.test_scenario_dict = {'algo': 'echo Hello',
                                    'paramfile':
                                        'test/test_files/scenario_test/param.pcs',
@@ -38,6 +41,8 @@ class ScenarioTest(unittest.TestCase):
                                        'test/test_files/scenario_test/test.txt',
                                    'feature_file':
                                        'test/test_files/scenario_test/features.txt'}
+
+
 
     def tearDown(self):
         os.chdir(self.current_dir)

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -3,6 +3,7 @@ Created on Mar 29, 2015
 
 @author: Andre Biedenkapp
 '''
+from collections import defaultdict
 import os
 import logging
 import unittest
@@ -11,6 +12,12 @@ import numpy as np
 
 from smac.scenario.scenario import Scenario
 from smac.configspace import ConfigurationSpace
+
+
+class InitFreeScenario(Scenario):
+    def __init__(self):
+        self._groups = defaultdict(set)
+
 
 class ScenarioTest(unittest.TestCase):
 
@@ -94,6 +101,24 @@ class ScenarioTest(unittest.TestCase):
                                Scenario,
                                {'wallclock-limit': '12345',
                                 'duairznbvulncbzpneairzbnuqdae': 'uqpab'})
+
+    def test_add_argument(self):
+        # Check if adding non-bool required fails
+        scenario = InitFreeScenario()
+        self.assertRaisesRegexp(TypeError, "Argument 'required' must be of "
+                                           "type 'bool'.",
+                                scenario.add_argument, 'name', required=1,
+                                help=None)
+
+        # Check that adding a parameter which is both required and in a
+        # required-group fails
+        self.assertRaisesRegexp(ValueError, "Cannot make argument 'name' "
+                                            "required and add it to a group of "
+                                            "mutually exclusive arguments.",
+                                scenario.add_argument, 'name', required=True,
+                                help=None, mutually_exclusive_group='required')
+
+
 
 
 if __name__ == "__main__":

--- a/test/test_tae/test_exec_func.py
+++ b/test/test_tae/test_exec_func.py
@@ -4,6 +4,7 @@ import unittest.mock
 
 import numpy as np
 
+from smac.configspace import ConfigurationSpace
 from smac.tae.execute_func import ExecuteTAFunc
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
@@ -13,7 +14,8 @@ from smac.tae.execute_ta_run import StatusType
 class TestExecuteFunc(unittest.TestCase):
 
     def setUp(self):
-        self.scenario = Scenario({})
+        self.cs = ConfigurationSpace()
+        self.scenario = Scenario({'cs': self.cs})
         self.stats = Stats(scenario=self.scenario)
 
     def test_run(self):

--- a/test/test_tae/test_execute_ta_run.py
+++ b/test/test_tae/test_execute_ta_run.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 
+from smac.configspace import ConfigurationSpace
 from smac.tae.execute_ta_run import ExecuteTARun
 from smac.stats.stats import Stats
 from smac.scenario.scenario import Scenario
@@ -13,7 +14,7 @@ class TestExecuteTARun(unittest.TestCase):
     def test_memory_limit_usage(self, run_mock):
         run_mock.return_value = StatusType.SUCCESS, 12345.0, 1.2345, {}
 
-        stats = Stats(Scenario({}))
+        stats = Stats(Scenario({'cs': ConfigurationSpace()}))
         stats.start_timing()
         tae = ExecuteTARun(lambda x : x**2, stats, run_obj='quality')
 

--- a/test/test_tae/test_tae_aclib.py
+++ b/test/test_tae/test_tae_aclib.py
@@ -7,6 +7,7 @@ import os
 import unittest
 import shlex
 
+from smac.configspace import ConfigurationSpace
 from smac.tae.execute_ta_run_aclib import ExecuteTARunAClib
 from smac.tae.execute_ta_run import StatusType
 from smac.scenario.scenario import Scenario
@@ -28,7 +29,7 @@ class TaeOldTest(unittest.TestCase):
         '''
             running some simple algo in aclib 2.0 style
         '''
-        scen = Scenario(scenario={}, cmd_args=None)
+        scen = Scenario(scenario={'cs': ConfigurationSpace()}, cmd_args=None)
         stats = Stats(scen)
         
         eta = ExecuteTARunAClib(

--- a/test/test_tae/test_tae_old.py
+++ b/test/test_tae/test_tae_old.py
@@ -7,6 +7,7 @@ import os
 import unittest
 import shlex
 
+from smac.configspace import ConfigurationSpace
 from smac.tae.execute_ta_run_old import ExecuteTARunOld
 from smac.tae.execute_ta_run import StatusType
 from smac.scenario.scenario import Scenario
@@ -28,7 +29,7 @@ class TaeOldTest(unittest.TestCase):
         '''
             running some simple algo in old style
         '''
-        scen = Scenario(scenario={}, cmd_args=None)
+        scen = Scenario(scenario={'cs': ConfigurationSpace()}, cmd_args=None)
         stats = Stats(scen)
         
         eta = ExecuteTARunOld(

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -15,6 +15,7 @@ except:
     from mock import patch
 from smac.utils.io.traj_logging import TrajLogger
 
+from smac.configspace import ConfigurationSpace
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
 
@@ -29,9 +30,10 @@ class TrajLoggerTest(unittest.TestCase):
         self.logger = logging.getLogger('TrajLogger Test')
         self.logger.setLevel(logging.DEBUG)
         self.value = 0
+        self.cs = ConfigurationSpace()
 
     def test_init(self):
-        scen = Scenario(scenario={}, cmd_args=None)
+        scen = Scenario(scenario={'cs': self.cs}, cmd_args=None)
         stats = Stats(scen)
         TrajLogger(output_dir='./tmp_test_folder', stats=stats)
         self.assertFalse(os.path.exists('smac3-output'))


### PR DESCRIPTION
This PR makes sure that either the argument `cs` or `paramfile` is passed to the scenario object.