### PR TITLE
Output directory name for scenario file

### DIFF
--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -255,7 +255,7 @@ class Scenario(object):
                           default="smac3-output_%s" % (
                               datetime.datetime.fromtimestamp(
                                   time.time()).strftime(
-                                  '%Y-%m-%d_%H:%M:%S')))
+                                  '%Y-%m-%d_%H:%M:%S_(%f)')))
         self.add_argument(name='input_psmac_dirs', help=None,
                           default=None)
         self.add_argument(name='shared_model', help=None, default='0',


### PR DESCRIPTION
Add milliseconds to output directory name for scenario to avoid crash (OSError) when starting multiple smac instances in parallel (did happen on cluster)