### PR TITLE
Fix issues #125 and #131

### DIFF
--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -176,7 +176,9 @@ class SMBO(BaseSolver):
             List of 2020 suggested configurations to evaluate.
         """
         if X.shape[0] == 0:
-            return [x[1] for x in self._get_next_by_random_search()]
+            # Only return a single point to avoid an overly high number of
+            # random search iterations
+            return [x[1] for x in self._get_next_by_random_search(num_points=1)]
 
         self.model.train(X, Y)
 

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -246,7 +246,10 @@ class SMBO(BaseSolver):
         list : (acquisition value, Candidate solutions)
         """
 
-        rand_configs = self.config_space.sample_configuration(size=num_points)
+        if num_points > 1:
+            rand_configs = self.config_space.sample_configuration(size=num_points)
+        else:
+            rand_configs = [self.config_space.sample_configuration()]
         if _sorted:
             imputed_rand_configs = map(ConfigSpace.util.impute_inactive_values,
                                        rand_configs)

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -249,7 +249,7 @@ class SMBO(BaseSolver):
         if num_points > 1:
             rand_configs = self.config_space.sample_configuration(size=num_points)
         else:
-            rand_configs = [self.config_space.sample_configuration()]
+            rand_configs = [self.config_space.sample_configuration(size=1)]
         if _sorted:
             imputed_rand_configs = map(ConfigSpace.util.impute_inactive_values,
                                        rand_configs)

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -175,6 +175,9 @@ class SMBO(BaseSolver):
         list
             List of 2020 suggested configurations to evaluate.
         """
+        if X.shape[0] == 0:
+            return [x[1] for x in self._get_next_by_random_search()]
+
         self.model.train(X, Y)
 
         if self.runhistory.empty():

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -149,8 +149,6 @@ class TestSMBO(unittest.TestCase):
 
     def test_choose_next_empty_X(self):
         smbo = SMAC(self.scenario, rng=1).solver
-        smbo.incumbent = self.scenario.cs.sample_configuration()
-        smbo.runhistory = RunHistory(aggregate_func=average_cost)
         smbo.acquisition_func._compute = mock.Mock(spec=RandomForestWithInstances)
         smbo._get_next_by_random_search = mock.Mock(spec=smbo._get_next_by_random_search)
         smbo._get_next_by_random_search.return_value = [[0, 0], [0, 1], [0, 2]]
@@ -162,6 +160,16 @@ class TestSMBO(unittest.TestCase):
         self.assertEqual(x, [0, 1, 2])
         self.assertEqual(smbo._get_next_by_random_search.call_count, 1)
         self.assertEqual(smbo.acquisition_func._compute.call_count, 0)
+
+    def test_choose_next_empty_X_2(self):
+        smbo = SMAC(self.scenario, rng=1).solver
+
+        X = np.zeros((0, 2))
+        Y = np.zeros((0, 1))
+
+        x = smbo.choose_next(X, Y)
+        self.assertEqual(len(x), 1)
+        self.assertIsInstance(x[0], Configuration)
 
     @mock.patch('ConfigSpace.util.impute_inactive_values')
     @mock.patch.object(EI, '__call__')


### PR DESCRIPTION
SMAC does not longer crash if the first run was a memout or a timout. More general, if an empty array X is passed to choose_next, a random set of configurations is returned.

Fixes issues #125 and #131.