### PR TITLE
Speed up conditional hyperparameter imputation

### DIFF
--- a/smac/smbo/local_search.py
+++ b/smac/smbo/local_search.py
@@ -71,9 +71,9 @@ class LocalSearch(object):
         """
         incumbent = start_point
         # Compute the acquisition value of the incumbent
-        incumbent_ = incumbent.get_array()
-        incumbent_[~np.isfinite(incumbent_)] = -1
-        acq_val_incumbent = self.acquisition_function(incumbent_, *args)
+        incumbent_array = incumbent.get_array()
+        incumbent_array[~np.isfinite(incumbent_array)] = -1
+        acq_val_incumbent = self.acquisition_function(incumbent_array, *args)
 
         local_search_steps = 0
         neighbors_looked_at = 0
@@ -95,10 +95,10 @@ class LocalSearch(object):
 
             for neighbor in all_neighbors:
                 s_time = time.time()
-                neighbor_ = neighbor.get_array()
-                neighbor_[~np.isfinite(neighbor_)] = -1
+                neighbor_array_ = neighbor.get_array()
+                neighbor_array_[~np.isfinite(neighbor_array_)] = -1
 
-                acq_val = self.acquisition_function(neighbor_, *args)
+                acq_val = self.acquisition_function(neighbor_array_, *args)
 
                 neighbors_looked_at += 1
 

--- a/smac/smbo/local_search.py
+++ b/smac/smbo/local_search.py
@@ -3,7 +3,7 @@ import time
 import random
 import numpy as np
 
-from smac.configspace import impute_inactive_values, get_one_exchange_neighbourhood, Configuration
+from smac.configspace import get_one_exchange_neighbourhood
 
 __author__ = "Aaron Klein, Marius Lindauer"
 __copyright__ = "Copyright 2015, ML4AAD"
@@ -71,10 +71,9 @@ class LocalSearch(object):
         """
         incumbent = start_point
         # Compute the acquisition value of the incumbent
-        incumbent_ = impute_inactive_values(incumbent)
-        acq_val_incumbent = self.acquisition_function(
-                                            incumbent_.get_array(),
-                                            *args)
+        incumbent_ = incumbent.get_array()
+        incumbent_[~np.isfinite(incumbent_)] = -1
+        acq_val_incumbent = self.acquisition_function(incumbent_, *args)
 
         local_search_steps = 0
         neighbors_looked_at = 0
@@ -96,10 +95,10 @@ class LocalSearch(object):
 
             for neighbor in all_neighbors:
                 s_time = time.time()
-                neighbor_ = impute_inactive_values(neighbor)
-                n_array = neighbor_.get_array()
+                neighbor_ = neighbor.get_array()
+                neighbor_[~np.isfinite(neighbor_)] = -1
 
-                acq_val = self.acquisition_function(n_array, *args)
+                acq_val = self.acquisition_function(neighbor_, *args)
 
                 neighbors_looked_at += 1
 

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -1,14 +1,11 @@
 import itertools
 import logging
 import numpy as np
-import os
 import random
-import sys
 import time
 import typing
 import math
 
-import ConfigSpace.util
 
 from smac.smbo.acquisition import AbstractAcquisitionFunction
 from smac.smbo.base_solver import BaseSolver
@@ -23,7 +20,6 @@ from smac.initial_design.initial_design import InitialDesign
 from smac.scenario.scenario import Scenario
 from smac.configspace import Configuration
 
-from smac.epm.rfr_imputator import RFRImputator
 
 __author__ = "Aaron Klein, Marius Lindauer, Matthias Feurer"
 __copyright__ = "Copyright 2015, ML4AAD"
@@ -307,13 +303,10 @@ class SMBO(BaseSolver):
 
         """
 
-        imputed_configs = map(ConfigSpace.util.impute_inactive_values,
-                              configs)
-        imputed_configs = [x.get_array()
-                           for x in imputed_configs]
-        imputed_configs = np.array(imputed_configs,
-                                   dtype=np.float64)
-        acq_values = self.acquisition_func(imputed_configs)
+        config_array = np.array([x.get_array() for x in configs], dtype=np.float64)
+        # This imputes inactive values!
+        config_array[~np.isfinite(config_array)] = -1
+        acq_values = self.acquisition_func(config_array)
 
         # From here
         # http://stackoverflow.com/questions/20197990/how-to-make-argsort-result-to-be-random-between-equal-values
@@ -323,5 +316,4 @@ class SMBO(BaseSolver):
 
         # Cannot use zip here because the indices array cannot index the
         # rand_configs list, because the second is a pure python list
-        return [(acq_values[ind][0], configs[ind])
-                for ind in indices[::-1]]
+        return [(acq_values[ind][0], configs[ind]) for ind in indices[::-1]]

--- a/test/test_runhistory/test_rfr_imputor.py
+++ b/test/test_runhistory/test_rfr_imputor.py
@@ -132,7 +132,7 @@ class ImputorTest(unittest.TestCase):
                                                  cutoff=cutoff,
                                                  threshold=cutoff*10,
                                                  change_threshold=0.01,
-                                                 max_iter=10,
+                                                 max_iter=5,
                                                  model=self.model)
             
             imp_y = imputor.impute(censored_X=cen_X, censored_y=cen_y,


### PR DESCRIPTION
Instead of using a method for this, convert the configuration
into an array and replace missing values with -1.