### PR TITLE
Add/#149

### DIFF
--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -309,4 +309,18 @@ class SMAC(object):
         finally:
             self.solver.stats.print_stats()
             self.logger.info("Final Incumbent: %s" % (self.solver.incumbent))
+            self.runhistory = self.solver.runhistory
+            self.trajectory = self.solver.intensifier.traj_logger.trajectory
         return incumbent
+
+    def get_runhistory(self):
+        if not hasattr(self, 'runhistory'):
+            raise ValueError('SMAC was not fitted yet. Call optimize() prior '
+                             'to accessing the runhistory.')
+        return self.runhistory
+
+    def get_trajectory(self):
+        if not hasattr(self, 'trajectory'):
+            raise ValueError('SMAC was not fitted yet. Call optimize() prior '
+                             'to accessing the runhistory.')
+        return self.trajectory

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -60,6 +60,8 @@ class TrajLogger(object):
     
             self.aclib_traj_fn = os.path.join(output_dir, "traj_aclib2.json")
 
+        self.trajectory = []
+
     def add_entry(self, train_perf, incumbent_id, incumbent):
         """
             adds entries to trajectory files (several formats) with using the
@@ -74,11 +76,11 @@ class TrajLogger(object):
             incumbent: Configuration()
                 current incumbent configuration
         """
-
+        ta_time_used = self.stats.ta_time_used
+        wallclock_time = self.stats.get_used_wallclock_time()
+        self.trajectory.append([train_perf, incumbent_id, incumbent,
+                                ta_time_used, wallclock_time])
         if self.output_dir is not None:
-            ta_time_used = self.stats.ta_time_used
-            wallclock_time = self.stats.get_used_wallclock_time()
-    
             self._add_in_old_format(train_perf, incumbent_id, incumbent,
                                     ta_time_used, wallclock_time)
             self._add_in_aclib_format(train_perf, incumbent_id, incumbent,

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -89,3 +89,14 @@ class TestSMACFacade(unittest.TestCase):
                   rng=np.random.RandomState(1))
         S2 = S2.solver.scenario.cs.random
         self.assertEqual(sum(S1.get_state()[1] - S2.get_state()[1]), 0)
+
+    def test_get_runhistory_and_trajectory(self):
+        ta = ExecuteTAFuncDict(lambda x: x ** 2)
+        smac = SMAC(tae_runner=ta, scenario=self.scenario)
+        self.assertRaises(ValueError, smac.get_runhistory)
+        self.assertRaises(ValueError, smac.get_trajectory)
+        smac.trajectory = 'dummy'
+        self.assertEqual(smac.get_trajectory(), 'dummy')
+        smac.runhistory = 'dummy'
+        self.assertEqual(smac.get_runhistory(), 'dummy')
+

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -77,6 +77,12 @@ class TrajLoggerTest(unittest.TestCase):
         self.assertEquals(len(json_dict['incumbent']), 3)
         self.assertTrue("param_a='0.5'" in json_dict['incumbent'])
 
+        # And finally, test the list that's added to the trajectory class
+        self.assertEqual(tl.trajectory[0], [0.9, 1,
+                                            {'param_c': 'value', 'param_b': 1,
+                                             'param_a': 0.5}, 0.5, 1])
+        self.assertEqual(len(tl.trajectory), 1)
+
     @patch('smac.stats.stats.Stats')
     def test_add_multiple_entries(self, mock_stats):
         tl = TrajLogger(output_dir='./tmp_test_folder', stats=mock_stats)


### PR DESCRIPTION
Stores the trajectory in the trajectory logger as a list. Saves the list in the SMAC object after optimization is finished. Adds a getter to retrieve the trajectory once optimization is finished. For consistency it also adds a getter for the runhistory.

Adds feature requested in #149.