### PR TITLE
MAINT use basic EI instead of EI which favours exploitation

### DIFF
--- a/smac/smbo/acquisition.py
+++ b/smac/smbo/acquisition.py
@@ -118,15 +118,15 @@ class EI(AbstractAcquisitionFunction):
 
         Parameters
         ----------
-        model: Model object
+        model : Model object
             A model that implements at least
                  - predict(X)
                  - getCurrentBestX().
             If you want to calculate derivatives than it should also support
                  - predictive_gradients(X)
-        par: float
-            Controls the balance between exploration
-            and exploitation of the acquisition function. Default is 0.01
+        par : float, default=0.0
+            Controls the balance between exploration and exploitation of the
+            acquisition function.
         """
 
         super(EI, self).__init__(model)
@@ -208,15 +208,15 @@ class EIPS(EI):
 
         Parameters
         ----------
-        model: Model object
+        model : Model object
             A model that implements at least
                  - predict(X)
                  - getCurrentBestX().
             If you want to calculate derivatives than it should also support
                  - predictive_gradients(X)
-        par: float
-            Controls the balance between exploration
-            and exploitation of the acquisition function. Default is 0.01
+        par : float, default=0.0
+            Controls the balance between exploration and exploitation of the
+            acquisition function.
         """
 
         super(EIPS, self).__init__(model, par=par)

--- a/smac/smbo/acquisition.py
+++ b/smac/smbo/acquisition.py
@@ -106,7 +106,7 @@ class EI(AbstractAcquisitionFunction):
 
     def __init__(self,
                  model,
-                 par=0.01,
+                 par=0.0,
                  **kwargs):
         r"""
         Computes for a given x the expected improvement as
@@ -195,7 +195,7 @@ class EI(AbstractAcquisitionFunction):
 class EIPS(EI):
     def __init__(self,
                  model,
-                 par=0.01,
+                 par=0.0,
                  **kwargs):
         r"""
         Computes for a given x the expected improvement as
@@ -219,7 +219,7 @@ class EIPS(EI):
             and exploitation of the acquisition function. Default is 0.01
         """
 
-        super(EIPS, self).__init__(model)
+        super(EIPS, self).__init__(model, par=par)
         self.long_name = 'Expected Improvement per Second'
 
     def _compute(self, X, derivative=False, **kwargs):

--- a/test/test_smbo/test_acquisition.py
+++ b/test/test_smbo/test_acquisition.py
@@ -26,7 +26,7 @@ class TestEI(unittest.TestCase):
         X = np.array([[1.0, 1.0, 1.0]])
         acq = self.ei(X)
         self.assertEqual(acq.shape, (1, 1))
-        self.assertAlmostEqual(acq[0][0], 0.39396222734922848)
+        self.assertAlmostEqual(acq[0][0], 0.3989422804014327)
 
     def test_NxD(self):
         self.ei.update(model=self.model, eta=1.0)
@@ -36,15 +36,15 @@ class TestEI(unittest.TestCase):
         acq = self.ei(X)
         self.assertEqual(acq.shape, (3, 1))
         self.assertAlmostEqual(acq[0][0], 0.0)
-        self.assertAlmostEqual(acq[1][0], 0.89022927659832807)
-        self.assertAlmostEqual(acq[2][0], 0.39396222734922848)
+        self.assertAlmostEqual(acq[1][0], 0.90020601136712231)
+        self.assertAlmostEqual(acq[2][0], 0.3989422804014327)
 
     def test_1x1(self):
         self.ei.update(model=self.model, eta=1.0)
         X = np.array([[1.0]])
         acq = self.ei(X)
         self.assertEqual(acq.shape, (1, 1))
-        self.assertAlmostEqual(acq[0][0], 0.39396222734922848)
+        self.assertAlmostEqual(acq[0][0], 0.3989422804014327)
 
     def test_Nx1(self):
         self.ei.update(model=self.model, eta=1.0)
@@ -53,9 +53,9 @@ class TestEI(unittest.TestCase):
                       [2.0]])
         acq = self.ei(X)
         self.assertEqual(acq.shape, (3, 1))
-        self.assertAlmostEqual(acq[0][0], 0.9899)
-        self.assertAlmostEqual(acq[1][0], 0.39396222734922848)
-        self.assertAlmostEqual(acq[2][0], 0.19725469421480674)
+        self.assertAlmostEqual(acq[0][0], 0.9999)
+        self.assertAlmostEqual(acq[1][0], 0.3989422804014327)
+        self.assertAlmostEqual(acq[2][0], 0.19964122837424575)
 
     def test_zero_variance(self):
         self.ei.update(model=self.model, eta=1.0)


### PR DESCRIPTION
Closes issue #87.