### PR TITLE
MAINT add MANIFEST.in to allow pip install smac.tar.gz

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
Adding the manifest adds the requirements to the SMAC source distribution file. This is crucial as the setup.py reads the requirements file.