### PR TITLE
Fix/adaptive cap

### DIFF
--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -240,7 +240,7 @@ class SMAC(object):
                     scenario=scenario, num_params=num_params,
                     success_states=[StatusType.SUCCESS, ],
                     impute_censored_data=True,
-                    impute_state=[StatusType.TIMEOUT, ],
+                    impute_state=[StatusType.TIMEOUT, StatusType.CAPPED ],
                     imputor=imputor)
 
             elif scenario.run_obj == 'quality':

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -240,7 +240,7 @@ class SMAC(object):
                     scenario=scenario, num_params=num_params,
                     success_states=[StatusType.SUCCESS, ],
                     impute_censored_data=True,
-                    impute_state=[StatusType.TIMEOUT, StatusType.CAPPED ],
+                    impute_state=[StatusType.CAPPED, ],
                     imputor=imputor)
 
             elif scenario.run_obj == 'quality':

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -87,7 +87,9 @@ class RunHistory(object):
                 information from TA or fields such as start time and host_id)
             external_data: bool
                 if True, run will not be added to self._configid_to_inst_seed
-                and not available through get_runs_for_config()
+                and not available through get_runs_for_config();
+                essentially, intensification will not see this run,
+                but the EPM still gets it
         '''
 
         config_id = self.config_ids.get(config)
@@ -102,18 +104,18 @@ class RunHistory(object):
 
         # Each runkey is supposed to be used only once. Repeated tries to add
         # the same runkey will be ignored silently.
-        if self.data.get(k) is None:
+        if self.data.get(k) is None or self.data.get(k).status==StatusType.CAPPED:
             self.data[k] = v
 
-            if not external_data:
+            if not external_data and status!=StatusType.CAPPED:
                 # also add to fast data structure
                 is_k = InstSeedKey(instance_id, seed)
                 self._configid_to_inst_seed[
                     config_id] = self._configid_to_inst_seed.get(config_id, [])
                 self._configid_to_inst_seed[config_id].append(is_k)
 
-            # assumes an average across runs as cost function
-            self.incremental_update_cost(config, cost)
+                # assumes an average across runs as cost function
+                self.incremental_update_cost(config, cost)
 
     def update_cost(self, config):
         '''

--- a/smac/runhistory/runhistory2epm.py
+++ b/smac/runhistory/runhistory2epm.py
@@ -80,7 +80,7 @@ class AbstractRunHistory2EPM(object):
             self.rs = np.random.RandomState()
 
         if self.impute_state is None:
-            self.impute_state = [StatusType.TIMEOUT, StatusType.CAPPED]
+            self.impute_state = [StatusType.CAPPED, ]
 
         if self.success_states is None:
             self.success_states = [StatusType.SUCCESS, ]

--- a/smac/runhistory/runhistory2epm.py
+++ b/smac/runhistory/runhistory2epm.py
@@ -80,7 +80,7 @@ class AbstractRunHistory2EPM(object):
             self.rs = np.random.RandomState()
 
         if self.impute_state is None:
-            self.impute_state = [StatusType.TIMEOUT, ]
+            self.impute_state = [StatusType.TIMEOUT, StatusType.CAPPED]
 
         if self.success_states is None:
             self.success_states = [StatusType.SUCCESS, ]

--- a/smac/tae/execute_ta_run.py
+++ b/smac/tae/execute_ta_run.py
@@ -156,8 +156,8 @@ class ExecuteTARun(object):
             else:
                 cost = runtime
 
-        self.logger.debug("Return: Status: %d, cost: %f, time. %f, additional: %s" % (
-            status.value, cost, runtime, str(additional_info)))
+        self.logger.debug("Return: Status: %r, cost: %f, time: %f, additional: %s" % (
+            status, cost, runtime, str(additional_info)))
 
         if self.runhistory:
             self.runhistory.add(config=config,

--- a/smac/tae/execute_ta_run.py
+++ b/smac/tae/execute_ta_run.py
@@ -5,6 +5,8 @@ from enum import Enum
 
 import numpy as np
 
+from smac.configspace import Configuration
+
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2015, ML4AAD"
 __license__ = "3-clause BSD"
@@ -23,6 +25,7 @@ class StatusType(Enum):
     CRASHED = 3
     ABORT = 4
     MEMOUT = 5
+    CAPPED = 6
 
     def enum_hook(obj):
         """
@@ -49,6 +52,11 @@ class FirstRunCrashedException(TAEAbortException):
     """ Exception indicating that the first run crashed (depending on options
     this could trigger an ABORT of SMAC. """
     pass
+
+class CappedRunException(Exception):
+    """ Exception indicating that a run was capped with a cutoff smaller than the actual timeout """
+    pass
+
 
 class ExecuteTARun(object):
 
@@ -91,26 +99,31 @@ class ExecuteTARun(object):
         self.logger = logging.getLogger("smac.tae."+self.__class__.__name__)
         self._supports_memory_limit = False
 
-    def start(self, config, instance,
-              cutoff=None,
-              seed=12345,
-              instance_specific="0"):
+    def start(self, config:Configuration, 
+              instance:str,
+              cutoff:float=None,
+              seed:int=12345,
+              instance_specific:str="0",
+              capped:bool=False):
         """
             wrapper function for ExecuteTARun.run() to check configuration budget before the runs
             and to update stats after run
 
             Parameters
             ----------
-                config : dictionary
-                    dictionary param -> value
+                config : Configuration
+                    mainly a dictionary param -> value
                 instance : string
                     problem instance
-                cutoff : double
+                cutoff : float
                     runtime cutoff
                 seed : int
                     random seed
                 instance_specific: str
                     instance specific information (e.g., domain file or solution)
+                capped: bool
+                    if true and status is StatusType.TIMEOUT, 
+                    uses StatusType.CAPPED 
 
             Returns
             -------
@@ -155,6 +168,8 @@ class ExecuteTARun(object):
                 cost = cutoff * self.par_factor
             else:
                 cost = runtime
+            if status == StatusType.TIMEOUT and capped:
+                status = StatusType.CAPPED
 
         self.logger.debug("Return: Status: %r, cost: %f, time: %f, additional: %s" % (
             status, cost, runtime, str(additional_info)))
@@ -164,6 +179,9 @@ class ExecuteTARun(object):
                                 cost=cost, time=runtime, status=status,
                                 instance_id=instance, seed=seed,
                                 additional_info=additional_info)
+        
+        if status == StatusType.CAPPED:
+            raise CappedRunException("")
 
         return status, cost, runtime, additional_info
 

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -234,15 +234,7 @@ class TestIntensify(unittest.TestCase):
 
         # self.assertTrue(False)
         self.assertEqual(inc, self.config1)
-        self.assertLess(
-            self.rh.get_cost(self.config2), 2, self.rh.get_cost(self.config2))
 
-        # get data for config2 to check that the correct run was performed
-        run = self.rh.get_runs_for_config(self.config2)[0]
-        config_id = self.rh.config_ids[self.config2]
-        self.assertEqual(run.instance, 1, run.instance)
-        self.assertEqual(run.seed, 12345, run.seed)
-        
     def test_race_challenger_3(self):
         '''
            test _race_challenger with adaptive capping on a previously capped configuration  
@@ -250,18 +242,18 @@ class TestIntensify(unittest.TestCase):
 
         def target(config: Configuration, seed: int, instance: str):
             if instance == 1:
-                time.sleep(2000)
+                time.sleep(2.1)
             else:
                 time.sleep(0.6)
             return (config['a'] + 1) / 1000.
-        taf = ExecuteTAFuncDict(ta=target, stats=self.stats, run_obj="runtime", par_factor=10)
+        taf = ExecuteTAFuncDict(ta=target, stats=self.stats, run_obj="runtime", par_factor=1)
         taf.runhistory = self.rh
 
         intensifier = Intensifier(
             tae_runner=taf, stats=self.stats,
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=np.random.RandomState(12345),
-            cutoff=200,
+            cutoff=2,
             instances=[1])
 
         self.rh.add(config=self.config1, cost=0.5, time=.5,
@@ -279,7 +271,7 @@ class TestIntensify(unittest.TestCase):
         self.assertEqual(inc, self.config1)
         
         # further run for incumbent
-        self.rh.add(config=self.config1, cost=200, time=200,
+        self.rh.add(config=self.config1, cost=2, time=2,
                     status=StatusType.TIMEOUT, instance_id=2,
                     seed=12345,
                     additional_info=None)
@@ -292,8 +284,10 @@ class TestIntensify(unittest.TestCase):
         
         # the incumbent should still be config1 because
         # config2 should get on inst 1 a full timeout
-        # such that c(config1) = 100.25 and c(config2) = 100.3
-        self.assertEqual(inc, self.config1, msg)
+        # such that c(config1) = 1.25 and c(config2) close to 1.3
+        self.assertEqual(inc, self.config1)
+        # the capped run should not be counted in runs_perf_config
+        self.assertAlmostEqual(self.rh.runs_per_config[2], 2)
 
     def test_race_challenger_large(self):
         '''


### PR DESCRIPTION
FIX adaptive capping with re-occurring configurations

* ADD new StatusType.CAPPED
* ADD new exception (CappedRunException) to prevent infinite loop in intensification
* FIX CAPPED runs are added to runhistory in data but not in the remaining
fast data structures as used in intensification
* MAINT improve corresponding unit test