### PR TITLE
Fix/#133

### DIFF
--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -1,6 +1,6 @@
 import collections
 import json
-import numpy
+import numpy as np
 import typing
 
 from smac.configspace import Configuration
@@ -61,7 +61,8 @@ class RunHistory(object):
     def add(self, config, cost, time,
             status, instance_id=None,
             seed=None,
-            additional_info=None):
+            additional_info=None,
+            external_data:bool=False):
         '''
         adds a data of a new target algorithm (TA) run;
         it will update data if the same key values are used 
@@ -70,7 +71,7 @@ class RunHistory(object):
         Attributes
         ----------
             config : dict (or other type -- depending on config space module)
-                parameter configuratoin
+                parameter configuration
             cost: float
                 cost of TA run (will be minimized)
             time: float
@@ -84,6 +85,9 @@ class RunHistory(object):
             additional_info: dict
                 additional run infos (could include further returned
                 information from TA or fields such as start time and host_id)
+            external_data: bool
+                if True, run will not be added to self._configid_to_inst_seed 
+                and not available through get_runs_for_config()
         '''
 
         config_id = self.config_ids.get(config)
@@ -97,11 +101,12 @@ class RunHistory(object):
         v = RunValue(cost, time, status, additional_info)
         self.data[k] = v
 
-        # also add to fast data structure
-        is_k = InstSeedKey(instance_id, seed)
-        self._configid_to_inst_seed[
-            config_id] = self._configid_to_inst_seed.get(config_id, [])
-        self._configid_to_inst_seed[config_id].append(is_k)
+        if not external_data:
+            # also add to fast data structure
+            is_k = InstSeedKey(instance_id, seed)
+            self._configid_to_inst_seed[
+                config_id] = self._configid_to_inst_seed.get(config_id, [])
+            self._configid_to_inst_seed[config_id].append(is_k)
 
         # assumes an average across runs as cost function
         self.incremental_update_cost(config, cost)
@@ -127,8 +132,6 @@ class RunHistory(object):
         '''
             computes the cost of all configurations from scratch
             and overwrites self.cost_perf_config and self.runs_per_config accordingly;
-            Since we iterate over the runhistory for every configuration,
-            this function can be quite expensive.
 
             Arguments
             ---------
@@ -174,7 +177,7 @@ class RunHistory(object):
             uses  self.cost_per_config
         '''
         config_id = self.config_ids[config]
-        return self.cost_per_config[config_id]
+        return self.cost_per_config.get(config_id, np.nan)
 
     def get_runs_for_config(self, config):
         """Return all runs (instance seed pairs) for a configuration.
@@ -275,13 +278,16 @@ class RunHistory(object):
         new_runhistory.load_json(fn, cs)
         self.update(runhistory=new_runhistory)
 
-    def update(self, runhistory):
+    def update(self, runhistory, external_data:bool=False):
         """Update the current runhistory by adding new runs from a json file.
 
         Parameters
         ----------
         runhistory: RunHistory
             runhistory with additional data to be added to self
+        external_data: bool
+            if True, run will not be added to self._configid_to_inst_seed 
+            and not available through get_runs_for_config()
         """
 
         # Configurations might be already known, but by a different ID. This
@@ -294,4 +300,5 @@ class RunHistory(object):
             config = runhistory.ids_config[config_id]
             self.add(config=config, cost=cost, time=time,
                      status=status, instance_id=instance_id,
-                     seed=seed, additional_info=additional_info)
+                     seed=seed, additional_info=additional_info,
+                     external_data=external_data)

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -183,7 +183,7 @@ class Scenario(object):
             normalized_key = key.lower().replace('-', '').replace('_', '')
             if normalized_key == normalized_name:
                 value = scenario.pop(key)
-
+                
         if dest is None:
             dest = name.lower().replace('-', '_')
 
@@ -333,7 +333,13 @@ class Scenario(object):
                               (self.pcs_fn))
             sys.exit(1)
 
-        self.logger.info("Output to %s" % (self.output_dir))
+        # you cannot set output dir to None directly
+        # because None is replaced by default always
+        if self.output_dir == "":
+            self.output_dir = None
+            self.logger.debug("Deactivate output directory.")
+        else:
+            self.logger.info("Output to %s" % (self.output_dir))
 
     def __getstate__(self):
         d = dict(self.__dict__)

--- a/smac/smac_cli.py
+++ b/smac/smac_cli.py
@@ -84,6 +84,7 @@ class SMACCLI(object):
 
         finally:
             # ensure that the runhistory is always dumped in the end
-            optimizer.solver.runhistory.save_json(
-                fn=os.path.join(scen.output_dir, "runhistory.json"))
+            if scen.output_dir is not None:
+                optimizer.solver.runhistory.save_json(
+                    fn=os.path.join(scen.output_dir, "runhistory.json"))
         #smbo.runhistory.load_json(fn="runhistory.json", cs=smbo.config_space)

--- a/smac/utils/merge_foreign_data.py
+++ b/smac/utils/merge_foreign_data.py
@@ -87,7 +87,7 @@ def merge_foreign_data(scenario: Scenario,
 
     # extend runhistory
     for rh in in_runhistory_list:
-        runhistory.update(rh)
+        runhistory.update(rh, external_data=True)
 
     for date in runhistory.data:
         if scenario.feature_dict.get(date.instance_id) is None:

--- a/smac/utils/merge_foreign_data.py
+++ b/smac/utils/merge_foreign_data.py
@@ -37,7 +37,7 @@ def merge_foreign_data_from_file(scenario: Scenario,
 
     if not in_scenario_fn_list:
         raise ValueError("To read warmstart data from previous runhistories, the corresponding scenarios are required. Use option --warmstart_scenario") 
-    scens = [Scenario(scenario=scen_fn) for scen_fn in in_scenario_fn_list]
+    scens = [Scenario(scenario=scen_fn, cmd_args={"output_dir":""}) for scen_fn in in_scenario_fn_list]
     rhs = []
     for rh_fn in in_runhistory_fn_list:
         rh = RunHistory(aggregate_func)

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -166,10 +166,13 @@ class ScenarioTest(unittest.TestCase):
                            in_scenario_list=[scenario_2], in_runhistory_list=[rh_merge])
 
         # both runs should be in the runhistory
-        # but only the run on "d" should be used for the cost of <config>
+        # but we should not use the data to update the cost of config
         self.assertTrue(len(rh_base.data) == 2)
-        self.assertTrue(rh_base.get_cost(config) == 5)
+        self.assertTrue(np.isnan(rh_base.get_cost(config)))
         
+        # we should not get direct access to external run data
+        runs = rh_base.get_runs_for_config(config)
+        self.assertTrue(len(runs) == 0)
 
         rh_merge.add(config=config, instance_id="inst_new_2", cost=10, time=20,
                      status=StatusType.SUCCESS,
@@ -177,6 +180,7 @@ class ScenarioTest(unittest.TestCase):
                      additional_info=None)
         
         self.assertRaises(ValueError, merge_foreign_data, **{"scenario":scenario, "runhistory":rh_base, "in_scenario_list":[scenario_2], "in_runhistory_list":[rh_merge]})
+        
 
     def test_pickle_dump(self):
         scenario = Scenario(self.test_scenario_dict)


### PR DESCRIPTION
Fix for #133 
and adding feature to deactivate output_dir which can be annoying and confusing if merge_foreign_data is used.

Downside of this fix is that the externally loaded runhistory data is only used for training the EPM.  Previously, I hoped that we could also use the loaded data to have more evidence in `intensify` if the instance set is the same, but I don't see how this can be implemented in a consistent way using our current `intensify`.