### PR TITLE
ADD #204, always save the runhistory

### DIFF
--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import typing
 
 import numpy as np
@@ -337,6 +338,11 @@ class SMAC(object):
             self.logger.info("Final Incumbent: %s" % (self.solver.incumbent))
             self.runhistory = self.solver.runhistory
             self.trajectory = self.solver.intensifier.traj_logger.trajectory
+
+            if self.solver.scenario.output_dir is not None:
+                self.solver.runhistory.save_json(
+                    fn=os.path.join(self.solver.scenario.output_dir,
+                                    "runhistory.json"))
         return incumbent
 
     def get_tae_runner(self):

--- a/smac/smac_cli.py
+++ b/smac/smac_cli.py
@@ -84,9 +84,3 @@ class SMACCLI(object):
             optimizer.optimize()
         except (TAEAbortException, FirstRunCrashedException) as err:
             self.logger.error(err)
-        finally:
-            # ensure that the runhistory is always dumped in the end
-            if scen.output_dir is not None:
-                optimizer.solver.runhistory.save_json(
-                    fn=os.path.join(scen.output_dir, "runhistory.json"))
-        #smbo.runhistory.load_json(fn="runhistory.json", cs=smbo.config_space)

--- a/smac/smbo/pSMAC.py
+++ b/smac/smbo/pSMAC.py
@@ -8,8 +8,8 @@ import glob
 from smac.runhistory.runhistory import RunHistory
 from smac.configspace import ConfigurationSpace
 
-RUNHISTORY_FILEPATTERN = '.runhistory_%d.json'
-RUNHISTORY_RE = r'\.runhistory_[0-9]*\.json'
+RUNHISTORY_FILEPATTERN = 'runhistory.json'
+RUNHISTORY_RE = r'runhistory\.json'
 
 
 def read(run_history: RunHistory, 
@@ -79,8 +79,7 @@ def write(run_history:RunHistory, output_directory:str, num_run:int):
 
     """
 
-    output_filename = os.path.join(output_directory,
-                                   RUNHISTORY_FILEPATTERN % num_run)
+    output_filename = os.path.join(output_directory, RUNHISTORY_FILEPATTERN)
 
     with tempfile.NamedTemporaryFile('wb', dir=output_directory,
                                      delete=False) as fh:

--- a/test/test_smbo/test_pSMAC.py
+++ b/test/test_smbo/test_pSMAC.py
@@ -71,7 +71,7 @@ class TestPSMAC(unittest.TestCase):
 
         pSMAC.write(run_history, self.tmp_dir, 20)
 
-        output_filename = os.path.join(self.tmp_dir, '.runhistory_20.json')
+        output_filename = os.path.join(self.tmp_dir, 'runhistory.json')
         self.assertTrue(os.path.exists(output_filename))
 
         fixture = json.loads(fixture, object_hook=StatusType.enum_hook)
@@ -104,7 +104,7 @@ class TestPSMAC(unittest.TestCase):
                   '"2": {"x": -4.998284377739827, "y": 4.534988589477597}}}'
 
         other_runhistory_filename = os.path.join(self.tmp_dir,
-                                                 '.runhistory_20.json')
+                                                 'runhistory.json')
         with open(other_runhistory_filename, 'w') as fh:
             fh.write(other_runhistory)
 


### PR DESCRIPTION
Adds #204, always saves the runhistory at the end of an optimization run instead of only saving it when called from command line. As a side-effect, the filename of the runhistory as saved for pSMAC no longer has the SMAC seed in it's file name. This should anyway be no longer needed since @mlindauer implemented pSMAC loading data from different directories.