### PR TITLE
ADD intensification_percentage option

### DIFF
--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -215,6 +215,8 @@ class Scenario(object):
         self.add_argument(name='execdir', default='.', help=None)
         self.add_argument(name='deterministic', default='0', help=None,
                           callback=_is_truthy)
+        self.add_argument(name='intensification_percentage', default=0.5,
+                          help=None, callback=float)
         self.add_argument(name='paramfile', help=None, dest='pcs_fn',
                           mutually_exclusive_group='cs')
         self.add_argument(name='run_obj', help=None, default='runtime')

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -123,8 +123,18 @@ class SMBO(BaseSolver):
             challengers = self.choose_next(X, Y)
 
             time_spend = time.time() - start_time
-            logging.debug(
-                "Time spend to choose next configurations: %.2f sec" % (time_spend))
+
+            # Calculate time left for intensify
+            frac_intensify = self.scenario.intensification_percentage
+            if (frac_intensify <= 0 or frac_intensify >= 1):
+                raise ValueError("The value for intensification_percentage-"
+                                 "option must lie in (0,1), instead: %.2f" % (frac_intensify))
+            total_time = time_spend / (1-frac_intensify)
+            time_left = frac_intensify * total_time
+            self.logger.debug("Total time: %.4f, time spend on choosing next "
+                              "configurations: %.4f (%.2f), time left for "
+                              "intensification: %.4f (%.2f)" % (total_time,
+                    time_spend, (1-frac_intensify), time_left, frac_intensify))
 
             self.logger.debug("Intensify")
 
@@ -133,7 +143,7 @@ class SMBO(BaseSolver):
                 incumbent=self.incumbent,
                 run_history=self.runhistory,
                 aggregate_func=self.aggregate_func,
-                time_bound=max(0.01, time_spend))
+                time_bound=max(0.01, time_left))
 
             if self.scenario.shared_model:
                 pSMAC.write(run_history=self.runhistory,

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -123,18 +123,7 @@ class SMBO(BaseSolver):
             challengers = self.choose_next(X, Y)
 
             time_spent = time.time() - start_time
-
-            # Calculate time left for intensify
-            frac_intensify = self.scenario.intensification_percentage
-            if (frac_intensify <= 0 or frac_intensify >= 1):
-                raise ValueError("The value for intensification_percentage-"
-                                 "option must lie in (0,1), instead: %.2f" % (frac_intensify))
-            total_time = time_spent / (1-frac_intensify)
-            time_left = frac_intensify * total_time
-            self.logger.debug("Total time: %.4f, time spent on choosing next "
-                              "configurations: %.4f (%.2f), time left for "
-                              "intensification: %.4f (%.2f)" % (total_time,
-                    time_spent, (1-frac_intensify), time_left, frac_intensify))
+            time_left = self._get_timebound_for_intensification(time_spent)
 
             self.logger.debug("Intensify")
 
@@ -331,3 +320,30 @@ class SMBO(BaseSolver):
         # Cannot use zip here because the indices array cannot index the
         # rand_configs list, because the second is a pure python list
         return [(acq_values[ind][0], configs[ind]) for ind in indices[::-1]]
+
+    def _get_timebound_for_intensification(self, time_spent):
+        """ Calculate time left for intensify from the time spent on
+        choosing challengers using the fraction of time intended for
+        intensification (which is specified in
+        scenario.intensification_percentage).
+
+        Parameters
+        ----------
+        time_spent : float
+
+        Returns
+        -------
+        time_left : float
+        """
+        frac_intensify = self.scenario.intensification_percentage
+        if (frac_intensify <= 0 or frac_intensify >= 1):
+            raise ValueError("The value for intensification_percentage-"
+                             "option must lie in (0,1), instead: %.2f" % (frac_intensify))
+        total_time = time_spent / (1-frac_intensify)
+        time_left = frac_intensify * total_time
+        self.logger.debug("Total time: %.4f, time spent on choosing next "
+                          "configurations: %.4f (%.2f), time left for "
+                          "intensification: %.4f (%.2f)" % (total_time,
+                time_spent, (1-frac_intensify), time_left, frac_intensify))
+        return time_left
+

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -122,19 +122,19 @@ class SMBO(BaseSolver):
             # get all found configurations sorted according to acq
             challengers = self.choose_next(X, Y)
 
-            time_spend = time.time() - start_time
+            time_spent = time.time() - start_time
 
             # Calculate time left for intensify
             frac_intensify = self.scenario.intensification_percentage
             if (frac_intensify <= 0 or frac_intensify >= 1):
                 raise ValueError("The value for intensification_percentage-"
                                  "option must lie in (0,1), instead: %.2f" % (frac_intensify))
-            total_time = time_spend / (1-frac_intensify)
+            total_time = time_spent / (1-frac_intensify)
             time_left = frac_intensify * total_time
-            self.logger.debug("Total time: %.4f, time spend on choosing next "
+            self.logger.debug("Total time: %.4f, time spent on choosing next "
                               "configurations: %.4f (%.2f), time left for "
                               "intensification: %.4f (%.2f)" % (total_time,
-                    time_spend, (1-frac_intensify), time_left, frac_intensify))
+                    time_spent, (1-frac_intensify), time_left, frac_intensify))
 
             self.logger.debug("Intensify")
 

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -299,9 +299,25 @@ class TestSMBO(unittest.TestCase):
         smbo = SMAC(scen, tae_runner=target, rng=1).solver
         self.assertRaises(FirstRunCrashedException, smbo.run)
 
+    def test_intensification_percentage_bad_value(self):
+        def target(x):
+            return 5
+        # Test for <= 0
+        scen = Scenario({'cs': test_helpers.get_branin_config_space(),
+                         'run_obj': 'quality',
+                         'intensification_percentage' : 0})
+        smbo = SMAC(scen, tae_runner=target, rng=1).solver
+        self.assertRaises(ValueError, smbo.run)
+        # Test for >= 1
+        scen = Scenario({'cs': test_helpers.get_branin_config_space(),
+                         'run_obj': 'quality',
+                         'intensification_percentage' : 1})
+        smbo = SMAC(scen, tae_runner=target, rng=1).solver
+        self.assertRaises(ValueError, smbo.run)
+
     def tearDown(self):
-            for d in glob.glob('smac3-output*'):
-                shutil.rmtree(d)
+        for d in glob.glob('smac3-output*'):
+            shutil.rmtree(d)
 
 
 if __name__ == "__main__":

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -8,6 +8,7 @@ import sys
 import unittest
 import shutil
 import glob
+import re
 
 import numpy as np
 from ConfigSpace import ConfigurationSpace, Configuration
@@ -50,7 +51,8 @@ class TestSMBO(unittest.TestCase):
 
     def setUp(self):
         self.scenario = Scenario({'cs': test_helpers.get_branin_config_space(),
-                                  'run_obj': 'quality'})
+                                  'run_obj': 'quality',
+                                  'output_dir': ""})
 
     def branin(self, x):
         y = (x[:, 1] - (5.1 / (4 * np.pi ** 2)) * x[:, 0] ** 2 + 5 * x[:, 0] / np.pi - 6) ** 2
@@ -294,30 +296,56 @@ class TestSMBO(unittest.TestCase):
             return 5
         patch.side_effect = FirstRunCrashedException()
         scen = Scenario({'cs': test_helpers.get_branin_config_space(),
-                         'run_obj': 'quality',
-                         'abort_on_first_run_crash' : 1})
+                         'run_obj': 'quality', 'output_dir': "",
+                         'abort_on_first_run_crash': 1})
         smbo = SMAC(scen, tae_runner=target, rng=1).solver
         self.assertRaises(FirstRunCrashedException, smbo.run)
+
+    def test_intensification_percentage(self):
+        def target(x):
+            return 5
+        scen = Scenario({'cs': test_helpers.get_branin_config_space(),
+                         'run_obj': 'quality', 'output_dir': "",
+                         'runcount_limit': 1,
+                         'intensification_percentage' : 0.3})
+        smbo = SMAC(scen, tae_runner=target, rng=1).solver
+        # check for correct execution by catching the logs. difficult to do
+        # differently, because no access to local variables possible
+        rgx = re.compile(r".*Total time: (\d+\.\d+), time spent on choosing next "
+                         "configurations: (\d+\.\d+) \((\d+\.\d+)\), time left for "
+                         "intensification: (\d+\.\d+) \((\d+\.\d+)\).*")
+        with self.assertLogs('smac.smbo.smbo.SMBO', level='DEBUG') as cm:
+            smbo.run()
+            match = rgx.match("".join(cm.output))
+
+        total, spent, frac_conf, left, frac_inten = [float(x) for x in match.groups()]
+        self.assertEqual(frac_conf, 0.7)
+        self.assertEqual(frac_inten, 0.3)
+        self.assertAlmostEqual(total*frac_conf, spent, 3)
+        self.assertAlmostEqual(total*frac_inten, left, 3)
 
     def test_intensification_percentage_bad_value(self):
         def target(x):
             return 5
+        def get_smbo(intensification_perc):
+            """ Return SMBO with intensification_percentage. """
+            scen = Scenario({'cs': test_helpers.get_branin_config_space(),
+                             'run_obj': 'quality', 'output_dir': "",
+                             'intensification_percentage' : intensification_perc})
+            return SMAC(scen, tae_runner=target, rng=1).solver
         # Test for <= 0
-        scen = Scenario({'cs': test_helpers.get_branin_config_space(),
-                         'run_obj': 'quality',
-                         'intensification_percentage' : 0})
-        smbo = SMAC(scen, tae_runner=target, rng=1).solver
+        smbo = get_smbo(0)
+        self.assertRaises(ValueError, smbo.run)
+        smbo = get_smbo(-0.2)
         self.assertRaises(ValueError, smbo.run)
         # Test for >= 1
-        scen = Scenario({'cs': test_helpers.get_branin_config_space(),
-                         'run_obj': 'quality',
-                         'intensification_percentage' : 1})
-        smbo = SMAC(scen, tae_runner=target, rng=1).solver
+        smbo = get_smbo(1)
+        self.assertRaises(ValueError, smbo.run)
+        smbo = get_smbo(1.2)
         self.assertRaises(ValueError, smbo.run)
 
     def tearDown(self):
-        for d in glob.glob('smac3-output*'):
-            shutil.rmtree(d)
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding option intensification_percentage (analogous to SMAC2), must be in (0,1), defines the fraction of time assigned to intensification. Uses the `time_bound`-parameter in `intensifier.intensify`.