### PR TITLE
MAINT clarify truth-interpretation in scenario-options

### DIFF
--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -23,7 +23,13 @@ __version__ = "0.0.2"
 
 
 def _is_truthy(arg):
-    return arg in ["1", "true", True]
+    if arg in ["1", "true", True]:
+        return True
+    elif arg in ["0", "false", False]:
+        return False
+    else:
+        raise ValueError("{} cannot be interpreted as a boolean argument. "
+                         "Please use one of {{0, false, 1, true}}.".format(arg))
 
 
 class Scenario(object):

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -15,7 +15,7 @@ import numpy as np
 from ConfigSpace import Configuration, ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformIntegerHyperparameter
 
-from smac.scenario.scenario import Scenario
+from smac.scenario.scenario import Scenario, _is_truthy
 from smac.configspace import ConfigurationSpace
 from smac.utils.merge_foreign_data import merge_foreign_data
 from smac.runhistory.runhistory import RunHistory
@@ -218,6 +218,15 @@ class ScenarioTest(unittest.TestCase):
         scenario_dict['overall_obj'] = 'par'
         scenario = Scenario(scenario_dict)
         self.assertEqual(scenario.par_factor, 1)
+
+    def test_truth_value(self):
+        self.assertTrue(_is_truthy("1"))
+        self.assertTrue(_is_truthy("true"))
+        self.assertTrue(_is_truthy(True))
+        self.assertFalse(_is_truthy("0"))
+        self.assertFalse(_is_truthy("false"))
+        self.assertFalse(_is_truthy(False))
+        self.assertRaises(ValueError, _is_truthy, "something")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implementing issue/#201, enforcing verbosity on boolean arguments in scenario-files.