### PR TITLE
MAINT make trajectory entries named tuple (issue/#153)

### DIFF
--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -63,7 +63,7 @@ class TrajLogger(object):
             if not os.path.isfile(self.old_traj_fn):
                 with open(self.old_traj_fn, "w") as fp:
                     fp.write(
-                        '"CPU Time Used","Estimated Training Performance","Wallclock Time","Incumbent ID","Automatic Configurator (CPU) Time","Configuration..."\n')
+                        '"CPU Time Used","Estimated Training Performance","Wallclock Time","Incumbent ID","Automatic Configurator (CPU) Time","Algorithm Runs","Configuration..."\n')
 
             self.aclib_traj_fn = os.path.join(output_dir, "traj_aclib2.json")
 
@@ -90,12 +90,12 @@ class TrajLogger(object):
                                 ta_runs, ta_time_used, wallclock_time))
         if self.output_dir is not None:
             self._add_in_old_format(train_perf, incumbent_id, incumbent,
-                                    ta_time_used, wallclock_time)
+                                    ta_runs, ta_time_used, wallclock_time)
             self._add_in_aclib_format(train_perf, incumbent_id, incumbent,
-                                      ta_time_used, wallclock_time)
+                                      ta_runs, ta_time_used, wallclock_time)
 
     def _add_in_old_format(self, train_perf, incumbent_id, incumbent,
-                           ta_time_used, wallclock_time):
+                           ta_runs, ta_time_used, wallclock_time):
         """
             adds entries to old SMAC2-like trajectory file
 
@@ -107,6 +107,8 @@ class TrajLogger(object):
                 id of incumbent
             incumbent: Configuration()
                 current incumbent configuration
+            ta_runs: int
+                Runs performed by the targed algorithm
             ta_time_used: float
                 CPU time used by the target algorithm
             wallclock_time: float
@@ -119,17 +121,18 @@ class TrajLogger(object):
                 conf.append("%s='%s'" % (p, repr(incumbent[p])))
 
         with open(self.old_traj_fn, "a") as fp:
-            fp.write("%f, %f, %f, %d, %f, %s\n" % (
+            fp.write("%f, %f, %f, %d, %f, %d, %s\n" % (
                 ta_time_used,
                 train_perf,
                 wallclock_time,
                 incumbent_id,
                 wallclock_time - ta_time_used,
+                ta_runs,
                 ", ".join(conf)
             ))
 
     def _add_in_aclib_format(self, train_perf, incumbent_id, incumbent,
-                             ta_time_used, wallclock_time):
+                             ta_runs, ta_time_used, wallclock_time):
         """
             adds entries to AClib2-like trajectory file
 
@@ -141,6 +144,8 @@ class TrajLogger(object):
                 id of incumbent
             incumbent: Configuration()
                 current incumbent configuration
+            ta_runs: int
+                Runs performed by the targed algorithm
             ta_time_used: float
                 CPU time used by the target algorithm
             wallclock_time: float
@@ -152,7 +157,8 @@ class TrajLogger(object):
             if not incumbent[p] is None:
                 conf.append("%s='%s'" % (p, repr(incumbent[p])))
 
-        traj_entry = {"cpu_time": ta_time_used,
+        traj_entry = {"algo_runs" : ta_runs,
+                      "cpu_time": ta_time_used,
                       "total_cpu_time": None,  # TODO: fix this
                       "wallclock_time": wallclock_time,
                       "evaluations": self.stats.ta_runs,
@@ -180,7 +186,8 @@ class TrajLogger(object):
             -------
             trajectory: list
                 each entry in the list is a dictionary of the form
-                {"cpu_time": float,
+                {"algo_runs" : int,
+                 "cpu_time": float,
                  "total_cpu_time": None, # TODO
                  "wallclock_time": float,
                  "evaluations": int

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -7,9 +7,15 @@ import sys
 import logging
 import json
 import typing
+import collections
 
 from ConfigSpace.configuration_space import ConfigurationSpace, Configuration
 from ConfigSpace.hyperparameters import FloatHyperparameter, IntegerHyperparameter
+
+
+TrajEntry = collections.namedtuple(
+    'TrajEntry', ['train_perf', 'incumbent_id', 'incumbent',
+                                'ta_time_used', 'wallclock_time'])
 
 
 class TrajLogger(object):
@@ -40,7 +46,8 @@ class TrajLogger(object):
 
         self.output_dir = output_dir
         if output_dir is None:
-            self.logger.info("No output directory for trajectory logging specified -- trajectory will not be logged.")
+            self.logger.info("No output directory for trajectory logging "
+                             "specified -- trajectory will not be logged.")
 
         else:
             if not os.path.isdir(output_dir):
@@ -78,8 +85,8 @@ class TrajLogger(object):
         """
         ta_time_used = self.stats.ta_time_used
         wallclock_time = self.stats.get_used_wallclock_time()
-        self.trajectory.append([train_perf, incumbent_id, incumbent,
-                                ta_time_used, wallclock_time])
+        self.trajectory.append(TrajEntry(train_perf, incumbent_id, incumbent,
+                                ta_time_used, wallclock_time))
         if self.output_dir is not None:
             self._add_in_old_format(train_perf, incumbent_id, incumbent,
                                     ta_time_used, wallclock_time)

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -15,7 +15,7 @@ from ConfigSpace.hyperparameters import FloatHyperparameter, IntegerHyperparamet
 
 TrajEntry = collections.namedtuple(
     'TrajEntry', ['train_perf', 'incumbent_id', 'incumbent',
-                                'ta_time_used', 'wallclock_time'])
+                  'ta_runs', 'ta_time_used', 'wallclock_time'])
 
 
 class TrajLogger(object):
@@ -57,14 +57,14 @@ class TrajLogger(object):
                     self.logger.error(
                         "Could not make output directory: %s" % (output_dir))
                     sys.exit(3)
-            
-    
+
+
             self.old_traj_fn = os.path.join(output_dir, "traj_old.csv")
             if not os.path.isfile(self.old_traj_fn):
                 with open(self.old_traj_fn, "w") as fp:
                     fp.write(
                         '"CPU Time Used","Estimated Training Performance","Wallclock Time","Incumbent ID","Automatic Configurator (CPU) Time","Configuration..."\n')
-    
+
             self.aclib_traj_fn = os.path.join(output_dir, "traj_aclib2.json")
 
         self.trajectory = []
@@ -83,10 +83,11 @@ class TrajLogger(object):
             incumbent: Configuration()
                 current incumbent configuration
         """
+        ta_runs = self.stats.ta_runs
         ta_time_used = self.stats.ta_time_used
         wallclock_time = self.stats.get_used_wallclock_time()
         self.trajectory.append(TrajEntry(train_perf, incumbent_id, incumbent,
-                                ta_time_used, wallclock_time))
+                                ta_runs, ta_time_used, wallclock_time))
         if self.output_dir is not None:
             self._add_in_old_format(train_perf, incumbent_id, incumbent,
                                     ta_time_used, wallclock_time)

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -63,7 +63,7 @@ class TrajLogger(object):
             if not os.path.isfile(self.old_traj_fn):
                 with open(self.old_traj_fn, "w") as fp:
                     fp.write(
-                        '"CPU Time Used","Estimated Training Performance","Wallclock Time","Incumbent ID","Automatic Configurator (CPU) Time","Algorithm Runs","Configuration..."\n')
+                        '"CPU Time Used","Estimated Training Performance","Wallclock Time","Incumbent ID","Automatic Configurator (CPU) Time","Configuration..."\n')
 
             self.aclib_traj_fn = os.path.join(output_dir, "traj_aclib2.json")
 
@@ -90,12 +90,12 @@ class TrajLogger(object):
                                 ta_runs, ta_time_used, wallclock_time))
         if self.output_dir is not None:
             self._add_in_old_format(train_perf, incumbent_id, incumbent,
-                                    ta_runs, ta_time_used, wallclock_time)
+                                    ta_time_used, wallclock_time)
             self._add_in_aclib_format(train_perf, incumbent_id, incumbent,
-                                      ta_runs, ta_time_used, wallclock_time)
+                                      ta_time_used, wallclock_time)
 
     def _add_in_old_format(self, train_perf, incumbent_id, incumbent,
-                           ta_runs, ta_time_used, wallclock_time):
+                           ta_time_used, wallclock_time):
         """
             adds entries to old SMAC2-like trajectory file
 
@@ -107,8 +107,6 @@ class TrajLogger(object):
                 id of incumbent
             incumbent: Configuration()
                 current incumbent configuration
-            ta_runs: int
-                Runs performed by the targed algorithm
             ta_time_used: float
                 CPU time used by the target algorithm
             wallclock_time: float
@@ -121,18 +119,17 @@ class TrajLogger(object):
                 conf.append("%s='%s'" % (p, repr(incumbent[p])))
 
         with open(self.old_traj_fn, "a") as fp:
-            fp.write("%f, %f, %f, %d, %f, %d, %s\n" % (
+            fp.write("%f, %f, %f, %d, %f, %s\n" % (
                 ta_time_used,
                 train_perf,
                 wallclock_time,
                 incumbent_id,
                 wallclock_time - ta_time_used,
-                ta_runs,
                 ", ".join(conf)
             ))
 
     def _add_in_aclib_format(self, train_perf, incumbent_id, incumbent,
-                             ta_runs, ta_time_used, wallclock_time):
+                             ta_time_used, wallclock_time):
         """
             adds entries to AClib2-like trajectory file
 
@@ -144,8 +141,6 @@ class TrajLogger(object):
                 id of incumbent
             incumbent: Configuration()
                 current incumbent configuration
-            ta_runs: int
-                Runs performed by the targed algorithm
             ta_time_used: float
                 CPU time used by the target algorithm
             wallclock_time: float
@@ -157,8 +152,7 @@ class TrajLogger(object):
             if not incumbent[p] is None:
                 conf.append("%s='%s'" % (p, repr(incumbent[p])))
 
-        traj_entry = {"algo_runs" : ta_runs,
-                      "cpu_time": ta_time_used,
+        traj_entry = {"cpu_time": ta_time_used,
                       "total_cpu_time": None,  # TODO: fix this
                       "wallclock_time": wallclock_time,
                       "evaluations": self.stats.ta_runs,
@@ -186,8 +180,7 @@ class TrajLogger(object):
             -------
             trajectory: list
                 each entry in the list is a dictionary of the form
-                {"algo_runs" : int,
-                 "cpu_time": float,
+                {"cpu_time": float,
                  "total_cpu_time": None, # TODO
                  "wallclock_time": float,
                  "evaluations": int

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -68,14 +68,12 @@ class TrajLoggerTest(unittest.TestCase):
         frmt_str = '%1.6f'
         self.assertEquals(frmt_str % .5, data[0][0])
         self.assertEquals(frmt_str % .9, data[0][1])
-        self.assertEquals(frmt_str % 0.5, data[0][-5])
-        self.assertEquals('1', data[0][5])
+        self.assertEquals(frmt_str % 0.5, data[0][-4])
         
         with open('tmp_test_folder/traj_aclib2.json') as js:
             json_dict = json.load(js)
 
         self.assertEquals(json_dict['cpu_time'], .5)
-        self.assertEquals(json_dict['algo_runs'], 1)
         self.assertEquals(json_dict['cost'], 0.9)
         self.assertEquals(len(json_dict['incumbent']), 3)
         self.assertTrue("param_a='0.5'" in json_dict['incumbent'])
@@ -126,18 +124,15 @@ class TrajLoggerTest(unittest.TestCase):
         frmt_str = '%1.6f'
         self.assertEquals(frmt_str % 0.5, data[0][0])
         self.assertEquals(frmt_str % 0.9, data[0][1])
-        self.assertEquals(frmt_str % 0.5, data[0][-5])
-        self.assertEquals('1', data[0][5])
+        self.assertEquals(frmt_str % 0.5, data[0][-4])
 
         self.assertEquals(frmt_str % 0, data[1][0])
         self.assertEquals(frmt_str % 1.3, data[1][1])
-        self.assertEquals(frmt_str % 2, data[1][-5])
-        self.assertEquals('2', data[1][5])
+        self.assertEquals(frmt_str % 2, data[1][-4])
 
         self.assertEquals(frmt_str % 0, data[2][0])
         self.assertEquals(frmt_str % .7, data[2][1])
-        self.assertEquals(frmt_str % 3, data[2][-5])
-        self.assertEquals('2', data[2][5])
+        self.assertEquals(frmt_str % 3, data[2][-4])
 
         json_dicts = []
         with open('tmp_test_folder/traj_aclib2.json') as js:
@@ -147,7 +142,6 @@ class TrajLoggerTest(unittest.TestCase):
             json_dicts.append(json.loads(d))
 
         self.assertEquals(json_dicts[0]['cpu_time'], .5)
-        self.assertEquals(json_dicts[0]['algo_runs'], 1)
         self.assertEquals(json_dicts[0]['cost'], 0.9)
         self.assertEquals(len(json_dicts[0]['incumbent']), 3)
         self.assertTrue("param_a='0.5'" in json_dicts[0]['incumbent'])

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -14,6 +14,7 @@ try:
 except:
     from mock import patch
 from smac.utils.io.traj_logging import TrajLogger
+from smac.utils.io.traj_logging import TrajEntry
 
 from smac.configspace import ConfigurationSpace
 from smac.scenario.scenario import Scenario
@@ -78,9 +79,14 @@ class TrajLoggerTest(unittest.TestCase):
         self.assertTrue("param_a='0.5'" in json_dict['incumbent'])
 
         # And finally, test the list that's added to the trajectory class
-        self.assertEqual(tl.trajectory[0], [0.9, 1,
+        self.assertEqual(tl.trajectory[0], TrajEntry(0.9, 1,
                                             {'param_c': 'value', 'param_b': 1,
-                                             'param_a': 0.5}, 0.5, 1])
+                                             'param_a': 0.5}, 0.5, 1))
+        # Test named-tuple-access:
+        self.assertEqual(tl.trajectory[0].train_perf, 0.9)
+        self.assertEqual(tl.trajectory[0].incumbent_id, 1)
+        self.assertEqual(tl.trajectory[0].ta_time_used, 0.5)
+        self.assertEqual(tl.trajectory[0].wallclock_time, 1)
         self.assertEqual(len(tl.trajectory), 1)
 
     @patch('smac.stats.stats.Stats')

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -81,10 +81,11 @@ class TrajLoggerTest(unittest.TestCase):
         # And finally, test the list that's added to the trajectory class
         self.assertEqual(tl.trajectory[0], TrajEntry(0.9, 1,
                                             {'param_c': 'value', 'param_b': 1,
-                                             'param_a': 0.5}, 0.5, 1))
+                                             'param_a': 0.5}, 1, 0.5, 1))
         # Test named-tuple-access:
         self.assertEqual(tl.trajectory[0].train_perf, 0.9)
         self.assertEqual(tl.trajectory[0].incumbent_id, 1)
+        self.assertEqual(tl.trajectory[0].ta_runs, 1)
         self.assertEqual(tl.trajectory[0].ta_time_used, 0.5)
         self.assertEqual(tl.trajectory[0].wallclock_time, 1)
         self.assertEqual(len(tl.trajectory), 1)

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -68,12 +68,14 @@ class TrajLoggerTest(unittest.TestCase):
         frmt_str = '%1.6f'
         self.assertEquals(frmt_str % .5, data[0][0])
         self.assertEquals(frmt_str % .9, data[0][1])
-        self.assertEquals(frmt_str % 0.5, data[0][-4])
+        self.assertEquals(frmt_str % 0.5, data[0][-5])
+        self.assertEquals('1', data[0][5])
         
         with open('tmp_test_folder/traj_aclib2.json') as js:
             json_dict = json.load(js)
 
         self.assertEquals(json_dict['cpu_time'], .5)
+        self.assertEquals(json_dict['algo_runs'], 1)
         self.assertEquals(json_dict['cost'], 0.9)
         self.assertEquals(len(json_dict['incumbent']), 3)
         self.assertTrue("param_a='0.5'" in json_dict['incumbent'])
@@ -124,15 +126,18 @@ class TrajLoggerTest(unittest.TestCase):
         frmt_str = '%1.6f'
         self.assertEquals(frmt_str % 0.5, data[0][0])
         self.assertEquals(frmt_str % 0.9, data[0][1])
-        self.assertEquals(frmt_str % 0.5, data[0][-4])
+        self.assertEquals(frmt_str % 0.5, data[0][-5])
+        self.assertEquals('1', data[0][5])
 
         self.assertEquals(frmt_str % 0, data[1][0])
         self.assertEquals(frmt_str % 1.3, data[1][1])
-        self.assertEquals(frmt_str % 2, data[1][-4])
+        self.assertEquals(frmt_str % 2, data[1][-5])
+        self.assertEquals('2', data[1][5])
 
         self.assertEquals(frmt_str % 0, data[2][0])
         self.assertEquals(frmt_str % .7, data[2][1])
-        self.assertEquals(frmt_str % 3, data[2][-4])
+        self.assertEquals(frmt_str % 3, data[2][-5])
+        self.assertEquals('2', data[2][5])
 
         json_dicts = []
         with open('tmp_test_folder/traj_aclib2.json') as js:
@@ -142,6 +147,7 @@ class TrajLoggerTest(unittest.TestCase):
             json_dicts.append(json.loads(d))
 
         self.assertEquals(json_dicts[0]['cpu_time'], .5)
+        self.assertEquals(json_dicts[0]['algo_runs'], 1)
         self.assertEquals(json_dicts[0]['cost'], 0.9)
         self.assertEquals(len(json_dicts[0]['incumbent']), 3)
         self.assertTrue("param_a='0.5'" in json_dicts[0]['incumbent'])


### PR DESCRIPTION
Trajectory entries are named tuples, allowing access by name, e.g.: `tl.trajectory[n].train_perf'`