### PR TITLE
FIX issue #167

### DIFF
--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -99,17 +99,21 @@ class RunHistory(object):
 
         k = RunKey(config_id, instance_id, seed)
         v = RunValue(cost, time, status, additional_info)
-        self.data[k] = v
 
-        if not external_data:
-            # also add to fast data structure
-            is_k = InstSeedKey(instance_id, seed)
-            self._configid_to_inst_seed[
-                config_id] = self._configid_to_inst_seed.get(config_id, [])
-            self._configid_to_inst_seed[config_id].append(is_k)
+        # Each runkey is supposed to be used only once. Repeated tries to add
+        # the same runkey will be ignored silently.
+        if self.data.get(k) is None:
+            self.data[k] = v
 
-        # assumes an average across runs as cost function
-        self.incremental_update_cost(config, cost)
+            if not external_data:
+                # also add to fast data structure
+                is_k = InstSeedKey(instance_id, seed)
+                self._configid_to_inst_seed[
+                    config_id] = self._configid_to_inst_seed.get(config_id, [])
+                self._configid_to_inst_seed[config_id].append(is_k)
+
+            # assumes an average across runs as cost function
+            self.incremental_update_cost(config, cost)
 
     def update_cost(self, config):
         '''
@@ -191,11 +195,7 @@ class RunHistory(object):
             list: tuples of instance, seed
         """
         config_id = self.config_ids.get(config)
-        is_list = self._configid_to_inst_seed.get(config_id)
-        if is_list is None:
-            return []
-        else:
-            return is_list
+        return self._configid_to_inst_seed.get(config_id, [])
 
     def get_all_configs(self):
         """ Return all configurations in this RunHistory object

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -392,5 +392,3 @@ class TestIntensify(unittest.TestCase):
         # scenario cutoff
         self.assertEqual(cutoff, 5)
         
-        
-        

--- a/test/test_runhistory/test_runhistory.py
+++ b/test/test_runhistory/test_runhistory.py
@@ -29,8 +29,7 @@ class RunhistoryTest(unittest.TestCase):
         '''
         rh = RunHistory(aggregate_func=average_cost)
         cs = get_config_space()
-        config = Configuration(cs,
-                               values={'a': 1, 'b': 2})
+        config = Configuration(cs, values={'a': 1, 'b': 2})
 
         self.assertTrue(rh.empty())
 
@@ -54,6 +53,21 @@ class RunhistoryTest(unittest.TestCase):
         with open(name, 'rb') as fh:
             loaded_rh = pickle.load(fh)
         self.assertEqual(loaded_rh.data, rh.data)
+
+    def test_add_multiple_times(self):
+        rh = RunHistory(aggregate_func=average_cost)
+        cs = get_config_space()
+        config = Configuration(cs, values={'a': 1, 'b': 2})
+
+        for i in range(5):
+            rh.add(config=config, cost=i + 1, time=i + 1,
+                   status=StatusType.SUCCESS, instance_id=None,
+                   seed=12345, additional_info=None)
+
+        self.assertEqual(len(rh.data), 1)
+        self.assertEqual(len(rh.get_runs_for_config(config)), 1)
+        self.assertEqual(len(rh._configid_to_inst_seed[1]), 1)
+        self.assertEqual(list(rh.data.values())[0].cost, 1)
 
     def test_get_config_runs(self):
         '''

--- a/test/test_smbo/test_pSMAC.py
+++ b/test/test_smbo/test_pSMAC.py
@@ -115,8 +115,8 @@ class TestPSMAC(unittest.TestCase):
                          [1, 2, 3, 4])
         self.assertEqual(len(runhistory.data), 6)
 
-        # load from non-empty runhistory, but existing run will be overridden
-        #  because it alread existed
+        # load from non-empty runhistory, in case of a duplicate the existing
+        # result will be kept and the new one silently discarded
         runhistory = RunHistory(aggregate_func=average_cost)
         configuration_space.seed(1)
         config = configuration_space.sample_configuration()
@@ -127,10 +127,10 @@ class TestPSMAC(unittest.TestCase):
                                     configuration_space)
         id_after = id(runhistory.data[RunKey(1, 'branin', 1)])
         self.assertEqual(len(runhistory.data), 6)
-        self.assertNotEqual(id_before, id_after)
+        self.assertEqual(id_before, id_after)
 
-        # load from non-empty runhistory, but existing run will not be
-        # overridden, but config_id will be re-used
+        # load from non-empty runhistory, in case of a duplicate the existing
+        # result will be kept and the new one silently discarded
         runhistory = RunHistory(aggregate_func=average_cost)
         configuration_space.seed(1)
         config = configuration_space.sample_configuration()


### PR DESCRIPTION
Fixes issue #167 by not changing the runhistory if a run with equal config, instance and seed would be added again.