### PR TITLE
MAINT make uncorrelated_mo_rf_with_inst subclass of AbstractEPM (issue/94)

### DIFF
--- a/smac/epm/uncorrelated_mo_rf_with_instances.py
+++ b/smac/epm/uncorrelated_mo_rf_with_instances.py
@@ -1,9 +1,10 @@
 import numpy as np
 
+from smac.epm.base_epm import AbstractEPM
 from smac.epm.rf_with_instances import RandomForestWithInstances
 
 
-class UncorrelatedMultiObjectiveRandomForestWithInstances(object):
+class UncorrelatedMultiObjectiveRandomForestWithInstances(AbstractEPM):
     def __init__(self, target_names, types, **kwargs):
         """Wrapper for the random forest to predict multiple targets.
 


### PR DESCRIPTION
Fixing issue/#94, UncorrelatedMultiObjectiveRandomForestWithInstances was the only class not derived from AbstractEPM.