### PR TITLE
increase mem_limit for rf-example

### DIFF
--- a/examples/rf.py
+++ b/examples/rf.py
@@ -3,8 +3,10 @@ import os
 import inspect
 
 import numpy as np
-from sklearn.model_selection import KFold
+from sklearn.metrics import make_scorer
+from sklearn.model_selection import cross_val_score
 from sklearn.ensemble import RandomForestRegressor
+from sklearn.datasets import load_boston
 
 from smac.configspace import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter, \
@@ -13,6 +15,8 @@ from ConfigSpace.hyperparameters import CategoricalHyperparameter, \
 from smac.tae.execute_func import ExecuteTAFuncDict
 from smac.scenario.scenario import Scenario
 from smac.facade.smac_facade import SMAC
+
+boston = load_boston()
 
 def rfr(cfg, seed):
     """
@@ -45,36 +49,19 @@ def rfr(cfg, seed):
         bootstrap=cfg["do_bootstrapping"],
         random_state=seed)
 
-    rmses = []
-    for train, test in kf:
-        # We iterate over cv-folds
-        X_train, X_test = X[train], X[test]
-        y_train, y_test = y[train], y[test]
-
-        rfr.fit(X_train, y_train)
-
-        y_pred = rfr.predict(X_test)
-
-        # We use root mean square error as performance measure
-        rmse = np.sqrt(np.mean((y_pred - y_test)**2))
-        rmses.append(rmse)
-    return np.mean(rmses)
+    def rmse(y, y_pred):
+        return np.sqrt(np.mean((y_pred - y)**2))
+    # Creating root mean square error for sklearns crossvalidation
+    rmse_scorer = make_scorer(rmse, greater_is_better=False)
+    score = cross_val_score(rfr, boston.data, boston.target, cv=11, scoring=rmse_scorer)
+    return -1 * np.mean(score)  # Because cross_validation sign-flips the score
 
 
 logger = logging.getLogger("RF-example")
 logging.basicConfig(level=logging.INFO)
 #logging.basicConfig(level=logging.DEBUG)  # Enable to show debug-output
-
-folder = os.path.realpath(
-    os.path.abspath(os.path.split(inspect.getfile(inspect.currentframe()))[0]))
-
-# Load data
-X = np.array(np.loadtxt(os.path.join(folder, "data/X.csv")), dtype=np.float32)
-y = np.array(np.loadtxt(os.path.join(folder, "data/y.csv")), dtype=np.float32)
-
-# Create cross-validation folds
-kf = KFold(n_splits=4, shuffle=True, random_state=42)
-kf = kf.split(X, y)
+logger.info("Running random forest example for SMAC. If you experience "
+            "difficulties, try to decrease the memory-limit.")
 
 # Build Configuration Space which defines all parameters and their ranges.
 # To illustrate different parameter types,
@@ -89,7 +76,7 @@ cs.add_hyperparameter(do_bootstrapping)
 # Or we can add multiple hyperparameters at once:
 num_trees = UniformIntegerHyperparameter("num_trees", 10, 50, default=10)
 max_depth = UniformIntegerHyperparameter("max_depth", 20, 30, default=20)
-max_features = UniformIntegerHyperparameter("max_features", 1, X.shape[1], default=1)
+max_features = UniformIntegerHyperparameter("max_features", 1, boston.data.shape[1], default=1)
 min_weight_frac_leaf = UniformFloatHyperparameter("min_weight_frac_leaf", 0.0, 0.5, default=0.0)
 criterion = CategoricalHyperparameter("criterion", ["mse", "mae"], default="mse")
 min_samples_to_split = UniformIntegerHyperparameter("min_samples_to_split", 2, 20, default=2)
@@ -100,11 +87,11 @@ cs.add_hyperparameters([num_trees, max_depth, min_weight_frac_leaf, criterion,
         max_features, min_samples_to_split, min_samples_in_leaf, max_leaf_nodes])
 
 # SMAC scenario oject
-scenario = Scenario({"run_obj": "quality",  # we optimize quality (alternative runtime)
-                     "runcount-limit": 20,  # maximum number of function evaluations
-                     "cs": cs,              # configuration space
-                     "deterministic": "true",
-                     "memory_limit": 1024,
+scenario = Scenario({"run_obj": "quality",   # we optimize quality (alternative runtime)
+                     "runcount-limit": 200,  # maximum number of function evaluations
+                     "cs": cs,               # configuration space
+                     "deterministic": "false",
+                     "memory_limit": 3072,   # adapt this to reasonable value for your hardware
                      })
 
 # To optimize, we pass the function to the SMAC-object

--- a/examples/rf.py
+++ b/examples/rf.py
@@ -18,7 +18,7 @@ from smac.facade.smac_facade import SMAC
 
 boston = load_boston()
 
-def rfr(cfg, seed):
+def rf_from_cfg(cfg, seed):
     """
         Creates a random forest regressor from sklearn and fits the given data on it.
         This is the function-call we try to optimize. Chosen values are stored in
@@ -40,7 +40,6 @@ def rfr(cfg, seed):
     rfr = RandomForestRegressor(
         n_estimators=cfg["num_trees"],
         criterion=cfg["criterion"],
-        max_depth=cfg["max_depth"],
         min_samples_split=cfg["min_samples_to_split"],
         min_samples_leaf=cfg["min_samples_in_leaf"],
         min_weight_fraction_leaf=cfg["min_weight_frac_leaf"],
@@ -75,7 +74,6 @@ cs.add_hyperparameter(do_bootstrapping)
 
 # Or we can add multiple hyperparameters at once:
 num_trees = UniformIntegerHyperparameter("num_trees", 10, 50, default=10)
-max_depth = UniformIntegerHyperparameter("max_depth", 20, 30, default=20)
 max_features = UniformIntegerHyperparameter("max_features", 1, boston.data.shape[1], default=1)
 min_weight_frac_leaf = UniformFloatHyperparameter("min_weight_frac_leaf", 0.0, 0.5, default=0.0)
 criterion = CategoricalHyperparameter("criterion", ["mse", "mae"], default="mse")
@@ -83,20 +81,20 @@ min_samples_to_split = UniformIntegerHyperparameter("min_samples_to_split", 2, 2
 min_samples_in_leaf = UniformIntegerHyperparameter("min_samples_in_leaf", 1, 20, default=1)
 max_leaf_nodes = UniformIntegerHyperparameter("max_leaf_nodes", 10, 1000, default=100)
 
-cs.add_hyperparameters([num_trees, max_depth, min_weight_frac_leaf, criterion,
+cs.add_hyperparameters([num_trees, min_weight_frac_leaf, criterion,
         max_features, min_samples_to_split, min_samples_in_leaf, max_leaf_nodes])
 
 # SMAC scenario oject
 scenario = Scenario({"run_obj": "quality",   # we optimize quality (alternative runtime)
-                     "runcount-limit": 200,  # maximum number of function evaluations
+                     "runcount-limit": 50,  # maximum number of function evaluations
                      "cs": cs,               # configuration space
-                     "deterministic": "false",
+                     "deterministic": "true",
                      "memory_limit": 3072,   # adapt this to reasonable value for your hardware
                      })
 
 # To optimize, we pass the function to the SMAC-object
 smac = SMAC(scenario=scenario, rng=np.random.RandomState(42),
-            tae_runner=rfr)
+            tae_runner=rf_from_cfg)
 
 # Example call of the function with default values
 # It returns: Status, Cost, Runtime, Additional Infos


### PR DESCRIPTION
fixing issue/#223

- increase memory_limit to 3072 and runcount-limit to 200
- make example non-deterministic (since it actually is a randomized algorithm)
- use boston-housing-data from sklearn
- use cross-validation from sklearn