### PR TITLE
ADD allow passing callable as target algorithm

### DIFF
--- a/smac/facade/roar_facade.py
+++ b/smac/facade/roar_facade.py
@@ -36,10 +36,9 @@ class ROAR(SMAC):
         ----------
         scenario: smac.scenario.scenario.Scenario
             Scenario object
-        tae_runner: ExecuteTARun
-            object that implements the following method to call the target
-            algorithm (or any other arbitrary function):
-            run(self, config)
+        tae_runner: ExecuteTARun or callable
+            Callable or implementation of :class:`ExecuteTaRun`. In case a
+            callable is passed it will be wrapped by tae.ExecuteTaFunc().
             If not set, it will be initialized with the tae.ExecuteTARunOld()
         runhistory: RunHistory
             runhistory to store all algorithm runs

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -125,6 +125,11 @@ class SMAC(object):
                                          run_obj=scenario.run_obj,
                                          runhistory=runhistory,
                                          par_factor=scenario.par_factor)
+        elif not isinstance(tae_runner, ExecuteTARun):
+            raise TypeError("Argument 'tae_runner' is %s, but must be "
+                            "either a callable or an instance of ExecuteTaRun."
+                            % type(tae_runner))
+
         # inject stats if necessary
         if tae_runner.stats is None:
             tae_runner.stats = self.stats

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -113,18 +113,23 @@ class SMAC(object):
                                    scenario.cs)
 
         # initialize tae_runner
-        if tae_runner is not None and callable(tae_runner):
-            tae_runner = ExecuteTAFunc(ta=tae_runner,
-                                       stats=self.stats,
-                                       run_obj=scenario.run_obj,
-                                       runhistory=runhistory,
-                                       par_factor=scenario.par_factor)
-        elif tae_runner is None:
+        # First case, if tae_runner is None, the target algorithm is a call
+        # string in the scenario file
+        if tae_runner is None:
             tae_runner = ExecuteTARunOld(ta=scenario.ta,
                                          stats=self.stats,
                                          run_obj=scenario.run_obj,
                                          runhistory=runhistory,
                                          par_factor=scenario.par_factor)
+        # Second case, the tae_runner is a function to be optimized
+        elif callable(tae_runner):
+            tae_runner = ExecuteTAFunc(ta=tae_runner,
+                                       stats=self.stats,
+                                       run_obj=scenario.run_obj,
+                                       runhistory=runhistory,
+                                       par_factor=scenario.par_factor)
+        # Third case, if it is an ExecuteTaRun we can simply use the
+        # instance. Otherwise, the next check raises an exception
         elif not isinstance(tae_runner, ExecuteTARun):
             raise TypeError("Argument 'tae_runner' is %s, but must be "
                             "either a callable or an instance of "

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -127,7 +127,10 @@ class SMAC(object):
                                          par_factor=scenario.par_factor)
         elif not isinstance(tae_runner, ExecuteTARun):
             raise TypeError("Argument 'tae_runner' is %s, but must be "
-                            "either a callable or an instance of ExecuteTaRun."
+                            "either a callable or an instance of "
+                            "ExecuteTaRun. Passing 'None' will result in the "
+                            "creation of target algorithm runner based on the "
+                            "call string in the scenario file."
                             % type(tae_runner))
 
         # inject stats if necessary

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -22,3 +22,13 @@ class TestSMACFacade(unittest.TestCase):
         SMAC(tae_runner=ta, scenario=self.scenario)
         self.assertIsInstance(ta.stats, Stats)
         self.assertIsInstance(ta.runhistory, RunHistory)
+
+    def test_pass_callable(self):
+        # Check that SMAC accepts a callable as target algorithm and that it is
+        # correctly wrapped with ExecuteTaFunc
+        def target_algorithm(conf, inst):
+            return 5
+        smac = SMAC(tae_runner=target_algorithm, scenario=self.scenario)
+        self.assertIsInstance(smac.solver.intensifier.tae_runner,
+                              ExecuteTAFunc)
+        self.assertIs(smac.solver.intensifier.tae_runner.ta, target_algorithm)

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -32,3 +32,10 @@ class TestSMACFacade(unittest.TestCase):
         self.assertIsInstance(smac.solver.intensifier.tae_runner,
                               ExecuteTAFunc)
         self.assertIs(smac.solver.intensifier.tae_runner.ta, target_algorithm)
+
+    def test_pass_invalid_tae_runner(self):
+        self.assertRaisesRegexp(TypeError, "Argument 'tae_runner' is <class "
+                                           "'int'>, but must be either a "
+                                           "callable or an instance of "
+                                           "ExecuteTaRun.",
+                                SMAC, tae_runner=1, scenario=self.scenario)


### PR DESCRIPTION
Allows passing a callable to the SMAC or ROAR class. The SMAC class will then wrap the callable in the necessary ExecuteTaRun class. Fixes #49 