### PR TITLE
MAINT extend runhistory unit test for picklability

### DIFF
--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -23,23 +23,17 @@ RunValue = collections.namedtuple(
 
 class RunHistory(object):
 
-    '''
-         saves all run informations from target algorithm runs
+    '''Container for target algorithm run information.
 
-        Attributes
-        ----------
+    Guaranteed to be picklable.
+
+    Arguments
+    ---------
+    aggregate_func: callable
+        function to aggregate perf across instances
     '''
 
     def __init__(self, aggregate_func):
-        '''
-        Constructor
-        
-        Arguments
-        ---------
-        aggregate_func: callable
-            function to aggregate perf across instances
-        
-        '''
 
         # By having the data in a deterministic order we can do useful tests
         # when we serialize the data and can assume it's still in the same

--- a/test/test_runhistory/test_runhistory.py
+++ b/test/test_runhistory/test_runhistory.py
@@ -1,5 +1,6 @@
+import pickle
+import tempfile
 import unittest
-import logging
 
 from ConfigSpace import Configuration, ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformIntegerHyperparameter
@@ -21,9 +22,9 @@ def get_config_space():
 
 class RunhistoryTest(unittest.TestCase):
 
-    def test_add(self):
+    def test_add_and_pickle(self):
         '''
-            simply adding some rundata to runhistory
+            simply adding some rundata to runhistory, then pickle it
         '''
         rh = RunHistory(aggregate_func=average_cost)
         cs = get_config_space()
@@ -43,6 +44,15 @@ class RunhistoryTest(unittest.TestCase):
                additional_info={"start_time": 10})
 
         self.assertFalse(rh.empty())
+
+        tmpfile = tempfile.NamedTemporaryFile(mode='wb', delete=False)
+        pickle.dump(rh, tmpfile, -1)
+        name = tmpfile.name
+        tmpfile.close()
+
+        with open(name, 'rb') as fh:
+            loaded_rh = pickle.load(fh)
+        self.assertEqual(loaded_rh.data, rh.data)
 
     def test_get_config_runs(self):
         '''


### PR DESCRIPTION
This PR adds a unit test to ensure that the runhistory (with simple data) can be pickled.