### PR TITLE
MAINT pSMAC interface

### DIFF
--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -107,6 +107,10 @@ class RunHistory(object):
         if self.data.get(k) is None:
             self._add(k, v, status, external_data)
         elif status != StatusType.CAPPED and self.data[k].status == StatusType.CAPPED:
+            # overwrite capped runs with uncapped runs
+            self._add(k, v, status, external_data)
+        elif status == StatusType.CAPPED and self.data[k].status == StatusType.CAPPED and cost > self.data[k].cost:
+            # overwrite if censored with a larger cutoff
             self._add(k, v, status, external_data)
 
     def _add(self, k, v, status, external_data):

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -62,7 +62,7 @@ class RunHistory(object):
             status, instance_id=None,
             seed=None,
             additional_info=None,
-            external_data:bool=False):
+            external_data: bool=False):
         '''
         adds a data of a new target algorithm (TA) run;
         it will update data if the same key values are used
@@ -103,19 +103,27 @@ class RunHistory(object):
         v = RunValue(cost, time, status, additional_info)
 
         # Each runkey is supposed to be used only once. Repeated tries to add
-        # the same runkey will be ignored silently.
-        if self.data.get(k) is None or self.data.get(k).status==StatusType.CAPPED:
-            self.data[k] = v
+        # the same runkey will be ignored silently if not capped.
+        if self.data.get(k) is None:
+            self._add(k, v, status, external_data)
+        elif status != StatusType.CAPPED and self.data[k].status == StatusType.CAPPED:
+            self._add(k, v, status, external_data)
 
-            if not external_data and status!=StatusType.CAPPED:
-                # also add to fast data structure
-                is_k = InstSeedKey(instance_id, seed)
-                self._configid_to_inst_seed[
-                    config_id] = self._configid_to_inst_seed.get(config_id, [])
-                self._configid_to_inst_seed[config_id].append(is_k)
+    def _add(self, k, v, status, external_data):
+        '''
+            actual function to add new entry to data structures
+        '''
+        self.data[k] = v
 
-                # assumes an average across runs as cost function
-                self.incremental_update_cost(config, cost)
+        if not external_data and status != StatusType.CAPPED:
+            # also add to fast data structure
+            is_k = InstSeedKey(k.instance_id, k.seed)
+            self._configid_to_inst_seed[
+                k.config_id] = self._configid_to_inst_seed.get(k.config_id, [])
+            self._configid_to_inst_seed[k.config_id].append(is_k)
+
+            # assumes an average across runs as cost function aggregation
+            self.incremental_update_cost(self.ids_config[k.config_id], v.cost)
 
     def update_cost(self, config):
         '''
@@ -238,6 +246,7 @@ class RunHistory(object):
             using encoder implied using object_hook defined in StatusType
             to deserialize from json.
             """
+
             def default(self, obj):
                 if isinstance(obj, StatusType):
                     return {"__enum__": str(obj)}
@@ -267,7 +276,6 @@ class RunHistory(object):
         cs : ConfigSpace
             instance of configuration space
         """
-
         with open(fn) as fp:
             all_data = json.load(fp, object_hook=StatusType.enum_hook)
 
@@ -303,7 +311,7 @@ class RunHistory(object):
         new_runhistory.load_json(fn, cs)
         self.update(runhistory=new_runhistory)
 
-    def update(self, runhistory, external_data:bool=False):
+    def update(self, runhistory, external_data: bool=False):
         """Update the current runhistory by adding new runs from a json file.
 
         Parameters

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -247,6 +247,8 @@ class Scenario(object):
                               datetime.datetime.fromtimestamp(
                                   time.time()).strftime(
                                   '%Y-%m-%d_%H:%M:%S')))
+        self.add_argument(name='input_psmac_dirs', help=None,
+                          default=None)
         self.add_argument(name='shared_model', help=None, default='0',
                           callback=_is_truthy)
         self.add_argument(name='instances', default=[[None]], help=None,
@@ -354,6 +356,11 @@ class Scenario(object):
             self.logger.debug("Deactivate output directory.")
         else:
             self.logger.info("Output to %s" % (self.output_dir))
+            
+        if self.shared_model and self.input_psmac_dirs is None:
+            # per default, we assume that
+            # all psmac runs write to the same directory
+            self.input_psmac_dirs = [self.output_dir] 
 
     def __getstate__(self):
         d = dict(self.__dict__)

--- a/smac/smbo/pSMAC.py
+++ b/smac/smbo/pSMAC.py
@@ -25,7 +25,8 @@ def read(run_history: RunHistory,
         objects stored in the output directory.
 
     output_dirs : typing.Union[str,typing.List[str]]
-        List of SMAC output directory. 
+        List of SMAC output directories
+        or Linux path expression (str) which will be casted into a list with glob.glob(). 
         This function will search the output directories
         for files matching the runhistory regular expression.
 

--- a/smac/smbo/pSMAC.py
+++ b/smac/smbo/pSMAC.py
@@ -1,13 +1,21 @@
 import re
 import tempfile
 import os
+import typing
+import logging
+import glob
 
+from smac.runhistory.runhistory import RunHistory
+from smac.configspace import ConfigurationSpace
 
 RUNHISTORY_FILEPATTERN = '.runhistory_%d.json'
 RUNHISTORY_RE = r'\.runhistory_[0-9]*\.json'
 
 
-def read(run_history, output_directory, configuration_space, logger):
+def read(run_history: RunHistory, 
+         output_dirs: typing.Union[str,typing.List[str]],
+         configuration_space: ConfigurationSpace,
+         logger: logging.Logger):
     """Update runhistory with run results from concurrent runs of pSMAC.
 
     Parameters
@@ -16,8 +24,9 @@ def read(run_history, output_directory, configuration_space, logger):
         RunHistory object to be updated with run information from runhistory
         objects stored in the output directory.
 
-    output_directory : str
-        SMAC output directory. This function will search the output directory
+    output_dirs : typing.Union[str,typing.List[str]]
+        List of SMAC output directory. 
+        This function will search the output directories
         for files matching the runhistory regular expression.
 
     configuration_space : ConfigSpace.ConfigurationSpace
@@ -29,27 +38,30 @@ def read(run_history, output_directory, configuration_space, logger):
     numruns_in_runhistory = len(run_history.data)
     initial_numruns_in_runhistory = numruns_in_runhistory
 
-    files_in_output_directory = os.listdir(output_directory)
-    for file_in_output_directory in files_in_output_directory:
-        match = re.match(RUNHISTORY_RE, file_in_output_directory)
-        if match:
-            runhistory_file = os.path.join(output_directory,
-                                           file_in_output_directory)
-            run_history.update_from_json(runhistory_file,
-                                         configuration_space)
+    if isinstance(output_dirs, str):
+        output_dirs = glob.glob(output_dirs)
 
-            new_numruns_in_runhistory = len(run_history.data)
-            difference = new_numruns_in_runhistory - numruns_in_runhistory
-            logger.debug('Shared model mode: Loaded %d new runs from %s' %
-                         (difference, file_in_output_directory))
-            numruns_in_runhistory = new_numruns_in_runhistory
+    for output_directory in output_dirs:
+        for file_in_output_directory in os.listdir(output_directory):
+            match = re.match(RUNHISTORY_RE, file_in_output_directory)
+            if match:
+                runhistory_file = os.path.join(output_directory,
+                                               file_in_output_directory)
+                run_history.update_from_json(runhistory_file,
+                                             configuration_space)
+
+                new_numruns_in_runhistory = len(run_history.data)
+                difference = new_numruns_in_runhistory - numruns_in_runhistory
+                logger.debug('Shared model mode: Loaded %d new runs from %s' %
+                             (difference, file_in_output_directory))
+                numruns_in_runhistory = new_numruns_in_runhistory
 
     difference = numruns_in_runhistory - initial_numruns_in_runhistory
     logger.debug('Shared model mode: Finished loading new runs, found %d new '
                  'runs.' % difference)
 
 
-def write(run_history, output_directory, num_run):
+def write(run_history:RunHistory, output_directory:str, num_run:int):
     """Write the runhistory to the output directory.
 
     Overwrites previously outputted runhistories.

--- a/smac/smbo/smbo.py
+++ b/smac/smbo/smbo.py
@@ -111,7 +111,7 @@ class SMBO(BaseSolver):
         while True:
             if self.scenario.shared_model:
                 pSMAC.read(run_history=self.runhistory,
-                           output_directory=self.scenario.output_dir,
+                           output_dirs=self.scenario.input_psmac_dirs,
                            configuration_space=self.config_space,
                            logger=self.logger)
 


### PR DESCRIPTION
* FIX update of runhistory wrt to capped runs in combination with shared_model
* MAINT add option in scenario to specify a list (or a glob expression) of dictionaries from which pSMAC should read the runhistories 