### PR TITLE
MAINT refactor EPM module

### DIFF
--- a/smac/epm/base_epm.py
+++ b/smac/epm/base_epm.py
@@ -194,9 +194,4 @@ class AbstractEPM(object):
             var[i,0] = var_x
             mean[i,0] = np.mean(means)
 
-        if len(mean.shape) == 1:
-            mean = mean.reshape((-1, 1))
-        if len(var.shape) == 1:
-            var = var.reshape((-1, 1))
-
         return mean, var

--- a/smac/epm/base_epm.py
+++ b/smac/epm/base_epm.py
@@ -1,6 +1,9 @@
 import logging
 import numpy as np
 
+from sklearn.decomposition import PCA
+from sklearn.preprocessing import MinMaxScaler
+
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2016, ML4AAD"
 __license__ = "3-clause BSD"
@@ -12,57 +15,94 @@ __version__ = "0.0.1"
 class AbstractEPM(object):
     '''Abstract implementation of the EPM API '''
 
-    def __init__(self, rng):
+    def __init__(self, pca_dims:float=None, n_feats:int=0):
         '''
         initialize random number generator
 
         Parameters
         ----------
-        rng : np.random.RandomState
+        pca_dims: float
+            if set to a float, use PCA to reduce dimensionality of instance features
+            also requires to set n_feats (> pca_dims)
+        n_feats: int
+            number of instances features -- always appended to X
         '''
-        self.rng = rng
+        self.pca_dims = pca_dims
+        self.n_feats = n_feats
+        
+        self.n_params = None # will be updated on train()
+        
+        self.pca = None
+        self.scaler = None
+        print(pca_dims)
+        if self.pca_dims and self.n_feats > self.pca_dims:
+            self.pca = PCA(n_components=self.pca_dims)
+            self.scaler = MinMaxScaler()
 
     def train(self, X, Y, **kwargs):
-        '''
-        Trains the EPM on X and Y.
+        '''Trains the random forest on X and y.
 
         Parameters
         ----------
-        X: np.ndarray (N, D)
-            Input data points. The dimensionality of X is (N, D),
-            with N as the number of points and D is the number of features.
-        Y: np.ndarray (N, 1)
-            The corresponding target values.
-        '''
-        raise NotImplementedError()
-
-    def predict(self, X):
-        '''
-        Predict values for configs in X
-
-        Parameters
-        ----------
-        configs : list
-            list of configurations
-
-        instance_features : list
-            list of instance features
+        X : np.ndarray [n_samples, n_features (config + instance features)]
+            Input data points.
+        Y : np.ndarray [n_samples, n_objectives]
+            The corresponding target values. n_objectives must match the
+            number of target names specified in the constructor.
 
         Returns
         -------
-        predictions
+        self
         '''
-        raise NotImplementedError()
-    
-    def predict_marginalized_over_instances(self, X):
-        """Predict mean and variance marginalized over all instances.
+        # reduce dimensionality of features of larger than PCA_DIM
+        if self.pca:
+            print(X.shape)
 
-        Returns the predictive mean and variance marginalised over all
-        instances for a set of configurations.
+            X_feats = X[:,:-self.n_feats]
+            # scale features
+            print(X_feats.shape)
+            X_feats = self.scaler.fit_transform(X_feats)
+            X_feats = np.nan_to_num(X_feats)  # if features with max == min
+            print(X_feats.shape)
+            # PCA
+            X_feats = self.pca.fit_transform(X_feats)
+            print(X_feats.shape)
+            self.n_params = X.shape[1] - self.n_feats
+            print("X",X[:, :self.n_params].shape)
+            X = np.vstack((X[:, :self.n_params], X_feats ))
+            print(X.shape)
+            if hasattr(self, types):
+                self.types  = self.types[:self.n_params+X_feats.shape[1]] 
+            self.logger.info("HALLLLLLLLLLLLLLLLLLLLLO")
+
+        return self._train(X, Y)
+        
+    
+    def _train(self, X, Y, **kwargs):
+        '''Trains the random forest on X and y.
 
         Parameters
         ----------
-        X : np.ndarray of shape = [n_features (config), ]
+        X : np.ndarray [n_samples, n_features (config + instance features)]
+            Input data points.
+        Y : np.ndarray [n_samples, n_objectives]
+            The corresponding target values. n_objectives must match the
+            number of target names specified in the constructor.
+
+        Returns
+        -------
+        self
+        '''
+        raise NotImplementedError
+        
+    def predict(self, X):
+        '''
+        Predict means and variances for given X.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape = [n_samples, n_features (config + instance
+        features)]
 
         Returns
         -------
@@ -70,6 +110,93 @@ class AbstractEPM(object):
             Predictive mean
         vars : np.ndarray  of shape = [n_samples, 1]
             Predictive variance
-        """
+        '''
+        if self.pca:
+            print(X.shape)
+            X_feats = X[:,:-self.n_feats]
+            X_feats = self.scaler.transform(X_feats)
+            X_feats = self.pca.transform(X_feats)
+            X = np.vstack((X[:, :self.n_params], X_feats ))
+            print(X.shape)
+        
+        return self._predict(X)
+    
+    def _predict(self, X):
+        '''
+        Predict means and variances for given X.
 
+        Parameters
+        ----------
+        X : np.ndarray of shape = [n_samples, n_features (config + instance
+        features)]
+
+        Returns
+        -------
+        means : np.ndarray of shape = [n_samples, 1]
+            Predictive mean
+        vars : np.ndarray  of shape = [n_samples, 1]
+            Predictive variance
+        '''
         raise NotImplementedError()
+    
+    def predict_marginalized_over_instances(self, X):
+        '''Predict mean and variance marginalized over all instances.
+
+        Returns the predictive mean and variance marginalised over all
+        instances for a set of configurations.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape = [n_samples, n_features (config + instance
+        features)]
+
+        Returns
+        -------
+        means : np.ndarray of shape = [n_samples, 1]
+            Predictive mean
+        vars : np.ndarray  of shape = [n_samples, 1]
+            Predictive variance
+        '''
+
+        if self.instance_features is None or \
+                len(self.instance_features) == 0:
+            mean, var = self.predict(X)
+            var[var < self.var_threshold] = self.var_threshold
+            var[np.isnan(var)] = self.var_threshold
+            return mean, var
+        else:
+            n_instance_features = self.instance_features.shape[1]
+            n_instances = len(self.instance_features)
+
+        if len(X.shape) != 2:
+            raise ValueError(
+                'Expected 2d array, got %dd array!' % len(X.shape))
+        if X.shape[1] != self.types.shape[0] - n_instance_features:
+            raise ValueError('Rows in X should have %d entries but have %d!' %
+                             (self.types.shape[0] - n_instance_features,
+                              X.shape[1]))
+
+        mean = np.zeros(X.shape[0])
+        var = np.zeros(X.shape[0])
+        for i, x in enumerate(X):
+            X_ = np.hstack(
+                (np.tile(x, (n_instances, 1)), self.instance_features))
+            means, vars = self.predict(X_)
+            # use only mean of variance and not the variance of the mean here
+            # since we don't want to reason about the instance hardness distribution
+            var_x = np.mean(vars) # + np.var(means)
+            if var_x < self.var_threshold:
+                var_x = self.var_threshold
+
+            var[i] = var_x
+            mean[i] = np.mean(means)
+
+        var[var < self.var_threshold] = self.var_threshold
+        var[np.isnan(var)] = self.var_threshold
+
+        if len(mean.shape) == 1:
+            mean = mean.reshape((-1, 1))
+        if len(var.shape) == 1:
+            var = var.reshape((-1, 1))
+
+        return mean, var

--- a/smac/epm/base_epm.py
+++ b/smac/epm/base_epm.py
@@ -113,9 +113,9 @@ class AbstractEPM(object):
 
         Returns
         -------
-        means : np.ndarray of shape = [n_samples, 1]
+        means : np.ndarray of shape = [n_samples, n_objectives]
             Predictive mean
-        vars : np.ndarray  of shape = [n_samples, 1]
+        vars : np.ndarray  of shape = [n_samples, n_objectives]
             Predictive variance
         '''
         if self.pca:
@@ -137,9 +137,9 @@ class AbstractEPM(object):
 
         Returns
         -------
-        means : np.ndarray of shape = [n_samples, 1]
+        means : np.ndarray of shape = [n_samples, n_objectives]
             Predictive mean
-        vars : np.ndarray  of shape = [n_samples, 1]
+        vars : np.ndarray  of shape = [n_samples, n_objectives]
             Predictive variance
         '''
         raise NotImplementedError()

--- a/smac/epm/base_epm.py
+++ b/smac/epm/base_epm.py
@@ -1,4 +1,5 @@
 import logging
+
 import numpy as np
 
 from sklearn.decomposition import PCA
@@ -17,7 +18,7 @@ class AbstractEPM(object):
 
     def __init__(self,
                  instance_features: np.ndarray=None,
-                 pca_dims: float=None):
+                 pca_components: float=None):
         '''
         initialize random number generator
 
@@ -26,13 +27,13 @@ class AbstractEPM(object):
         instance_features: np.ndarray (I, K)
             Contains the K dimensional instance features
             of the I different instances
-        pca_dims: float
+        pca_components: float
             if set to a float, use PCA to reduce dimensionality of instance features
             also requires to set n_feats (> pca_dims)
 
         '''
         self.instance_features = instance_features
-        self.pca_dims = pca_dims
+        self.pca_components = pca_components
         if instance_features is not None:
             self.n_feats = instance_features.shape[1]
         else:
@@ -42,8 +43,8 @@ class AbstractEPM(object):
 
         self.pca = None
         self.scaler = None
-        if self.pca_dims and self.n_feats > self.pca_dims:
-            self.pca = PCA(n_components=self.pca_dims)
+        if self.pca_components and self.n_feats > self.pca_components:
+            self.pca = PCA(n_components=self.pca_components)
             self.scaler = MinMaxScaler()
 
         # Never use a lower variance than this
@@ -69,7 +70,7 @@ class AbstractEPM(object):
 
         # reduce dimensionality of features of larger than PCA_DIM
         if self.pca:
-            X_feats = X[:, :-self.n_feats]
+            X_feats = X[:, -self.n_feats:]
             # scale features
             X_feats = self.scaler.fit_transform(X_feats)
             X_feats = np.nan_to_num(X_feats)  # if features with max == min
@@ -118,7 +119,7 @@ class AbstractEPM(object):
             Predictive variance
         '''
         if self.pca:
-            X_feats = X[:, :-self.n_feats]
+            X_feats = X[:, -self.n_feats:]
             X_feats = self.scaler.transform(X_feats)
             X_feats = self.pca.transform(X_feats)
             X = np.hstack((X[:, :self.n_params], X_feats))

--- a/smac/epm/base_epm.py
+++ b/smac/epm/base_epm.py
@@ -14,14 +14,21 @@ __version__ = "0.0.1"
 
 
 class AbstractEPM(object):
-    '''Abstract implementation of the EPM API '''
+    '''Abstract implementation of the EPM API 
+        
+        Note: The input dimensions of Y for training
+        and the output dimensions of all predictions 
+        (also called n_objectives)
+        depends on the concrete implementation of this
+        abstract class.
+    '''
 
     def __init__(self,
                  instance_features: np.ndarray=None,
                  pca_components: float=None):
         '''
-        initialize random number generator
-
+        Constructor
+        
         Parameters
         ----------
         instance_features: np.ndarray (I, K)

--- a/smac/epm/random_epm.py
+++ b/smac/epm/random_epm.py
@@ -25,7 +25,7 @@ class RandomEPM(AbstractEPM):
         self.logger = logging.getLogger(self.__module__ + "." + self.__class__.__name__)
         self.rng = rng
 
-    def train(self, X, Y, **kwargs):
+    def _train(self, X, Y, **kwargs):
         '''
         Pseudo training on X and Y.
 
@@ -45,7 +45,7 @@ class RandomEPM(AbstractEPM):
 
         self.logger.debug("(Pseudo) Fit model to data")
 
-    def predict(self, X):
+    def _predict(self, X):
         '''
         Predict values for configs
 
@@ -63,24 +63,4 @@ class RandomEPM(AbstractEPM):
         '''
         if not isinstance(X, np.ndarray):
             raise NotImplementedError("X has to be of type np.ndarray")
-        return self.rng.rand(len(X), 1), self.rng.rand(len(X), 1)
-    
-    def predict_marginalized_over_instances(self, X):
-        """Predict mean and variance marginalized over all instances.
-
-        Returns the predictive mean and variance marginalised over all
-        instances for a set of configurations.
-
-        Parameters
-        ----------
-        X : np.ndarray of shape = [n_features (config), ]
-
-        Returns
-        -------
-        means : np.ndarray of shape = [n_samples, 1]
-            Predictive mean
-        vars : np.ndarray  of shape = [n_samples, 1]
-            Predictive variance
-        """
-
         return self.rng.rand(len(X), 1), self.rng.rand(len(X), 1)

--- a/smac/epm/rf_with_instances.py
+++ b/smac/epm/rf_with_instances.py
@@ -87,9 +87,6 @@ class RandomForestWithInstances(AbstractEPM):
 
         self.logger = logging.getLogger(self.__module__ + "." + self.__class__.__name__)
 
-        # Never use a lower variance than this
-        self.var_threshold = 10 ** -5
-
     def _train(self, X, y, **kwargs):
         """Trains the random forest on X and y.
 

--- a/smac/epm/rf_with_instances.py
+++ b/smac/epm/rf_with_instances.py
@@ -28,9 +28,6 @@ class RandomForestWithInstances(AbstractEPM):
         2 dimension where the first dimension consists of 3 different
         categorical choices and the second dimension is continuous than we
         have to pass np.array([2, 0]). Note that we count starting from 0.
-    instance_features: np.ndarray (I, K)
-        Contains the K dimensional instance features
-        of the I different instances
     num_trees: int
         The number of trees in the random forest.
     do_bootstrapping: bool
@@ -52,7 +49,6 @@ class RandomForestWithInstances(AbstractEPM):
     '''
 
     def __init__(self, types,
-                 instance_features=None,
                  num_trees=10,
                  do_bootstrapping=True,
                  n_points_per_tree=0,
@@ -67,7 +63,6 @@ class RandomForestWithInstances(AbstractEPM):
 
         super().__init__(**kwargs)
 
-        self.instance_features = instance_features
         self.types = types
 
         self.rf = pyrfr.regression.binary_rss()

--- a/smac/epm/rf_with_instances.py
+++ b/smac/epm/rf_with_instances.py
@@ -62,7 +62,10 @@ class RandomForestWithInstances(AbstractEPM):
                  max_depth=20,
                  eps_purity=1e-8,
                  max_num_nodes=1000,
-                 seed=42):
+                 seed=42,
+                 **kwargs):
+
+        super().__init__(**kwargs)
 
         self.instance_features = instance_features
         self.types = types
@@ -92,7 +95,7 @@ class RandomForestWithInstances(AbstractEPM):
         # Never use a lower variance than this
         self.var_threshold = 10 ** -5
 
-    def train(self, X, y, **kwargs):
+    def _train(self, X, y, **kwargs):
         """Trains the random forest on X and y.
 
         Parameters
@@ -114,7 +117,7 @@ class RandomForestWithInstances(AbstractEPM):
         self.rf.fit(data)
         return self
 
-    def predict(self, X):
+    def _predict(self, X):
         """Predict means and variances for given X.
 
         Parameters
@@ -139,64 +142,3 @@ class RandomForestWithInstances(AbstractEPM):
         means, vars = self.rf.batch_predictions(X)
 
         return means.reshape((-1, 1)), vars.reshape((-1, 1))
-
-    def predict_marginalized_over_instances(self, X):
-        """Predict mean and variance marginalized over all instances.
-
-        Returns the predictive mean and variance marginalised over all
-        instances for a set of configurations.
-
-        Parameters
-        ----------
-        X : np.ndarray of shape = [n_features (config), ]
-
-        Returns
-        -------
-        means : np.ndarray of shape = [n_samples, 1]
-            Predictive mean
-        vars : np.ndarray  of shape = [n_samples, 1]
-            Predictive variance
-        """
-
-        if self.instance_features is None or \
-                len(self.instance_features) == 0:
-            mean, var = self.predict(X)
-            var[var < self.var_threshold] = self.var_threshold
-            var[np.isnan(var)] = self.var_threshold
-            return mean, var
-        else:
-            n_instance_features = self.instance_features.shape[1]
-            n_instances = len(self.instance_features)
-
-        if len(X.shape) != 2:
-            raise ValueError(
-                'Expected 2d array, got %dd array!' % len(X.shape))
-        if X.shape[1] != self.types.shape[0] - n_instance_features:
-            raise ValueError('Rows in X should have %d entries but have %d!' %
-                             (self.types.shape[0] - n_instance_features,
-                              X.shape[1]))
-
-        mean = np.zeros(X.shape[0])
-        var = np.zeros(X.shape[0])
-        for i, x in enumerate(X):
-            X_ = np.hstack(
-                (np.tile(x, (n_instances, 1)), self.instance_features))
-            means, vars = self.predict(X_)
-            # use only mean of variance and not the variance of the mean here
-            # since we don't want to reason about the instance hardness distribution
-            var_x = np.mean(vars) # + np.var(means)
-            if var_x < self.var_threshold:
-                var_x = self.var_threshold
-
-            var[i] = var_x
-            mean[i] = np.mean(means)
-
-        var[var < self.var_threshold] = self.var_threshold
-        var[np.isnan(var)] = self.var_threshold
-
-        if len(mean.shape) == 1:
-            mean = mean.reshape((-1, 1))
-        if len(var.shape) == 1:
-            var = var.reshape((-1, 1))
-
-        return mean, var

--- a/smac/epm/uncorrelated_mo_rf_with_instances.py
+++ b/smac/epm/uncorrelated_mo_rf_with_instances.py
@@ -31,7 +31,7 @@ class UncorrelatedMultiObjectiveRandomForestWithInstances(AbstractEPM):
                            for i in range(self.num_targets)]
 
 
-    def train(self, X, Y, **kwargs):
+    def _train(self, X, Y, **kwargs):
         """Trains the random forest on X and y.
 
         Parameters
@@ -51,7 +51,7 @@ class UncorrelatedMultiObjectiveRandomForestWithInstances(AbstractEPM):
 
         return self
 
-    def predict(self, X):
+    def _predict(self, X):
         """Predict means and variances for given X.
 
         Parameters

--- a/smac/epm/uncorrelated_mo_rf_with_instances.py
+++ b/smac/epm/uncorrelated_mo_rf_with_instances.py
@@ -25,6 +25,8 @@ class UncorrelatedMultiObjectiveRandomForestWithInstances(AbstractEPM):
             See RandomForestWithInstances documentation
 
         """
+        super().__init__(**kwargs)
+        
         self.target_names = target_names
         self.num_targets = len(self.target_names)
         self.estimators = [RandomForestWithInstances(types, **kwargs)

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -125,7 +125,9 @@ class SMAC(object):
         if model is None:
             model = RandomForestWithInstances(types=types,
                                               instance_features=scenario.feature_array,
-                                              seed=rng.randint(MAXINT))
+                                              seed=rng.randint(MAXINT),
+                                              n_feats=scenario.feature_array.shape[1],
+                                              pca_dims=scenario.PCA_DIM)
         # initial acquisition function
         if acquisition_function is None:
             acquisition_function = EI(model=model)

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -126,7 +126,7 @@ class SMAC(object):
             model = RandomForestWithInstances(types=types,
                                               instance_features=scenario.feature_array,
                                               seed=rng.randint(MAXINT),
-                                              pca_dims=scenario.PCA_DIM)
+                                              pca_components=scenario.PCA_DIM)
         # initial acquisition function
         if acquisition_function is None:
             acquisition_function = EI(model=model)

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -126,7 +126,6 @@ class SMAC(object):
             model = RandomForestWithInstances(types=types,
                                               instance_features=scenario.feature_array,
                                               seed=rng.randint(MAXINT),
-                                              n_feats=scenario.feature_array.shape[1],
                                               pca_dims=scenario.PCA_DIM)
         # initial acquisition function
         if acquisition_function is None:

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -9,9 +9,6 @@ import datetime
 import copy
 import typing
 
-from sklearn.decomposition import PCA
-from sklearn.preprocessing import MinMaxScaler
-
 from smac.utils.io.input_reader import InputReader
 from smac.configspace import pcs, pcs_new
 from smac.utils.io.output_writer import OutputWriter
@@ -336,19 +333,6 @@ class Scenario(object):
                 self.feature_array.append(self.feature_dict[inst_])
             self.feature_array = numpy.array(self.feature_array)
             self.n_features = self.feature_array.shape[1]
-            # reduce dimensionality of features of larger than PCA_DIM
-            if self.feature_array.shape[1] > self.PCA_DIM:
-                X = self.feature_array
-                # scale features
-                X = MinMaxScaler().fit_transform(X)
-                X = numpy.nan_to_num(X)  # if features with max == min
-                # PCA
-                pca = PCA(n_components=self.PCA_DIM)
-                self.feature_array = pca.fit_transform(X)
-                self.n_features = self.feature_array.shape[1]
-                # update feature dictionary
-                for feat, inst_ in zip(self.feature_array, self.train_insts):
-                    self.feature_dict[inst_] = feat
 
         # read pcs file
         if self.pcs_fn and os.path.isfile(self.pcs_fn):

--- a/test/test_epm/test_rfr_with_instances.py
+++ b/test/test_epm/test_rfr_with_instances.py
@@ -50,11 +50,6 @@ class TestRFWithInstances(unittest.TestCase):
         self.assertRaisesRegexp(ValueError, "Expected 2d array, got 3d array!",
                                 model.predict_marginalized_over_instances, X)
 
-        X = rs.rand(10, 5)
-        self.assertRaisesRegexp(ValueError, "Rows in X should have 8 entries "
-                                            "but have 5!",
-                                model.predict_marginalized_over_instances, X)
-
     @mock.patch.object(RandomForestWithInstances, 'predict')
     def test_predict_marginalized_over_instances_no_features(self, rf_mock):
         """The RF should fall back to the regular predict() method."""

--- a/test/test_epm/test_rfr_with_instances.py
+++ b/test/test_epm/test_rfr_with_instances.py
@@ -44,7 +44,7 @@ class TestRFWithInstances(unittest.TestCase):
         F = rs.rand(10, 10)
         Y = rs.rand(20, 1)
         model = RandomForestWithInstances(np.zeros((20,), dtype=np.uint),
-                                          pca_dims=2,
+                                          pca_components=2,
                                           instance_features=F)
         model.train(X, Y)
         

--- a/test/test_epm/test_rfr_with_instances.py
+++ b/test/test_epm/test_rfr_with_instances.py
@@ -38,6 +38,21 @@ class TestRFWithInstances(unittest.TestCase):
         self.assertEqual(m_hat.shape, (10, 1))
         self.assertEqual(v_hat.shape, (10, 1))
 
+    def test_train_with_pca(self):
+        rs = np.random.RandomState(1)
+        X = rs.rand(20, 20)
+        F = rs.rand(10, 10)
+        Y = rs.rand(20, 1)
+        model = RandomForestWithInstances(np.zeros((20,), dtype=np.uint),
+                                          pca_dims=2,
+                                          instance_features=F)
+        model.train(X, Y)
+        
+        self.assertEqual(model.n_params,10)
+        self.assertEqual(model.n_feats,10)
+        self.assertIsNotNone(model.pca)
+        self.assertIsNotNone(model.scaler)
+        
     def test_predict_marginalized_over_instances_wrong_X_dimensions(self):
         rs = np.random.RandomState(1)
 

--- a/test/test_epm/test_rfr_with_instances.py
+++ b/test/test_epm/test_rfr_with_instances.py
@@ -93,6 +93,7 @@ class TestRFWithInstances(unittest.TestCase):
 
         model = RandomForestWithInstances(np.zeros((15,), dtype=np.uint),
                                           instance_features=F)
+        model.train(rs.rand(11, 15),rs.rand(11))
         means, vars = model.predict_marginalized_over_instances(rs.rand(11, 10))
         self.assertEqual(rf_mock.call_count, 11)
         self.assertEqual(means.shape, (11, 1))


### PR DESCRIPTION
* AbstractEPM handles PCA and marginalization over instances
* AbstractEPM can be seen as a wrapper around all other EPMs -- should make it easier to add other EPM models
* all instances of AbstractEPM have to call the inherited constructor
* remove a check in predict_marginalized_over_instances() since it is
not guarantueed that self.types is available