### PR TITLE
FIX #130

### DIFF
--- a/smac/epm/rfr_imputator.py
+++ b/smac/epm/rfr_imputator.py
@@ -111,10 +111,10 @@ class RFRImputator(smac.epm.base_imputor.BaseImputor):
             n_nans = sum(nans)
             if n_nans > 0:
                 # Replace all nans with maximum of predicted perf and censored value
-                # This case should hopefully never happen -- therefore it is a warning
-                self.logger.warning("Going to replace %d nan-value(s) with "
+                # this happens if the prediction is far smaller than the censored data point
+                self.logger.debug("Going to replace %d nan-value(s) with "
                                   "max(captime, predicted mean)" % n_nans)
-                imputed_y[nans] = max(censored_y[nans], y_mean[nans])
+                imputed_y[nans] = np.max([censored_y[nans], y_mean[nans]], axis=0)
                 
             if it > 1:
                 # Calc mean difference between imputed values this and last

--- a/smac/epm/rfr_imputator.py
+++ b/smac/epm/rfr_imputator.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 import numpy as np
 from scipy.stats import truncnorm
 
@@ -89,41 +90,51 @@ class RFRImputator(smac.epm.base_imputor.BaseImputor):
 
         it = 1
         change = 0
-        
+
         while True:
             self.logger.debug("Iteration %d of %d" % (it, self.max_iter))
 
             # predict censored y values
             y_mean, y_var = self.model.predict(censored_X)
             y_var[y_var < self.var_threshold] = self.var_threshold
-            y_stdev = np.sqrt(y_var)[:,0]
-            y_mean = y_mean[:,0]
-            
-            imputed_y = truncnorm.stats(a=(censored_y - y_mean) / y_stdev,
-                                    b=(self.threshold - y_mean) / y_stdev,
-                                    loc=y_mean,
-                                    scale=y_stdev,
-                                    moments='m')
-            
+            y_stdev = np.sqrt(y_var)[:, 0]
+            y_mean = y_mean[:, 0]
+
+            # ignore the warnings of truncnorm.stats
+            # since we handle them appropriately
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    'ignore', r'invalid value encountered in subtract.*')
+                warnings.filterwarnings(
+                    'ignore', r'divide by zero encountered in true_divide.*')
+                imputed_y = truncnorm.stats(a=(censored_y - y_mean) / y_stdev,
+                                            b=(self.threshold - y_mean) /
+                                            y_stdev,
+                                            loc=y_mean,
+                                            scale=y_stdev,
+                                            moments='m')
+
             imputed_y = np.array(imputed_y)
 
             nans = np.isfinite(imputed_y) == False
             n_nans = sum(nans)
             if n_nans > 0:
                 # Replace all nans with maximum of predicted perf and censored value
-                # this happens if the prediction is far smaller than the censored data point
+                # this happens if the prediction is far smaller than the
+                # censored data point
                 self.logger.debug("Going to replace %d nan-value(s) with "
                                   "max(captime, predicted mean)" % n_nans)
-                imputed_y[nans] = np.max([censored_y[nans], y_mean[nans]], axis=0)
-                
+                imputed_y[nans] = np.max(
+                    [censored_y[nans], y_mean[nans]], axis=0)
+
             if it > 1:
                 # Calc mean difference between imputed values this and last
                 # iteration, assume imputed values are always concatenated
                 # after uncensored values
 
                 change = np.mean(abs(imputed_y -
-                                        y[uncensored_y.shape[0]:]) /
-                                    y[uncensored_y.shape[0]:])
+                                     y[uncensored_y.shape[0]:]) /
+                                 y[uncensored_y.shape[0]:])
 
             # lower all values that are higher than threshold
             # should probably never happen
@@ -144,7 +155,7 @@ class RFRImputator(smac.epm.base_imputor.BaseImputor):
                 break
 
         self.logger.debug("Imputation used %d/%d iterations, last_change=%f" %
-                          (it-1, self.max_iter, change))
+                          (it - 1, self.max_iter, change))
 
         # replace all y > cutoff with PAR10 values (i.e., threshold)
         imputed_y = np.array(imputed_y, dtype=np.float)

--- a/smac/epm/rfr_imputator.py
+++ b/smac/epm/rfr_imputator.py
@@ -104,9 +104,9 @@ class RFRImputator(smac.epm.base_imputor.BaseImputor):
             # since we handle them appropriately
             with warnings.catch_warnings():
                 warnings.filterwarnings(
-                    'ignore', r'invalid value encountered in subtract.*')
+                    'ignore', r'invalid value encountered in (subtract|true_divide).*')
                 warnings.filterwarnings(
-                    'ignore', r'divide by zero encountered in true_divide.*')
+                    'ignore', r'divide by zero encountered in (true_divide|log).*')
                 imputed_y = truncnorm.stats(a=(censored_y - y_mean) / y_stdev,
                                             b=(self.threshold - y_mean) /
                                             y_stdev,

--- a/smac/epm/rfr_imputator.py
+++ b/smac/epm/rfr_imputator.py
@@ -116,7 +116,7 @@ class RFRImputator(smac.epm.base_imputor.BaseImputor):
 
             imputed_y = np.array(imputed_y)
 
-            nans = np.isfinite(imputed_y) == False
+            nans = ~np.isfinite(imputed_y)
             n_nans = sum(nans)
             if n_nans > 0:
                 # Replace all nans with maximum of predicted perf and censored value
@@ -132,7 +132,7 @@ class RFRImputator(smac.epm.base_imputor.BaseImputor):
                 # iteration, assume imputed values are always concatenated
                 # after uncensored values
 
-                change = np.mean(abs(imputed_y -
+                change = np.mean(np.abs(imputed_y -
                                      y[uncensored_y.shape[0]:]) /
                                  y[uncensored_y.shape[0]:])
 

--- a/smac/runhistory/runhistory2epm.py
+++ b/smac/runhistory/runhistory2epm.py
@@ -335,7 +335,7 @@ class RunHistory2EPM4LogCost(RunHistory2EPM4Cost):
                               instances=instances, par_factor=par_factor)
 
         # ensure that minimal value is larger than 0
-        if np.sum(y <= 0) > 0:
+        if np.any(y <= 0):
             self.logger.warning(
                 "Got cost of smaller/equal to 0. Replace by %f since we use log cost." % (constants.MINIMAL_COST_FOR_LOG))
             y[y <

--- a/test/test_runhistory/test_rfr_imputor.py
+++ b/test/test_runhistory/test_rfr_imputor.py
@@ -56,6 +56,7 @@ class Scen(scenario.Scenario):
         self.cutoff = None
         self.feature_dict = None
         self.n_features = 0
+        self.par_factor = 1
 
 
 class ImputorTest(unittest.TestCase):

--- a/test/test_runhistory/test_runhistory2epm.py
+++ b/test/test_runhistory/test_runhistory2epm.py
@@ -6,6 +6,9 @@ __email__ = "eggenspk@cs.uni-freiburg.de"
 __version__ = "0.0.1"
 
 import unittest
+
+import numpy as np
+
 from smac.tae.execute_ta_run import StatusType
 from smac.runhistory import runhistory, runhistory2epm
 
@@ -14,6 +17,9 @@ from ConfigSpace.hyperparameters import UniformIntegerHyperparameter
 from smac.runhistory.runhistory import RunHistory
 from smac.scenario.scenario import Scenario
 from smac.smbo.objective import average_cost
+from smac.epm.rfr_imputator import RFRImputator
+from smac.epm.rf_with_instances import RandomForestWithInstances
+
 
 def get_config_space():
     cs = ConfigurationSpace()
@@ -25,46 +31,209 @@ def get_config_space():
                                                        upper=100))
     return cs
 
+
 class RunhistoryTest(unittest.TestCase):
 
-    def test_add(self):
-        '''
-            simply adding some rundata to runhistory
-        '''
-        rh = runhistory.RunHistory(aggregate_func=average_cost)
-        cs = get_config_space()
-        config1 = Configuration(cs,
-                                values={'a': 1, 'b': 2})
-        config2 = Configuration(cs,
-                                values={'a': 1, 'b': 25})
-        config3 = Configuration(cs,
-                                values={'a': 2, 'b': 2})
-        rh.add(config=config1, cost=10, time=20,
-               status=StatusType.SUCCESS, instance_id=23,
-               seed=None,
-               additional_info=None)
-        rh.add(config=config2, cost=10, time=20,
-               status=StatusType.SUCCESS, instance_id=1,
-               seed=12354,
-               additional_info={"start_time": 10})
-        rh.add(config=config3, cost=10, time=20,
-               status=StatusType.TIMEOUT, instance_id=1,
-               seed=45,
-               additional_info={"start_time": 10})
-        
-        scen = Scenario({"cutoff_time": 10, 'cs': cs})
+    def setUp(self):
+        unittest.TestCase.setUp(self)
 
-        self.assertRaises(TypeError, runhistory2epm.RunHistory2EPM4LogCost)
+        self.rh = runhistory.RunHistory(aggregate_func=average_cost)
+        self.cs = get_config_space()
+        self.config1 = Configuration(self.cs,
+                                     values={'a': 0, 'b': 100})
+        self.config2 = Configuration(self.cs,
+                                     values={'a': 100, 'b': 0})
+        self.config3 = Configuration(self.cs,
+                                     values={'a': 100, 'b': 100})
+
+        self.scen = Scenario({"cutoff_time": 20, 'cs': self.cs})
+
+    def test_log_runtime_with_imputation(self):
+        '''
+            adding some rundata to RunHistory2EPM4LogCost
+        '''
+        self.imputor = RFRImputator(rs=np.random.RandomState(seed=12345),
+                                    cutoff=np.log10(self.scen.cutoff),
+                                    threshold=np.log10(
+                                        self.scen.cutoff * self.scen.par_factor),
+                                    model=RandomForestWithInstances(types=np.array([0, 0], dtype=np.uint),
+                                                                    instance_features=None,
+                                                                    seed=12345)
+                                    )
 
         rh2epm = runhistory2epm.RunHistory2EPM4LogCost(num_params=2,
-                                                       scenario=scen)
-        rhArr = rh2epm.transform(rh)
+                                                       scenario=self.scen,
+                                                       impute_censored_data=True,
+                                                       impute_state=[
+                                                           StatusType.TIMEOUT],
+                                                       imputor=self.imputor)
 
-        # We expect
-        #  1  2 23     0 0 23
-        #  1 25  1  -> 0 1  1
-        # 21  2  1     1 0  1
-        #TODO: ML I don't understand this comment
+        self.rh.add(config=self.config1, cost=1, time=1,
+                    status=StatusType.SUCCESS, instance_id=23,
+                    seed=None,
+                    additional_info=None)
 
+        X, y = rh2epm.transform(self.rh)
+        self.assertTrue(np.allclose(X, np.array([[0.005, 0.995]]), atol=0.001))
+        self.assertTrue(np.allclose(y, np.array([[0.]])))  # 10^0 = 1
+
+        # rh2epm should use time and not cost field later
+        self.rh.add(config=self.config3, cost=200, time=20,
+                    status=StatusType.TIMEOUT, instance_id=1,
+                    seed=45,
+                    additional_info={"start_time": 20})
+
+        X, y = rh2epm.transform(self.rh)
+        self.assertTrue(
+            np.allclose(X, np.array([[0.005, 0.995], [0.995, 0.995]]), atol=0.001))
+        # log_10(20 * 10)
+        self.assertTrue(np.allclose(y, np.array([[0.], [2.301]]), atol=0.001))
+
+        self.rh.add(config=self.config2, cost=100, time=10,
+                    status=StatusType.TIMEOUT, instance_id=1,
+                    seed=12354,
+                    additional_info={"start_time": 10})
+
+        X, y = rh2epm.transform(self.rh)
+        self.assertTrue(np.allclose(
+            X, np.array([[0.005, 0.995], [0.995, 0.005], [0.995, 0.995]]), atol=0.001))
+        # both timeouts should be imputed to a PAR10
+        self.assertTrue(
+            np.allclose(y, np.array([[0.], [2.301], [2.301]]), atol=0.001))
+
+    def test_log_cost_without_imputation(self):
+        '''
+            adding some rundata to RunHistory2EPM4LogCost
+        '''
+        
+        rh2epm = runhistory2epm.RunHistory2EPM4LogCost(num_params=2,
+                                                       scenario=self.scen)
+
+        self.rh.add(config=self.config1, cost=1, time=1,
+                    status=StatusType.SUCCESS, instance_id=23,
+                    seed=None,
+                    additional_info=None)
+
+        X, y = rh2epm.transform(self.rh)
+        self.assertTrue(np.allclose(X, np.array([[0.005, 0.995]]), atol=0.001))
+        self.assertTrue(np.allclose(y, np.array([[0.]])))  # 10^0 = 1
+
+        # rh2epm should use time and not cost field later
+        self.rh.add(config=self.config3, cost=200, time=20,
+                    status=StatusType.TIMEOUT, instance_id=1,
+                    seed=45,
+                    additional_info={"start_time": 20})
+
+        X, y = rh2epm.transform(self.rh)
+        self.assertTrue(
+            np.allclose(X, np.array([[0.005, 0.995], [0.995, 0.995]]), atol=0.001))
+        # log_10(20 * 10)
+        self.assertTrue(np.allclose(y, np.array([[0.], [2.301]]), atol=0.001))
+
+        self.rh.add(config=self.config2, cost=100, time=10,
+                    status=StatusType.TIMEOUT, instance_id=1,
+                    seed=12354,
+                    additional_info={"start_time": 10})
+
+        X, y = rh2epm.transform(self.rh)
+        # last entry gets skipped since imputation is disabled
+        self.assertTrue(np.allclose(
+            X, np.array([[0.005, 0.995], [0.995, 0.995]]), atol=0.001))
+        self.assertTrue(
+            np.allclose(y, np.array([[0.], [2.301]]), atol=0.001))
+
+    def test_cost_with_imputation(self):
+        '''
+            adding some rundata to RunHistory2EPM4LogCost and impute censored data
+        '''
+        
+        self.imputor = RFRImputator(rs=np.random.RandomState(seed=12345),
+                                    cutoff=self.scen.cutoff,
+                                    threshold=self.scen.cutoff * self.scen.par_factor,
+                                    model=RandomForestWithInstances(types=np.array([0, 0], dtype=np.uint),
+                                                                    instance_features=None,
+                                                                    seed=12345)
+                                    )
+
+        rh2epm = runhistory2epm.RunHistory2EPM4Cost(num_params=2,
+                                                       scenario=self.scen,
+                                                       impute_censored_data=True,
+                                                       impute_state=[
+                                                           StatusType.TIMEOUT],
+                                                       imputor=self.imputor)
+
+        self.rh.add(config=self.config1, cost=1, time=1,
+                    status=StatusType.SUCCESS, instance_id=23,
+                    seed=None,
+                    additional_info=None)
+
+        X, y = rh2epm.transform(self.rh)
+        self.assertTrue(np.allclose(X, np.array([[0.005, 0.995]]), atol=0.001))
+        self.assertTrue(np.allclose(y, np.array([[1.]])))  # 10^0 = 1
+
+        # rh2epm should use time and not cost field later
+        self.rh.add(config=self.config3, cost=200, time=20,
+                    status=StatusType.TIMEOUT, instance_id=1,
+                    seed=45,
+                    additional_info={"start_time": 20})
+
+        X, y = rh2epm.transform(self.rh)
+        self.assertTrue(
+            np.allclose(X, np.array([[0.005, 0.995], [0.995, 0.995]]), atol=0.001))
+        # log_10(20 * 10)
+        self.assertTrue(np.allclose(y, np.array([[1.], [200.]]), atol=0.001))
+
+        self.rh.add(config=self.config2, cost=100, time=10,
+                    status=StatusType.TIMEOUT, instance_id=1,
+                    seed=12354,
+                    additional_info={"start_time": 10})
+
+        X, y = rh2epm.transform(self.rh)
+        self.assertTrue(np.allclose(
+            X, np.array([[0.005, 0.995], [0.995, 0.005], [0.995, 0.995]]), atol=0.001))
+        self.assertTrue(
+            np.allclose(y, np.array([[1.], [18.970], [200.]]), atol=0.001))
+        
+    def test_cost_without_imputation(self):
+        '''
+            adding some rundata to RunHistory2EPM4LogCost
+        '''
+        
+        rh2epm = runhistory2epm.RunHistory2EPM4Cost(num_params=2,
+                                                       scenario=self.scen)
+
+        self.rh.add(config=self.config1, cost=1, time=1,
+                    status=StatusType.SUCCESS, instance_id=23,
+                    seed=None,
+                    additional_info=None)
+
+        X, y = rh2epm.transform(self.rh)
+        self.assertTrue(np.allclose(X, np.array([[0.005, 0.995]]), atol=0.001))
+        self.assertTrue(np.allclose(y, np.array([[1.]])))  # 10^0 = 1
+
+        # rh2epm should use time and not cost field later
+        self.rh.add(config=self.config3, cost=200, time=20,
+                    status=StatusType.TIMEOUT, instance_id=1,
+                    seed=45,
+                    additional_info={"start_time": 20})
+
+        X, y = rh2epm.transform(self.rh)
+        self.assertTrue(
+            np.allclose(X, np.array([[0.005, 0.995], [0.995, 0.995]]), atol=0.001))
+        # log_10(20 * 10)
+        self.assertTrue(np.allclose(y, np.array([[1.], [200.]]), atol=0.001))
+
+        self.rh.add(config=self.config2, cost=100, time=10,
+                    status=StatusType.TIMEOUT, instance_id=1,
+                    seed=12354,
+                    additional_info={"start_time": 10})
+
+        X, y = rh2epm.transform(self.rh)
+        # last entry gets skipped since imputation is disabled
+        self.assertTrue(np.allclose(
+            X, np.array([[0.005, 0.995], [0.995, 0.995]]), atol=0.001))
+        self.assertTrue(
+            np.allclose(y, np.array([[1.], [200.]]), atol=0.001))
+        
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix of #130.
However, my assumption that the problem would be the too small stdev was wrong. In fact, it was a problem of handling PAR10 scores. I fixed `RunHistory2EPM4LogCost` and `RunHistory2EPM4Cost` such that it uses the time field and not the cost field. latter includes the penalization if we optimize runtime which ruins the censored threshold.

@KEggensperger please carefully check this PR. 
