### PR TITLE
CHANGE StatusType to Enum

### DIFF
--- a/smac/tae/execute_ta_run.py
+++ b/smac/tae/execute_ta_run.py
@@ -1,6 +1,7 @@
 import sys
 import logging
 import math
+from enum import Enum
 
 import numpy as np
 
@@ -12,7 +13,7 @@ __email__ = "lindauer@cs.uni-freiburg.de"
 __version__ = "0.0.1"
 
 
-class StatusType(object):
+class StatusType(Enum):
 
     """
         class to define numbers for status types
@@ -22,6 +23,17 @@ class StatusType(object):
     CRASHED = 3
     ABORT = 4
     MEMOUT = 5
+
+    def enum_hook(obj):
+        """
+        hook function passed to json-deserializer as "object_hook"
+        """
+        if "__enum__" in obj:
+            # object is marked as enum
+            name, member = obj["__enum__"].split(".")
+            return getattr(globals()[name], member)
+        else:
+            return obj
 
 
 class ExecuteTARun(object):
@@ -48,18 +60,18 @@ class ExecuteTARun(object):
             runhistory: RunHistory
                 runhistory to keep track of all runs; only used if set
             stats: Stats()
-                 stats object to collect statistics about runtime and so on                
+                 stats object to collect statistics about runtime and so on
             run_obj: str
                 run objective of SMAC
             par_factor: int
                 penalization factor
         """
-        
+
         self.ta = ta
         self.stats = stats
         self.runhistory = runhistory
         self.run_obj = run_obj
-        
+
         self.par_factor = par_factor
 
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -111,11 +123,11 @@ class ExecuteTARun(object):
                                                           cutoff=cutoff,
                                                           seed=seed,
                                                           instance_specific=instance_specific)
-        
+
         if self.stats.ta_runs == 0 and status in [StatusType.CRASHED, StatusType.ABORT]:
             self.logger.critical("First run crashed -- Abort")
             sys.exit(1)
-        
+
         # update SMAC stats
         self.stats.ta_runs += 1
         self.stats.ta_time_used += float(runtime)
@@ -127,14 +139,14 @@ class ExecuteTARun(object):
                 cost = runtime
 
         self.logger.debug("Return: Status: %d, cost: %f, time. %f, additional: %s" % (
-            status, cost, runtime, str(additional_info)))
+            status.value, cost, runtime, str(additional_info)))
 
         if self.runhistory:
             self.runhistory.add(config=config,
                                 cost=cost, time=runtime, status=status,
                                 instance_id=instance, seed=seed,
                                 additional_info=additional_info)
-            
+
         return status, cost, runtime, additional_info
 
     def run(self, config, instance,

--- a/smac/tae/execute_ta_run.py
+++ b/smac/tae/execute_ta_run.py
@@ -31,9 +31,9 @@ class StatusType(Enum):
         if "__enum__" in obj:
             # object is marked as enum
             name, member = obj["__enum__"].split(".")
-            return getattr(globals()[name], member)
-        else:
-            return obj
+            if name == "StatusType":
+                return getattr(globals()[name], member)
+        return obj
 
 
 class ExecuteTARun(object):

--- a/test/test_smbo/test_pSMAC.py
+++ b/test/test_smbo/test_pSMAC.py
@@ -27,12 +27,18 @@ class TestPSMAC(unittest.TestCase):
 
     def test_write(self):
         # The nulls make sure that we correctly emit the python None value
-        fixture = '{"data": [[[1, "branin", 1], [1, 1, 1, null]], ' \
-                  '[[1, "branini", 1], [1, 1, 1, null]], ' \
-                  '[[2, "branini", 1], [1, 1, 1, null]], ' \
-                  '[[2, null, 1], [1, 1, 1, null]], ' \
-                  '[[3, "branin-hoo", 1], [1, 1, 1, null]], ' \
-                  '[[4, null, 1], [1, 1, 1, null]]], ' \
+        fixture = '{"data": [[[1, "branin", 1], [1, 1, {"__enum__": ' \
+                  '"StatusType.SUCCESS"}, null]], ' \
+                  '[[1, "branini", 1], [1, 1, {"__enum__": ' \
+                  '"StatusType.SUCCESS"}, null]], ' \
+                  '[[2, "branini", 1], [1, 1, {"__enum__": ' \
+                  '"StatusType.SUCCESS"}, null]], ' \
+                  '[[2, null, 1], [1, 1, {"__enum__": ' \
+                  '"StatusType.SUCCESS"}, null]], ' \
+                  '[[3, "branin-hoo", 1], [1, 1, {"__enum__": ' \
+                  '"StatusType.SUCCESS"}, null]], ' \
+                  '[[4, null, 1], [1, 1, {"__enum__": ' \
+                  '"StatusType.SUCCESS"}, null]]],' \
                   '"configs": {' \
                   '"4": {"x": -2.2060968293349363, "y": 5.183410905645716}, ' \
                   '"3": {"x": -2.7986616377433045, "y": 1.385078921531967}, ' \
@@ -68,9 +74,9 @@ class TestPSMAC(unittest.TestCase):
         output_filename = os.path.join(self.tmp_dir, '.runhistory_20.json')
         self.assertTrue(os.path.exists(output_filename))
 
-        fixture = json.loads(fixture)
+        fixture = json.loads(fixture, object_hook=StatusType.enum_hook)
         with open(output_filename) as fh:
-            output = json.load(fh)
+            output = json.load(fh, object_hook=StatusType.enum_hook)
 
         print(output)
         print(fixture)
@@ -79,17 +85,23 @@ class TestPSMAC(unittest.TestCase):
     def test_load(self):
         configuration_space = test_helpers.get_branin_config_space()
 
-        other_runhistory = '{"data": [[[2, "branini", 1], [1, 1, 1, null]], ' \
-        '[[1, "branin", 1], [1, 1, 1, null]], ' \
-        '[[3, "branin-hoo", 1], [1, 1, 1, null]], ' \
-        '[[2, null, 1], [1, 1, 1, null]], ' \
-        '[[1, "branini", 1], [1, 1, 1, null]], ' \
-        '[[4, null, 1], [1, 1, 1, null]]], ' \
-        '"configs": {' \
-        '"4": {"x": -2.2060968293349363, "y": 5.183410905645716}, ' \
-        '"3": {"x": -2.7986616377433045, "y": 1.385078921531967}, ' \
-        '"1": {"x": 1.2553300705386103, "y": 10.804867401632372}, ' \
-        '"2": {"x": -4.998284377739827, "y": 4.534988589477597}}}'
+        other_runhistory = '{"data": [[[2, "branini", 1], [1, 1,' \
+                  '{"__enum__": "StatusType.SUCCESS"}, null]], ' \
+                  '[[1, "branin", 1], [1, 1,' \
+                  '{"__enum__": "StatusType.SUCCESS"}, null]], ' \
+                  '[[3, "branin-hoo", 1], [1, 1,' \
+                  '{"__enum__": "StatusType.SUCCESS"}, null]], ' \
+                  '[[2, null, 1], [1, 1,' \
+                  '{"__enum__": "StatusType.SUCCESS"}, null]], ' \
+                  '[[1, "branini", 1], [1, 1,' \
+                  '{"__enum__": "StatusType.SUCCESS"}, null]], ' \
+                  '[[4, null, 1], [1, 1,' \
+                  '{"__enum__": "StatusType.SUCCESS"}, null]]], ' \
+                  '"configs": {' \
+                  '"4": {"x": -2.2060968293349363, "y": 5.183410905645716}, ' \
+                  '"3": {"x": -2.7986616377433045, "y": 1.385078921531967}, ' \
+                  '"1": {"x": 1.2553300705386103, "y": 10.804867401632372}, ' \
+                  '"2": {"x": -4.998284377739827, "y": 4.534988589477597}}}'
 
         other_runhistory_filename = os.path.join(self.tmp_dir,
                                                  '.runhistory_20.json')


### PR DESCRIPTION
Implementing issue #81, adding human-readable mapping of StatusTypes. The originally wished for

    \>\>\> print(mapping[status])

is realized through [Enum](https://docs.python.org/3/library/enum.html#enum.Enum) as

    \>\>\> print(status.name)
 
JSON-serialization of runhistories is affected: status is now saved by customized JSON-Encoder.
This might affect the possibility of reading in the JSON-file from another language/without the object_hook.