### PR TITLE
update travis-ci, use requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ matrix:
 
   include:
   - os: linux
-    env: PYTHON_VERSION="3.4"
+    env: PYTHON_VERSION="3.4" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
   - os: linux
-    env: PYTHON_VERSION="3.5" COVERAGE="true"
+    env: PYTHON_VERSION="3.5" COVERAGE="true" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
 
   # Set language to generic to not break travis-ci
   # https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-195620855
@@ -15,11 +15,11 @@ matrix:
   - os: osx
     sudo: required
     language: generic
-    env: PYTHON_VERSION="3.4"
+    env: PYTHON_VERSION="3.4" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
   - os: osx
     sudo: required
     language: generic
-    env: PYTHON_VERSION="3.5"
+    env: PYTHON_VERSION="3.5" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 
 cache:
   directories:
@@ -32,9 +32,10 @@ before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget $MINICONDA_URL -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
+  - if [[ `which conda` ]]; then echo 'Conda installation successful'; else exit 1; fi
   - conda update --yes conda
   - conda create -n testenv --yes python=$PYTHON_VERSION pip wheel nose
   - source activate testenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,25 @@
 language: python
-python:
-  - "3.4"
-  - "3.5"
-
-os:
-  - linux
-  - osx
 
 matrix:
-  allow_failures:
-    - os: osx
+
+  include:
+  - os: linux
+    env: DISTRIB="conda" PYTHON_VERSION="3.4"
+  - os: linux
+    env: DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
+
+  # Set language to generic to not break travis-ci
+  # https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-195620855
+  # so far, this issue is still open and there is no good solution
+  # python will then be installed by anaconda
+  - os: osx
+    sudo: required
+    language: generic
+    env: DISTRIB="conda" PYTHON_VERSION="3.4"
+  - os: osx
+    sudo: required
+    language: generic
+    env: DISTRIB="conda" PYTHON_VERSION="3.5"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ matrix:
 
   include:
   - os: linux
-    env: DISTRIB="conda" TRAVIS_PYTHON_VERSION="3.4"
+    env: TRAVIS_PYTHON_VERSION="3.4"
   - os: linux
-    env: DISTRIB="conda" TRAVIS_PYTHON_VERSION="3.5" COVERAGE="true"
+    env: TRAVIS_PYTHON_VERSION="3.5" COVERAGE="true"
 
   # Set language to generic to not break travis-ci
   # https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-195620855
@@ -15,11 +15,11 @@ matrix:
   - os: osx
     sudo: required
     language: generic
-    env: DISTRIB="conda" PYTHON_VERSION="3.4"
+    env: TRAVIS_PYTHON_VERSION="3.4"
   - os: osx
     sudo: required
     language: generic
-    env: DISTRIB="conda" PYTHON_VERSION="3.5"
+    env: TRAVIS_PYTHON_VERSION="3.5"
 
 cache:
   directories:
@@ -36,6 +36,7 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda update --yes conda
+  - env
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION pip wheel nose
   - source activate testenv
   - conda install --yes gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ matrix:
 
   include:
   - os: linux
-    env: TRAVIS_PYTHON_VERSION="3.4"
+    env: PYTHON_VERSION="3.4"
   - os: linux
-    env: TRAVIS_PYTHON_VERSION="3.5" COVERAGE="true"
+    env: PYTHON_VERSION="3.5" COVERAGE="true"
 
   # Set language to generic to not break travis-ci
   # https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-195620855
@@ -15,11 +15,11 @@ matrix:
   - os: osx
     sudo: required
     language: generic
-    env: TRAVIS_PYTHON_VERSION="3.4"
+    env: PYTHON_VERSION="3.4"
   - os: osx
     sudo: required
     language: generic
-    env: TRAVIS_PYTHON_VERSION="3.5"
+    env: PYTHON_VERSION="3.5"
 
 cache:
   directories:
@@ -36,8 +36,7 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda update --yes conda
-  - env
-  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION pip wheel nose
+  - conda create -n testenv --yes python=$PYTHON_VERSION pip wheel nose
   - source activate testenv
   - conda install --yes gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ matrix:
 
   include:
   - os: linux
-    env: DISTRIB="conda" PYTHON_VERSION="3.4"
+    env: DISTRIB="conda" TRAVIS_PYTHON_VERSION="3.4"
   - os: linux
-    env: DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
+    env: DISTRIB="conda" TRAVIS_PYTHON_VERSION="3.5" COVERAGE="true"
 
   # Set language to generic to not break travis-ci
   # https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-195620855

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
     language: generic
     env: PYTHON_VERSION="3.5" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 
+  allow_failures:
+  - os: osx
+
 cache:
   directories:
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - conda update --yes conda
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION pip wheel nose
   - source activate testenv
-  - conda install gcc
+  - conda install --yes gcc
 
 install:
   - pip install coverage pep8 python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,15 +41,14 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda update --yes conda
-  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION pip nose
+  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION pip wheel nose
   - source activate testenv
 
 install:
-  - conda install --yes numpy>=1.6.1 scipy>=0.13.1 six setuptools Cython
   - pip install coverage pep8 python-coveralls
-  - pip install psutil
   # necessary for rfr
   - export CXX="g++-4.8" CC="gcc-4.8"
+  - cat requirements.txt | xargs -n 1 -L 1 pip install
   - python setup.py install
 
 # command to run tests, e.g. python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,21 +21,6 @@ sudo: false
 before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 
-# command to install dependencies
-addons:
-  apt:
-    sources:
-    # necessary for rfr 
-    - ubuntu-toolchain-r-test
-    packages:
-    # necessary for rfr
-    - gcc-4.8
-    - g++-4.8
-    - libatlas-dev
-    - liblapack-dev
-    - libatlas-base-dev
-    - gfortran
-
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -43,11 +28,10 @@ before_install:
   - conda update --yes conda
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION pip wheel nose
   - source activate testenv
+  - conda install gcc
 
 install:
   - pip install coverage pep8 python-coveralls
-  # necessary for rfr
-  - export CXX="g++-4.8" CC="gcc-4.8"
   - cat requirements.txt | xargs -n 1 -L 1 pip install
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ before_install:
   - conda create -n testenv --yes python=$PYTHON_VERSION pip wheel nose
   - source activate testenv
   - conda install --yes gcc
+  - echo "Using GCC at "`which gcc`
+  - export CC=`which gcc`
 
 install:
   - pip install coverage pep8 python-coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 setuptools
-numpy>=1.6.1
-scipy>=0.13.1
+numpy>=1.7.1
+scipy>=0.18.1
 six
 Cython
+psutil
 pynisher>=0.4.1
 ConfigSpace>=0.2.1
 pyrfr

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,13 @@
-import os
 import setuptools
 
 import smac
 
 
-requirements = ['setuptools',
-                'numpy>=1.6.1',
-                'scipy>=0.13.1',
-                'pyrfr',
-                'ConfigSpace>=0.2.1',
-                'pynisher>=0.4.1',
-                'scikit-learn',
-                'typing']
+with open('requirements.txt') as fh:
+    requirements = fh.read()
+requirements = requirements.split('\n')
+requirements = [requirement.strip() for requirement in requirements]
+
 
 setuptools.setup(
     name="smac",


### PR DESCRIPTION
This PR does:
* increase version number of scipy and numpy dependency
* only use requirements.txt, remove dependencies from setup.py
* set up environment for successful MAC OS builds
* use anaconda gcc instead of ubuntu gcc for compilation on travis-ci (side-effect, MAC OS build works)
