### PR TITLE
Warmstart

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Cython
 pynisher>=0.4.1
 ConfigSpace>=0.2.1
 pyrfr
+sklearn

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pynisher>=0.4.1
 ConfigSpace>=0.2.1
 pyrfr
 scikit-learn
+typing

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ requirements = ['setuptools',
                 'pyrfr',
                 'ConfigSpace>=0.2.1',
                 'pynisher>=0.4.1',
-		'scikit-learn']
+                'scikit-learn',
+                'typing']
 
 setuptools.setup(
     name="smac",

--- a/smac/epm/rfr_imputator.py
+++ b/smac/epm/rfr_imputator.py
@@ -149,4 +149,4 @@ class RFRImputator(smac.epm.base_imputor.BaseImputor):
         if not numpy.isfinite(imputed_y).all():
             self.logger.critical("Imputed values are not finite, %s" %
                                  str(imputed_y))
-        return imputed_y
+        return numpy.reshape(imputed_y, [imputed_y.shape[0], 1])

--- a/smac/epm/rfr_imputator.py
+++ b/smac/epm/rfr_imputator.py
@@ -22,7 +22,7 @@ class RFRImputator(smac.epm.base_imputor.BaseImputor):
     def __init__(self, rs, cutoff, threshold,
                  model,
                  change_threshold=0.01,
-                 max_iter=10):
+                 max_iter=2):
         """
         initialize imputator module
 

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -204,7 +204,7 @@ class SMAC(object):
                                        threshold=threshold,
                                        model=model,
                                        change_threshold=0.01,
-                                       max_iter=10)
+                                       max_iter=2)
 
                 runhistory2epm = RunHistory2EPM4LogCost(
                     scenario=scenario, num_params=num_params,

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -209,18 +209,27 @@ class RunHistory(object):
         cs : ConfigSpace
             instance of configuration space
         """
-
         new_runhistory = RunHistory(self.aggregate_func)
         new_runhistory.load_json(fn, cs)
+        self.update(runhistory=new_runhistory)
+        
+    def update(self, runhistory):
+        """Update the current runhistory by adding new runs from a json file.
+
+        Parameters
+        ----------
+        runhistory: RunHistory
+            runhistory with additional data to be added to self
+        """
 
         # Configurations might be already known, but by a different ID. This
         # does not matter here because the add() method handles this
         # correctly by assigning an ID to unknown configurations and re-using
         #  the ID
-        for key, value in new_runhistory.data.items():
+        for key, value in runhistory.data.items():
             config_id, instance_id, seed = key
             cost, time, status, additional_info = value
-            config = new_runhistory.ids_config[config_id]
+            config = runhistory.ids_config[config_id]
             self.add(config=config, cost=cost, time=time,
                      status=status, instance_id=instance_id,
                      seed=seed, additional_info=additional_info)

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -67,6 +67,7 @@ class Scenario(object):
             arg_name, arg_value = self._parse_argument(key, scenario, **value)
             parsed_arguments[arg_name] = arg_value
 
+        
         if len(scenario) != 0:
             raise ValueError('Could not parse the following arguments: %s' %
                              str(list(scenario.keys())))

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -6,6 +6,7 @@ import numpy
 import shlex
 import time
 import datetime
+import copy
 
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import MinMaxScaler
@@ -49,7 +50,7 @@ class Scenario(object):
             self.logger.info("Reading scenario file: %s" % (scenario_fn))
             scenario = self.in_reader.read_scenario_file(scenario_fn)
         elif type(scenario) is dict:
-            pass
+            scenario = copy.copy(scenario)
         else:
             raise TypeError(
                 "Wrong type of scenario (str or dict are supported)")

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -259,6 +259,7 @@ class Scenario(object):
             for inst_ in self.train_insts:
                 self.feature_array.append(self.feature_dict[inst_])
             self.feature_array = numpy.array(self.feature_array)
+            self.n_features = self.feature_array.shape[1]
             
             # reduce dimensionality of features of larger than PCA_DIM
             if self.feature_array.shape[1] > self.PCA_DIM:

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -8,6 +8,7 @@ import time
 import datetime
 
 from sklearn.decomposition import PCA
+from sklearn.preprocessing import MinMaxScaler
 
 from smac.utils.io.input_reader import InputReader
 from smac.configspace import pcs
@@ -265,7 +266,7 @@ class Scenario(object):
             if self.feature_array.shape[1] > self.PCA_DIM:
                 X = self.feature_array
                 # scale features
-                X = (X - X.min()) / (X.max() - X.min())
+                X = MinMaxScaler().fit_transform(X)
                 X = numpy.nan_to_num(X) # if features with max == min
                 #PCA
                 pca = PCA(n_components=self.PCA_DIM)

--- a/smac/smac_cli.py
+++ b/smac/smac_cli.py
@@ -9,7 +9,7 @@ from smac.facade.smac_facade import SMAC
 from smac.facade.roar_facade import ROAR
 from smac.runhistory.runhistory import RunHistory
 from smac.smbo.objective import average_cost
-from smac.utils.merge_foreign_data import merge_foreign_data
+from smac.utils.merge_foreign_data import merge_foreign_data_from_file
 
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2015, ML4AAD"
@@ -51,14 +51,13 @@ class SMACCLI(object):
             aggregate_func = average_cost
             rh = RunHistory(aggregate_func=aggregate_func)
 
-            if args_.warmstart_scenario:
-                in_scenario = Scenario(args_.warmstart_scenario)
-            else:
-                in_scenario = scen
-            scen, rh = merge_foreign_data(scenario=scen,
-                                          runhistory=rh,
-                                          in_scenario=in_scenario,
-                                          in_runhistory_fn_list=args_.warmstart_runhistory)
+            scen, rh = merge_foreign_data_from_file(
+                        scenario=scen, 
+                        runhistory=rh,
+                        in_scenario_fn_list=args_.warmstart_scenario, 
+                        in_runhistory_fn_list=args_.warmstart_runhistory,
+                        cs=scen.cs,
+                        aggregate_func=aggregate_func)
 
         if args_.modus == "SMAC":
             optimizer = SMAC(

--- a/smac/smac_cli.py
+++ b/smac/smac_cli.py
@@ -46,12 +46,14 @@ class SMACCLI(object):
 
         scen = Scenario(args_.scenario_file, misc_args)
 
+        rh = None
         if args_.warmstart_runhistory:
             aggregate_func = average_cost
             rh = RunHistory(aggregate_func=aggregate_func)
 
-            in_scenario = args_.warmstart_scenario
-            if not in_scenario:
+            if args_.warmstart_scenario:
+                in_scenario = Scenario(args_.warmstart_scenario)
+            else:
                 in_scenario = scen
             scen, rh = merge_foreign_data(scenario=scen,
                                           runhistory=rh,
@@ -64,8 +66,11 @@ class SMACCLI(object):
         elif args_.modus == "ROAR":
             optimizer = ROAR(
                 scenario=scen, rng=np.random.RandomState(args_.seed), runhistory=rh)
-        optimizer.optimize()
+        try:
+            optimizer.optimize()
 
-        optimizer.solver.runhistory.save_json(
-            fn=os.path.join(scen.output_dir, "runhistory.json"))
+        finally:
+            # ensure that the runhistory is always dumped in the end
+            optimizer.solver.runhistory.save_json(
+                fn=os.path.join(scen.output_dir, "runhistory.json"))
         #smbo.runhistory.load_json(fn="runhistory.json", cs=smbo.config_space)

--- a/smac/smac_cli.py
+++ b/smac/smac_cli.py
@@ -7,6 +7,8 @@ from smac.utils.io.cmd_reader import CMDReader
 from smac.scenario.scenario import Scenario
 from smac.facade.smac_facade import SMAC
 from smac.facade.roar_facade import ROAR
+from smac.runhistory.runhistory import RunHistory
+from smac.smbo.objective import average_cost
 
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2015, ML4AAD"
@@ -43,10 +45,17 @@ class SMACCLI(object):
 
         scen = Scenario(args_.scenario_file, misc_args)
         
+        rh = None
+        if args_.warmstart:
+            aggregate_func = average_cost
+            rh = RunHistory(aggregate_func=aggregate_func)
+            for fn in args_.warmstart:
+                rh.load_json(fn=fn, cs=scen.cs)
+        
         if args_.modus == "SMAC":
-            optimizer = SMAC(scenario=scen, rng=np.random.RandomState(args_.seed))
+            optimizer = SMAC(scenario=scen, rng=np.random.RandomState(args_.seed), runhistory=rh)
         elif args_.modus == "ROAR":
-            optimizer = ROAR(scenario=scen, rng=np.random.RandomState(args_.seed))
+            optimizer = ROAR(scenario=scen, rng=np.random.RandomState(args_.seed), runhistory=rh)
         optimizer.optimize()
 
         optimizer.solver.runhistory.save_json(fn=os.path.join(scen.output_dir,"runhistory.json"))

--- a/smac/smbo/local_search.py
+++ b/smac/smbo/local_search.py
@@ -16,7 +16,7 @@ __version__ = "0.0.1"
 class LocalSearch(object):
 
     def __init__(self, acquisition_function, config_space,
-                 epsilon=0.000001, max_iterations=None, rng=None):
+                 epsilon=0.00001, max_iterations=None, rng=None):
         """
         Implementation of SMAC's local search
 

--- a/smac/utils/io/cmd_reader.py
+++ b/smac/utils/io/cmd_reader.py
@@ -51,9 +51,14 @@ class CMDReader(object):
         req_opts.add_argument("--modus", default="SMAC",
                               choices=["SMAC", "ROAR"],
                               help=SUPPRESS)
-        req_opts.add_argument("--warmstart", default=None,
+        req_opts.add_argument("--warmstart_runhistory", default=None,
                               nargs="*",
-                              help=SUPPRESS) # list of runhistory dump files
+                              help=SUPPRESS)  # list of runhistory dump files
+
+        # scenario corresponding to --warmstart_runhistory; 
+        # pcs and feature space has to be identical to --scenario_file
+        req_opts.add_argument("--warmstart_scenario", default=None,
+                              help=SUPPRESS)  
 
         args_, misc = parser.parse_known_args()
         self._check_args(args_)

--- a/smac/utils/io/cmd_reader.py
+++ b/smac/utils/io/cmd_reader.py
@@ -51,6 +51,9 @@ class CMDReader(object):
         req_opts.add_argument("--modus", default="SMAC",
                               choices=["SMAC", "ROAR"],
                               help=SUPPRESS)
+        req_opts.add_argument("--warmstart", default=None,
+                              nargs="*",
+                              help=SUPPRESS) # list of runhistory dump files
 
         args_, misc = parser.parse_known_args()
         self._check_args(args_)

--- a/smac/utils/io/cmd_reader.py
+++ b/smac/utils/io/cmd_reader.py
@@ -58,6 +58,7 @@ class CMDReader(object):
         # scenario corresponding to --warmstart_runhistory; 
         # pcs and feature space has to be identical to --scenario_file
         req_opts.add_argument("--warmstart_scenario", default=None,
+                              nargs="*",
                               help=SUPPRESS)  
 
         args_, misc = parser.parse_known_args()

--- a/smac/utils/merge_foreign_data.py
+++ b/smac/utils/merge_foreign_data.py
@@ -1,36 +1,40 @@
 from smac.runhistory.runhistory import RunHistory
-from smac.scenario.scenario import Scenario 
+from smac.scenario.scenario import Scenario
 from smac.configspace import ConfigurationSpace
 from smac.smbo.objective import average_cost
 
-def merge_foreign_data_from_file(scenario:Scenario, runhistory:RunHistory,
-                       in_scenario_fn_list:list, in_runhistory_fn_list:list,
-                       cs:ConfigurationSpace,
-                       aggregate_func=average_cost):
+import typing
+
+def merge_foreign_data_from_file(scenario: Scenario, 
+                                 runhistory: RunHistory,
+                                 in_scenario_fn_list: typing.List[str], 
+                                 in_runhistory_fn_list: typing.List[str],
+                                 cs: ConfigurationSpace,
+                                 aggregate_func: typing.Callable = average_cost):
     '''
         extend <scenario> and <runhistory> with runhistory data from another <in_scenario> 
         assuming the same pcs, feature space, but different instances
-        
+
         Arguments
         ---------
         scenario: Scenario
             original scenario -- feature dictionary will be extended
         runhistory: RunHistory
             original runhistory -- will be extended by further data points
-        in_scenario_list: list
-            input scenario 
-        in_runhistory_list: list
-            list of runhistories wrt <in_scenario>
+        in_scenario_fn_list: typing.List[str]
+            input scenario file names
+        in_runhistory_fn_list: typing.List[str]
+            list filenames of runhistory dumps
         cs: ConfigurationSpace
             parameter configuration space to read runhistory from file
-        aggregate_func: func
+        aggregate_func: typing.Callable
             function to aggregate performance of a configuratoion across instances
-            
+
         Returns
         -------
             scenario, runhistory
     '''
-    
+
     scens = [Scenario(scenario=scen_fn) for scen_fn in in_scenario_fn_list]
     rhs = []
     for rh_fn in in_runhistory_fn_list:
@@ -39,49 +43,53 @@ def merge_foreign_data_from_file(scenario:Scenario, runhistory:RunHistory,
         rhs.append(rh)
 
     return merge_foreign_data(scenario, runhistory, in_scenario_list=scens, in_runhistory_list=rhs)
-    
 
-def merge_foreign_data(scenario:Scenario, runhistory:RunHistory,
-                       in_scenario_list:list, in_runhistory_list:list):
+
+def merge_foreign_data(scenario: Scenario, 
+                       runhistory: RunHistory,
+                       in_scenario_list: typing.List[Scenario], 
+                       in_runhistory_list: typing.List[RunHistory]):
     '''
         extend <scenario> and <runhistory> with runhistory data from another <in_scenario> 
         assuming the same pcs, feature space, but different instances
-        
+
         Arguments
         ---------
         scenario: Scenario
             original scenario -- feature dictionary will be extended
         runhistory: RunHistory
             original runhistory -- will be extended by further data points
-        in_scenario_list: list
+        in_scenario_list: typing.List[Scenario]
             input scenario 
-        in_runhistory_list: list
+        in_runhistory_list: typing.List[RunHistory]
             list of runhistories wrt <in_scenario>
-            
+
         Returns
         -------
             scenario, runhistory
     '''
-    
+
     # add further instance features
     for in_scenario in in_scenario_list:
         if scenario.n_features != in_scenario.n_features:
-            raise ValueError("Feature Space has to be the same for both scenarios (%d vs %d)." %(scenario.n_features, in_scenario.n_features))
-    
+            raise ValueError("Feature Space has to be the same for both scenarios (%d vs %d)." % (
+                scenario.n_features, in_scenario.n_features))
+
         if scenario.cs != in_scenario.cs:
             raise ValueError("PCS of both scenarios have to be identical.")
-        
+
         if scenario.cutoff != in_scenario.cutoff:
             raise ValueError("Cutoffs of both scenarios have to be identical.")
-        
+
         scenario.feature_dict.update(in_scenario.feature_dict)
-    
+
     # extend runhistory
     for rh in in_runhistory_list:
         runhistory.update(rh)
-    
+
     for date in runhistory.data:
         if scenario.feature_dict.get(date.instance_id) is None:
-            raise ValueError("Instance feature for \"%s\" was not found in scenario data." %(date.instance_id))
-    
+            raise ValueError(
+                "Instance feature for \"%s\" was not found in scenario data." % (date.instance_id))
+
     return scenario, runhistory

--- a/smac/utils/merge_foreign_data.py
+++ b/smac/utils/merge_foreign_data.py
@@ -1,0 +1,42 @@
+from smac.runhistory.runhistory import RunHistory
+from smac.scenario.scenario import Scenario 
+
+
+def merge_foreign_data(scenario:Scenario, runhistory:RunHistory,
+                       in_scenario:Scenario, in_runhistory_fn_list:list):
+    '''
+        extend <scenario> and <runhistory> with runhistory data from another <in_scenario> 
+        assuming the same pcs, feature space, but different instances
+        
+        Arguments
+        ---------
+        scenario: Scenario
+            original scenario -- feature dictionary will be extended
+        runhistory: RunHistory
+            original runhistory -- will be extended by further data points
+        in_scenario: Scenario
+            input scenario 
+        in_runhistory_fn_list: list
+            list of filenames of dumped runhistories wrt <in_scenario>
+            
+        Returns
+        -------
+            scenario, runhistory
+    '''
+    
+    if scenario.n_features != in_scenario.n_features:
+        raise ValueError("Feature Space has to be the same for both scenarios.")
+    
+    if scenario.cs != in_scenario.cs:
+        raise ValueError("PCS of both scenarios have to be identical.")
+    
+    if scenario.cutoff != in_scenario.cutoff:
+        raise ValueError("Cutoffs of both scenarios have to be identical.")
+    
+    # add further instance features
+    scenario.feature_dict.update(in_scenario.feature_dict)
+    
+    for fn in in_runhistory_fn_list:
+        runhistory.load_json(fn=fn, cs=scenario.cs)
+    
+    return scenario, runhistory

--- a/smac/utils/merge_foreign_data.py
+++ b/smac/utils/merge_foreign_data.py
@@ -1,9 +1,12 @@
 from smac.runhistory.runhistory import RunHistory
 from smac.scenario.scenario import Scenario 
+from smac.configspace import ConfigurationSpace
+from smac.smbo.objective import average_cost
 
-
-def merge_foreign_data(scenario:Scenario, runhistory:RunHistory,
-                       in_scenario:Scenario, in_runhistory_fn_list:list):
+def merge_foreign_data_from_file(scenario:Scenario, runhistory:RunHistory,
+                       in_scenario_fn_list:list, in_runhistory_fn_list:list,
+                       cs:ConfigurationSpace,
+                       aggregate_func=average_cost):
     '''
         extend <scenario> and <runhistory> with runhistory data from another <in_scenario> 
         assuming the same pcs, feature space, but different instances
@@ -14,29 +17,71 @@ def merge_foreign_data(scenario:Scenario, runhistory:RunHistory,
             original scenario -- feature dictionary will be extended
         runhistory: RunHistory
             original runhistory -- will be extended by further data points
-        in_scenario: Scenario
+        in_scenario_list: list
             input scenario 
-        in_runhistory_fn_list: list
-            list of filenames of dumped runhistories wrt <in_scenario>
+        in_runhistory_list: list
+            list of runhistories wrt <in_scenario>
+        cs: ConfigurationSpace
+            parameter configuration space to read runhistory from file
+        aggregate_func: func
+            function to aggregate performance of a configuratoion across instances
             
         Returns
         -------
             scenario, runhistory
     '''
     
-    if scenario.n_features != in_scenario.n_features:
-        raise ValueError("Feature Space has to be the same for both scenarios.")
+    scens = [Scenario(scenario=scen_fn) for scen_fn in in_scenario_fn_list]
+    rhs = []
+    for rh_fn in in_runhistory_fn_list:
+        rh = RunHistory(aggregate_func)
+        rh.load_json(rh_fn, cs)
+        rhs.append(rh)
+
+    return merge_foreign_data(scenario, runhistory, in_scenario_list=scens, in_runhistory_list=rhs)
     
-    if scenario.cs != in_scenario.cs:
-        raise ValueError("PCS of both scenarios have to be identical.")
-    
-    if scenario.cutoff != in_scenario.cutoff:
-        raise ValueError("Cutoffs of both scenarios have to be identical.")
+
+def merge_foreign_data(scenario:Scenario, runhistory:RunHistory,
+                       in_scenario_list:list, in_runhistory_list:list):
+    '''
+        extend <scenario> and <runhistory> with runhistory data from another <in_scenario> 
+        assuming the same pcs, feature space, but different instances
+        
+        Arguments
+        ---------
+        scenario: Scenario
+            original scenario -- feature dictionary will be extended
+        runhistory: RunHistory
+            original runhistory -- will be extended by further data points
+        in_scenario_list: list
+            input scenario 
+        in_runhistory_list: list
+            list of runhistories wrt <in_scenario>
+            
+        Returns
+        -------
+            scenario, runhistory
+    '''
     
     # add further instance features
-    scenario.feature_dict.update(in_scenario.feature_dict)
+    for in_scenario in in_scenario_list:
+        if scenario.n_features != in_scenario.n_features:
+            raise ValueError("Feature Space has to be the same for both scenarios (%d vs %d)." %(scenario.n_features, in_scenario.n_features))
     
-    for fn in in_runhistory_fn_list:
-        runhistory.load_json(fn=fn, cs=scenario.cs)
+        if scenario.cs != in_scenario.cs:
+            raise ValueError("PCS of both scenarios have to be identical.")
+        
+        if scenario.cutoff != in_scenario.cutoff:
+            raise ValueError("Cutoffs of both scenarios have to be identical.")
+        
+        scenario.feature_dict.update(in_scenario.feature_dict)
+    
+    # extend runhistory
+    for rh in in_runhistory_list:
+        runhistory.update(rh)
+    
+    for date in runhistory.data:
+        if scenario.feature_dict.get(date.instance_id) is None:
+            raise ValueError("Instance feature for \"%s\" was not found in scenario data." %(date.instance_id))
     
     return scenario, runhistory

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -151,8 +151,8 @@ class ScenarioTest(unittest.TestCase):
     def test_merge_foreign_data(self):
         ''' test smac.utils.merge_foreign_data '''
 
-        scenario = Scenario(copy.copy(self.test_scenario_dict))
-        scenario_2 = Scenario(copy.copy(self.test_scenario_dict))
+        scenario = Scenario(self.test_scenario_dict)
+        scenario_2 = Scenario(self.test_scenario_dict)
         scenario_2.feature_dict = {"inst_new": [4]}
 
         # init cs

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -7,14 +7,23 @@ from collections import defaultdict
 import os
 import logging
 import unittest
+import copy
 
 import numpy as np
 
+from ConfigSpace import Configuration, ConfigurationSpace
+from ConfigSpace.hyperparameters import UniformIntegerHyperparameter
+
 from smac.scenario.scenario import Scenario
 from smac.configspace import ConfigurationSpace
+from smac.utils.merge_foreign_data import merge_foreign_data
+from smac.runhistory.runhistory import RunHistory
+from smac.smbo.objective import average_cost
+from smac.tae.execute_ta_run import StatusType
 
 
 class InitFreeScenario(Scenario):
+
     def __init__(self):
         self._groups = defaultdict(set)
 
@@ -27,7 +36,8 @@ class ScenarioTest(unittest.TestCase):
         self.logger.setLevel(logging.DEBUG)
 
         base_directory = os.path.split(__file__)[0]
-        base_directory = os.path.abspath(os.path.join(base_directory, '..', '..'))
+        base_directory = os.path.abspath(
+            os.path.join(base_directory, '..', '..'))
         self.current_dir = os.getcwd()
         os.chdir(base_directory)
 
@@ -58,11 +68,12 @@ class ScenarioTest(unittest.TestCase):
 
     def test_string_scenario(self):
         scenario = Scenario('test/test_files/scenario_test/scenario.txt')
-        
+
         self.assertEquals(scenario.ta, ['echo', 'Hello'])
         self.assertEquals(scenario.execdir, '.')
         self.assertFalse(scenario.deterministic)
-        self.assertEquals(scenario.pcs_fn, 'test/test_files/scenario_test/param.pcs')
+        self.assertEquals(
+            scenario.pcs_fn, 'test/test_files/scenario_test/param.pcs')
         self.assertEquals(scenario.overall_obj, 'mean10')
         self.assertEquals(scenario.cutoff, 5.)
         self.assertEquals(scenario.algo_runs_timelimit, np.inf)
@@ -70,17 +81,18 @@ class ScenarioTest(unittest.TestCase):
         self.assertEquals(scenario.par_factor, 10)
         self.assertEquals(scenario.train_insts, ['d', 'e', 'f'])
         self.assertEquals(scenario.test_insts, ['a', 'b', 'c'])
-        test_dict = {'d' : 1, 'e' : 2, 'f' : 3}
+        test_dict = {'d': 1, 'e': 2, 'f': 3}
         self.assertEquals(scenario.feature_dict, test_dict)
         self.assertEquals(scenario.feature_array[0], 1)
 
     def test_dict_scenario(self):
         scenario = Scenario(self.test_scenario_dict)
-        
+
         self.assertEquals(scenario.ta, ['echo', 'Hello'])
         self.assertEquals(scenario.execdir, '.')
         self.assertFalse(scenario.deterministic)
-        self.assertEquals(scenario.pcs_fn, 'test/test_files/scenario_test/param.pcs')
+        self.assertEquals(
+            scenario.pcs_fn, 'test/test_files/scenario_test/param.pcs')
         self.assertEquals(scenario.overall_obj, 'mean10')
         self.assertEquals(scenario.cutoff, 5.)
         self.assertEquals(scenario.algo_runs_timelimit, np.inf)
@@ -88,7 +100,7 @@ class ScenarioTest(unittest.TestCase):
         self.assertEquals(scenario.par_factor, 10)
         self.assertEquals(scenario.train_insts, ['d', 'e', 'f'])
         self.assertEquals(scenario.test_insts, ['a', 'b', 'c'])
-        test_dict = {'d' : 1, 'e' : 2, 'f' : 3}
+        test_dict = {'d': 1, 'e': 2, 'f': 3}
         self.assertEquals(scenario.feature_dict, test_dict)
         self.assertEquals(scenario.feature_array[0], 1)
 
@@ -135,6 +147,46 @@ class ScenarioTest(unittest.TestCase):
         self.test_scenario_dict["initial_incumbent"] = "DOESNOTEXIST"
         scenario = Scenario(self.test_scenario_dict)
         self.assertIsNone(scenario.initial_incumbent)
+
+    def test_merge_foreign_data(self):
+        ''' test smac.utils.merge_foreign_data '''
+
+        scenario = Scenario(copy.copy(self.test_scenario_dict))
+        scenario_2 = Scenario(copy.copy(self.test_scenario_dict))
+        scenario_2.feature_dict = {"inst_new": [4]}
+
+        # init cs
+        cs = ConfigurationSpace()
+        cs.add_hyperparameter(UniformIntegerHyperparameter(name='a',
+                                                           lower=0,
+                                                           upper=100))
+        cs.add_hyperparameter(UniformIntegerHyperparameter(name='b',
+                                                           lower=0,
+                                                           upper=100))
+        # build runhistory
+        rh_merge = RunHistory(aggregate_func=average_cost)
+        config = Configuration(cs, values={'a': 1, 'b': 2})
+
+        rh_merge.add(config=config, instance_id="inst_new", cost=10, time=20,
+                     status=StatusType.SUCCESS,
+                     seed=None,
+                     additional_info=None)
+
+        # build empty rh
+        rh_base = RunHistory(aggregate_func=average_cost)
+
+        merge_foreign_data(scenario=scenario, runhistory=rh_base,
+                           in_scenario_list=[scenario_2], in_runhistory_list=[rh_merge])
+
+        assert len(rh_base.data) == 1
+
+        rh_merge.add(config=config, instance_id="inst_new_2", cost=10, time=20,
+                     status=StatusType.SUCCESS,
+                     seed=None,
+                     additional_info=None)
+        
+        self.assertRaises(ValueError, merge_foreign_data, **{"scenario":scenario, "runhistory":rh_base, "in_scenario_list":[scenario_2], "in_runhistory_list":[rh_merge]})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
ADD methods to warmstart SMAC and speed up imputation of censored data

* ADD utils.merge_foreign_data to load runhistory data from a different scenarios with the same pcs, feature space and running time cutoff
* ADD PCA on instance features
* MAINT vectorize truncnorm computation
* MAINT reduce number of imputation iterations to 2 (as in SMAC2)
* MAINT increase epsilon of SLS (as in SMAC2)