### PR TITLE
Issue/#187 check deps

### DIFF
--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -103,6 +103,9 @@ class SMAC(object):
         # initialize empty runhistory
         if runhistory is None:
             runhistory = RunHistory(aggregate_func=aggregate_func)
+        # inject aggr_func if necessary
+        if runhistory.aggregate_func is None:
+            runhistory.aggregate_func = aggregate_func
 
         # initial random number generator
         num_run, rng = self._get_rng(rng=rng)
@@ -124,6 +127,9 @@ class SMAC(object):
         # initial acquisition function
         if acquisition_function is None:
             acquisition_function = EI(model=model)
+        # inject model if necessary
+        if acquisition_function.model is None:
+            acquisition_function.model = model
 
         # initialize optimizer on acquisition function
         local_search = LocalSearch(acquisition_function,
@@ -170,7 +176,7 @@ class SMAC(object):
             tae_runner.runhistory = runhistory
 
 
-        # initial intensification
+        # initialize intensification
         if intensifier is None:
             intensifier = Intensifier(tae_runner=tae_runner,
                                       stats=self.stats,
@@ -183,6 +189,13 @@ class SMAC(object):
                                       instance_specifics=scenario.instance_specific,
                                       minR=scenario.minR,
                                       maxR=scenario.maxR)
+        # inject deps if necessary
+        if intensifier.tae_runner is None:
+            intensifier.tae_runner = tae_runner
+        if intensifier.stats is None:
+            intensifier.stats = self.stats
+        if intensifier.traj_logger is None:
+            intensifier.traj_logger = traj_logger
 
         # initial design
         if initial_design is not None and initial_configurations is not None:
@@ -215,6 +228,15 @@ class SMAC(object):
             else:
                 raise ValueError("Don't know what kind of initial_incumbent "
                                  "'%s' is" % scenario.initial_incumbent)
+        # inject deps if necessary
+        if initial_design.tae_runner is None:
+            initial_design.tae_runner = tae_runner
+        if initial_design.scenario is None:
+            initial_design.scenario = scenario
+        if initial_design.stats is None:
+            initial_design.stats = self.stats
+        if initial_design.traj_logger is None:
+            initial_design.traj_logger = traj_logger
 
         # initial conversion of runhistory into EPM data
         if runhistory2epm is None:
@@ -252,6 +274,10 @@ class SMAC(object):
             else:
                 raise ValueError('Unknown run objective: %s. Should be either '
                                  'quality or runtime.' % self.scenario.run_obj)
+
+        # inject scenario if necessary:
+        if runhistory2epm.scenario is None:
+            runhisory2epm.scenario = scenario
 
         self.solver = SMBO(scenario=scenario,
                            stats=self.stats,

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -277,7 +277,7 @@ class SMAC(object):
 
         # inject scenario if necessary:
         if runhistory2epm.scenario is None:
-            runhisory2epm.scenario = scenario
+            runhistory2epm.scenario = scenario
 
         self.solver = SMBO(scenario=scenario,
                            stats=self.stats,

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -4,12 +4,18 @@ import numpy as np
 
 from smac.configspace import ConfigurationSpace
 
-from smac.runhistory.runhistory import RunHistory
+from smac.epm.base_epm import AbstractEPM
 from smac.facade.smac_facade import SMAC
+from smac.initial_design.default_configuration_design import DefaultConfiguration
+from smac.intensification.intensification import Intensifier
+from smac.runhistory.runhistory import RunHistory
+from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost
 from smac.scenario.scenario import Scenario
+from smac.smbo.acquisition import EI, AbstractAcquisitionFunction
 from smac.stats.stats import Stats
 from smac.tae.execute_func import ExecuteTAFuncDict
-
+from smac.tae.execute_ta_run import ExecuteTARun
+from smac.utils.io.traj_logging import TrajLogger
 
 class TestSMACFacade(unittest.TestCase):
 
@@ -101,3 +107,53 @@ class TestSMACFacade(unittest.TestCase):
         self.assertEqual(smac.get_runhistory(), 'dummy')
         self.assertEqual(smac.get_tae_runner(), ta)
 
+    def test_inject_dependencies(self):
+        # initialize objects with missing dependencies
+        ta = ExecuteTAFuncDict(lambda x: x ** 2)
+        rh = RunHistory(aggregate_func=None)
+        acqu_func = EI(model=None)
+        intensifier = Intensifier(tae_runner=None,
+                                  stats=None,
+                                  traj_logger=None,
+                                  rng=np.random.RandomState(),
+                                  instances=None)
+        init_design = DefaultConfiguration(tae_runner=None,
+                                           scenario=None,
+                                           stats=None,
+                                           traj_logger=None,
+                                           rng=np.random.RandomState())
+        rh2epm = RunHistory2EPM4Cost(scenario=self.scenario, num_params=0)
+        rh2epm.scenario = None
+
+        # assert missing dependencies
+        self.assertIsNone(rh.aggregate_func)
+        self.assertIsNone(acqu_func.model)
+        self.assertIsNone(intensifier.tae_runner)
+        self.assertIsNone(intensifier.stats)
+        self.assertIsNone(intensifier.traj_logger)
+        self.assertIsNone(init_design.tae_runner)
+        self.assertIsNone(init_design.scenario)
+        self.assertIsNone(init_design.stats)
+        self.assertIsNone(init_design.traj_logger)
+        self.assertIsNone(rh2epm.scenario)
+
+        # initialize smac-object
+        SMAC(scenario=self.scenario,
+             tae_runner=ta,
+             runhistory=rh,
+             intensifier=intensifier,
+             acquisition_function=acqu_func,
+             runhistory2epm=rh2epm,
+             initial_design=init_design)
+
+        # assert that missing dependencies are injected
+        self.assertIsNotNone(rh.aggregate_func, AbstractAcquisitionFunction)
+        self.assertIsInstance(acqu_func.model, AbstractEPM)
+        self.assertIsInstance(intensifier.tae_runner, ExecuteTARun)
+        self.assertIsInstance(intensifier.stats, Stats)
+        self.assertIsInstance(intensifier.traj_logger, TrajLogger)
+        self.assertIsInstance(init_design.tae_runner, ExecuteTARun)
+        self.assertIsInstance(init_design.scenario, Scenario)
+        self.assertIsInstance(init_design.stats, Stats)
+        self.assertIsInstance(init_design.traj_logger, TrajLogger)
+        self.assertIsInstance(rh2epm.scenario, Scenario)


### PR DESCRIPTION
Inject dependencies if they don't exist in passed objects to SMAC:
`runhistory.aggregate_func`
`acquisition_function.model`
`intensifier.tae_runner`
`intensifier.stats`
`intensifier.traj_logger`
`initial_design.tae_runner`
`initial_design.scenario`
`initial_design.stats`
`initial_design.traj_logger`
`runhistory2epm.scenario`