### PR TITLE
Issue/#165 - setting par to 1 by default if no factor is given

### DIFF
--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -262,7 +262,7 @@ class Scenario(object):
         if self.overall_obj[:3] in ["PAR", "par"]:
             self.par_factor = int(self.overall_obj[3:])
         elif self.overall_obj[:4] in ["mean", "MEAN"]:
-            self.par_factor = int(self.overall_obj[4:])
+            self.par_factor = 1
         else:
             self.par_factor = 1
 
@@ -311,7 +311,7 @@ class Scenario(object):
                 self.feature_array.append(self.feature_dict[inst_])
             self.feature_array = numpy.array(self.feature_array)
             self.n_features = self.feature_array.shape[1]
-            
+
             # reduce dimensionality of features of larger than PCA_DIM
             if self.feature_array.shape[1] > self.PCA_DIM:
                 X = self.feature_array

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -260,10 +260,14 @@ class Scenario(object):
         self.feature_array = None
 
         if self.overall_obj[:3] in ["PAR", "par"]:
-            self.par_factor = int(self.overall_obj[3:])
+            par_str = self.overall_obj[3:]
         elif self.overall_obj[:4] in ["mean", "MEAN"]:
-            self.par_factor = 1
+            par_str = self.overall_obj[4:]
+        # Check for par-value as in "par10"/ "mean5"
+        if len(par_str) > 0:
+            self.par_factor = int(par_str)
         else:
+            self.logger.debug("No par-factor detected. Using 1 by default.")
             self.par_factor = 1
 
         # read instance files

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -209,6 +209,15 @@ class ScenarioTest(unittest.TestCase):
                                "Argument initial_incumbent can only take a "
                                "value in ['DEFAULT, 'RANDOM'] but is Default")
 
+    def test_par_factor(self):
+        scenario_dict = self.test_scenario_dict
+        scenario_dict['overall_obj'] = 'mean'
+        scenario = Scenario(scenario_dict)
+        self.assertEqual(scenario.par_factor, 1)
+        scenario_dict['overall_obj'] = 'par'
+        scenario = Scenario(scenario_dict)
+        self.assertEqual(scenario.par_factor, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -210,6 +210,7 @@ class ScenarioTest(unittest.TestCase):
                                "value in ['DEFAULT, 'RANDOM'] but is Default")
 
     def test_par_factor(self):
+        # Test setting the default value of 1 if no factor is given
         scenario_dict = self.test_scenario_dict
         scenario_dict['overall_obj'] = 'mean'
         scenario = Scenario(scenario_dict)


### PR DESCRIPTION
Setting par-factor to 1 by default if no factor is given. I.e. for `overall_obj` "mean" equals "mean1" equals "par" equals "par1".