### PR TITLE
Minimize SMAC overhead

### DIFF
--- a/examples/branin/branin_scenario.txt
+++ b/examples/branin/branin_scenario.txt
@@ -2,3 +2,4 @@ algo = python branin.py
 paramfile = branin_pcs.pcs
 run_obj = quality
 runcount_limit = 500
+deterministic = 1

--- a/smac/epm/rf_with_instances.py
+++ b/smac/epm/rf_with_instances.py
@@ -53,7 +53,7 @@ class RandomForestWithInstances(AbstractEPM):
 
     def __init__(self, types,
                  instance_features=None,
-                 num_trees=30,
+                 num_trees=10,
                  do_bootstrapping=True,
                  n_points_per_tree=0,
                  ratio_features=5. / 6.,

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -270,11 +270,11 @@ class Intensifier(object):
                     # challenger is not worse, continue
                     N = 2 * N
 
-            if chall_indx >= 1 and num_run > self.run_limit:
+            if chall_indx > 1 and num_run > self.run_limit:
                 self.logger.debug(
                     "Maximum #runs for intensification reached")
                 break
-            elif chall_indx >= 1 and time.time() - self.start_time - time_bound >= 0:
+            elif chall_indx > 1 and time.time() - self.start_time - time_bound >= 0:
                 self.logger.debug("Timelimit for intensification reached ("
                                   "used: %f sec, available: %f sec)" % (
                                       time.time() - self.start_time, time_bound))
@@ -285,5 +285,7 @@ class Intensifier(object):
         inc_perf = aggregate_func(incumbent, run_history, inc_runs)
         self.logger.info("Updated estimated performance of incumbent on %d runs: %.4f" % (
             len(inc_runs), inc_perf))
+        
+        self.stats.update_average_configs_per_intensify(n_configs=chall_indx)
 
         return incumbent, inc_perf

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -125,7 +125,6 @@ class Intensifier(object):
                     "Challenger was the same as the current incumbent; Skipping challenger")
                 continue
             
-            chall_indx += 1
             self.logger.debug("Intensify on %s", challenger)
             if hasattr(challenger, 'origin'):
                 self.logger.debug(
@@ -183,6 +182,10 @@ class Intensifier(object):
 
             inc_inst_seeds = set(run_history.get_runs_for_config(incumbent))
             inc_perf = aggregate_func(incumbent, run_history, inc_inst_seeds)
+            
+            # at least one run of challenger
+            # to increase chall_indx counter 
+            first_run = False 
 
             # Line 9
             while True:
@@ -191,6 +194,10 @@ class Intensifier(object):
 
                 # Line 10
                 missing_runs = list(inc_inst_seeds - chall_inst_seeds)
+                
+                if (not first_run) and missing_runs:
+                    first_run = True
+                    chall_indx += 1
 
                 # Line 11
                 self.rs.shuffle(missing_runs)

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -195,10 +195,6 @@ class Intensifier(object):
                 # Line 10
                 missing_runs = list(inc_inst_seeds - chall_inst_seeds)
                 
-                if (not first_run) and missing_runs:
-                    first_run = True
-                    chall_indx += 1
-
                 # Line 11
                 self.rs.shuffle(missing_runs)
                 to_run = missing_runs[:min(N, len(missing_runs))]
@@ -230,7 +226,11 @@ class Intensifier(object):
 
                     else:
                         cutoff = self.cutoff
-                        
+
+                    if not first_run:
+                        first_run = True
+                        chall_indx += 1
+                            
                     self.logger.debug("Add run of challenger")
                     status, cost, dur, res = self.tae_runner.start(
                         config=challenger,

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -116,13 +116,16 @@ class Intensifier(object):
             raise ValueError("time_bound must be >= 0.01")
 
         num_run = 0
+        chall_indx = 0
 
         # Line 1 + 2
-        for chall_indx, challenger in enumerate(challengers):
+        for challenger in challengers:
             if challenger == incumbent:
                 self.logger.warning(
                     "Challenger was the same as the current incumbent; Skipping challenger")
                 continue
+            
+            chall_indx += 1
             self.logger.debug("Intensify on %s", challenger)
             if hasattr(challenger, 'origin'):
                 self.logger.debug(

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -44,7 +44,7 @@ class RunHistory(object):
         # order as it was added.
         self.data = collections.OrderedDict()
 
-        # for fast access, we have also a unordered data structure
+        # for fast access, we have also an unordered data structure
         self._configid_to_inst_seed = {}
 
         self.config_ids = {}  # config -> id

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -43,7 +43,7 @@ class RunHistory(object):
         # when we serialize the data and can assume it's still in the same
         # order as it was added.
         self.data = collections.OrderedDict()
-        
+
         # for fast access, we have also a unordered data structure
         self._configid_to_inst_seed = {}
 
@@ -95,12 +95,13 @@ class RunHistory(object):
         k = RunKey(config_id, instance_id, seed)
         v = RunValue(cost, time, status, additional_info)
         self.data[k] = v
-        
-        #also add to fast data structure
-        is_k = InstSeedKey(instance_id,seed)
-        self._configid_to_inst_seed[config_id] = self._configid_to_inst_seed.get(config_id,{})
+
+        # also add to fast data structure
+        is_k = InstSeedKey(instance_id, seed)
+        self._configid_to_inst_seed[
+            config_id] = self._configid_to_inst_seed.get(config_id, {})
         self._configid_to_inst_seed[config_id][is_k] = v
-        
+
         # assumes an average across runs as cost function
         self.incremental_update_cost(config, cost)
 
@@ -251,12 +252,12 @@ class RunHistory(object):
 
         # important to use add method to use all data structure correctly
         for k, v in all_data["data"]:
-            self.add(config=self.ids_config[int(k[0])], 
-                     cost=float(v[0]), 
-                     time=float(v[1]), 
-                     status=v[2], 
-                     instance_id=k[1], 
-                     seed=int(k[2]), 
+            self.add(config=self.ids_config[int(k[0])],
+                     cost=float(v[0]),
+                     time=float(v[1]),
+                     status=v[2],
+                     instance_id=k[1],
+                     seed=int(k[2]),
                      additional_info=v[3])
 
     def update_from_json(self, fn, cs):

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -45,6 +45,7 @@ class RunHistory(object):
         self.data = collections.OrderedDict()
 
         # for fast access, we have also an unordered data structure
+        # to get all instance seed pairs of a configuration
         self._configid_to_inst_seed = {}
 
         self.config_ids = {}  # config -> id
@@ -99,8 +100,8 @@ class RunHistory(object):
         # also add to fast data structure
         is_k = InstSeedKey(instance_id, seed)
         self._configid_to_inst_seed[
-            config_id] = self._configid_to_inst_seed.get(config_id, {})
-        self._configid_to_inst_seed[config_id][is_k] = v
+            config_id] = self._configid_to_inst_seed.get(config_id, [])
+        self._configid_to_inst_seed[config_id].append(is_k)    
 
         # assumes an average across runs as cost function
         self.incremental_update_cost(config, cost)
@@ -187,11 +188,11 @@ class RunHistory(object):
             list: tuples of instance, seed
         """
         config_id = self.config_ids.get(config)
-        is_dict = self._configid_to_inst_seed.get(config_id)
-        if is_dict is None:
+        is_list = self._configid_to_inst_seed.get(config_id)
+        if is_list is None:
             return []
         else:
-            return list(is_dict.keys())
+            return is_list
 
     def empty(self):
         """

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -18,6 +18,9 @@ __version__ = "0.0.1"
 RunKey = collections.namedtuple(
     'RunKey', ['config_id', 'instance_id', 'seed'])
 
+InstSeedKey = collections.namedtuple(
+    'InstSeedKey', ['instance', 'seed'])
+
 RunValue = collections.namedtuple(
     'RunValue', ['cost', 'time', 'status', 'additional_info'])
 
@@ -40,6 +43,9 @@ class RunHistory(object):
         # when we serialize the data and can assume it's still in the same
         # order as it was added.
         self.data = collections.OrderedDict()
+        
+        # for fast access, we have also a unordered data structure
+        self._configid_to_inst_seed = {}
 
         self.config_ids = {}  # config -> id
         self.ids_config = {}  # id -> config
@@ -88,8 +94,13 @@ class RunHistory(object):
 
         k = RunKey(config_id, instance_id, seed)
         v = RunValue(cost, time, status, additional_info)
-
         self.data[k] = v
+        
+        #also add to fast data structure
+        is_k = InstSeedKey(instance_id,seed)
+        self._configid_to_inst_seed[config_id] = self._configid_to_inst_seed.get(config_id,{})
+        self._configid_to_inst_seed[config_id][is_k] = v
+        
         # assumes an average across runs as cost function
         self.incremental_update_cost(config, cost)
 
@@ -156,6 +167,10 @@ class RunHistory(object):
         self.runs_per_config[config_id] = n_runs + 1
 
     def get_cost(self, config):
+        '''
+            returns empirical cost for a configuration;
+            uses  self.cost_per_config
+        '''
         config_id = self.config_ids[config]
         return self.cost_per_config[config_id]
 
@@ -170,18 +185,12 @@ class RunHistory(object):
         ----------
             list: tuples of instance, seed
         """
-        InstanceSeedPair = collections.namedtuple("InstanceSeedPair",
-                                                  ["instance", "seed"])
         config_id = self.config_ids.get(config)
-        list_ = []
-        for k in self.data:
-            # TA will return ABORT if config. budget was exhausted and
-            # we don't want to collect such runs to compute the cost of a
-            # configuration
-            if config_id == k.config_id and self.data[k].status not in [StatusType.ABORT]:
-                ist = InstanceSeedPair(k.instance_id, k.seed)
-                list_.append(ist)
-        return list_
+        is_dict = self._configid_to_inst_seed.get(config_id)
+        if is_dict is None:
+            return []
+        else:
+            return list(is_dict.keys())
 
     def empty(self):
         """
@@ -240,9 +249,15 @@ class RunHistory(object):
 
         self._n_id = len(self.config_ids)
 
-        self.data = {RunKey(int(k[0]), k[1], int(k[2])):
-                     RunValue(float(v[0]), float(v[1]), v[2], v[3])
-                     for k, v in all_data["data"]}
+        # important to use add method to use all data structure correctly
+        for k, v in all_data["data"]:
+            self.add(config=self.ids_config[int(k[0])], 
+                     cost=float(v[0]), 
+                     time=float(v[1]), 
+                     status=v[2], 
+                     instance_id=k[1], 
+                     seed=int(k[2]), 
+                     additional_info=v[3])
 
     def update_from_json(self, fn, cs):
         """Update the current runhistory by adding new runs from a json file.

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -101,7 +101,7 @@ class RunHistory(object):
         is_k = InstSeedKey(instance_id, seed)
         self._configid_to_inst_seed[
             config_id] = self._configid_to_inst_seed.get(config_id, [])
-        self._configid_to_inst_seed[config_id].append(is_k)    
+        self._configid_to_inst_seed[config_id].append(is_k)
 
         # assumes an average across runs as cost function
         self.incremental_update_cost(config, cost)

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -284,7 +284,7 @@ class SMBO(BaseSolver):
                ordered by their acquisition function value
         """
         configs_acq = []
-
+        
         # Start N local search from different random start points
         for start_point in init_points:
             configuration, acq_val = self.acq_optimizer.maximize(start_point)

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -123,8 +123,6 @@ class SMBO(BaseSolver):
             logging.debug(
                 "Time spend to choose next configurations: %.2f sec" % (time_spend))
 
-            break
-
             self.logger.debug("Intensify")
 
             self.incumbent, inc_perf = self.intensifier.intensify(
@@ -204,8 +202,8 @@ class SMBO(BaseSolver):
             next_configs_by_local_search
         next_configs_by_acq_value.sort(reverse=True, key=lambda x: x[0])
         self.logger.debug(
-            "First 10 acq func values of selected configurations: %s" %
-            (str([_[0] for _ in next_configs_by_acq_value[:10]])))
+            "First 10 acq func (origin) values of selected configurations: %s" %
+            (str([[_[0],_[1].origin] for _ in next_configs_by_acq_value[:10]])))
         next_configs_by_acq_value = [_[1] for _ in next_configs_by_acq_value]
 
         challengers = list(itertools.chain(*zip(next_configs_by_acq_value,

--- a/smac/stats/stats.py
+++ b/smac/stats/stats.py
@@ -104,9 +104,9 @@ class Stats(object):
         self._n_configs_per_intensify += n_configs
         
         if self._n_calls_of_intensify == 1:
-            self._sliding_n_configs_per_intensifiy = n_configs
+            self._ema_n_configs_per_intensifiy = n_configs
         else:
-            self._sliding_n_configs_per_intensifiy = (1 - self._EMA_ALPHA) * self._sliding_n_configs_per_intensifiy \
+            self._ema_n_configs_per_intensifiy = (1 - self._EMA_ALPHA) * self._ema_n_configs_per_intensifiy \
                                                         + self._EMA_ALPHA * n_configs
         
 
@@ -132,6 +132,6 @@ class Stats(object):
         self._logger.debug("Debug Statistics:")
         if self._n_calls_of_intensify > 0:
             self._logger.debug("Average Configurations per Intensify: %.2f" %(self._n_configs_per_intensify / self._n_calls_of_intensify))
-            self._logger.debug("Exponential Moving Average of Configurations per Intensify: %.2f" %(self._sliding_n_configs_per_intensifiy))
+            self._logger.debug("Exponential Moving Average of Configurations per Intensify: %.2f" %(self._ema_n_configs_per_intensifiy))
         
         log_func("##########################################################")    

--- a/smac/stats/stats.py
+++ b/smac/stats/stats.py
@@ -24,6 +24,13 @@ class Stats(object):
         self.ta_time_used = 0
         self.inc_changed = 0
     
+        # debug stats
+        self._n_configs_per_intensify = 0
+        self._n_calls_of_intensify = 0
+        ## exponential moving average 
+        self._ema_n_configs_per_intensifiy = 0 
+        self._EMA_ALPHA = 0.2
+    
         self._start_time = None
         self._logger = logging.getLogger("Stats")
 
@@ -83,6 +90,25 @@ class Stats(object):
         return  self.get_remaing_time_budget() < 0 or \
                 self.get_remaining_ta_budget() < 0 or \
                 self.get_remaining_ta_runs() <= 0
+                
+    def update_average_configs_per_intensify(self, n_configs: int):
+        '''
+            updates statistics how many configurations on average per used in intensify
+            
+            Arguments
+            ---------
+            n_configs: int
+                number of configurations in current intensify
+        '''
+        self._n_calls_of_intensify += 1
+        self._n_configs_per_intensify += n_configs
+        
+        if self._n_calls_of_intensify == 1:
+            self._sliding_n_configs_per_intensifiy = n_configs
+        else:
+            self._sliding_n_configs_per_intensifiy = (1 - self._EMA_ALPHA) * self._sliding_n_configs_per_intensifiy \
+                                                        + self._EMA_ALPHA * n_configs
+        
 
     def print_stats(self, debug_out:bool=False):
         '''
@@ -103,5 +129,9 @@ class Stats(object):
         log_func("#Target algorithm runs: %d / %s" %(self.ta_runs, str(self.__scenario.ta_run_limit)))
         log_func("Used wallclock time: %.2f / %.2f sec " %(time.time() - self._start_time, self.__scenario.wallclock_limit))
         log_func("Used target algorithm runtime: %.2f / %.2f sec" %(self.ta_time_used, self.__scenario.algo_runs_timelimit))
+        self._logger.debug("Debug Statistics:")
+        if self._n_calls_of_intensify > 0:
+            self._logger.debug("Average Configurations per Intensify: %.2f" %(self._n_configs_per_intensify / self._n_calls_of_intensify))
+            self._logger.debug("Exponential Moving Average of Configurations per Intensify: %.2f" %(self._sliding_n_configs_per_intensifiy))
         
         log_func("##########################################################")    


### PR DESCRIPTION
the title of the branch is a bit misleading. My main goal was to speed up the local search but I also changed other stuff to minimize the overhead of SMAC. Profiling SMAC on branin "with instances" (see aclib2), SMAC spends now more time in the subprocess than in its own functions (for the first 2000 function evaluations), even tough branin is such a cheap function.

* initialize local search with best configs from random search
* reduce number of trees in RF to 10 (as in SMAC2)
* run at least 2 configurations per intensify call (as in SMAC2)
* adaptively adjust number of local search iterations based on intensify stats
* more efficient runhistory data structure to get runs for a given