### PR TITLE
obtain random samples for intensification from a generator

### DIFF
--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -379,6 +379,6 @@ class ChallengerList(object):
             return config
         else:
             self._next_is_random = True
+            config = self.challengers[self._index]
             self._index += 1
-            config = self.challengers[self._index - 1]
             return config

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -355,12 +355,15 @@ class ChallengerList(object):
         return self
 
     def __next__(self):
-        if self._index == len(self.challengers):
+        if self._index == len(self.challengers) and not self._next_is_random:
             raise StopIteration
         elif self._next_is_random:
-            return self.configuration_space.sample()
+            self._next_is_random = False
+            config = self.configuration_space.sample_configuration()
+            config.origin = 'Random Search'
+            return config
         else:
+            self._next_is_random = True
             self._index += 1
             config = self.challengers[self._index - 1]
-            config.origin = 'Random Search'
             return config

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -344,6 +344,21 @@ class SMBO(BaseSolver):
 
 
 class ChallengerList(object):
+    """Helper class to interleave random configurations in a list of challengers.
+
+    Provides an iterator which returns a random configuration in each second
+    iteration. Reduces time necessary to generate a list of new challengers
+    as one does not need to sample several hundreds of random configurations
+    in each iteration which are never looked at.
+
+    Parameters
+    ----------
+    challengers : list
+        List of challengers (without interleaved random configurations)
+
+    configuration_space : ConfigurationSpace
+        ConfigurationSpace from which to sample new random configurations.
+    """
 
     def __init__(self, challengers, configuration_space):
         self.challengers = challengers

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -110,7 +110,7 @@ class TestSMBO(unittest.TestCase):
         smbo.runhistory.add(smbo.incumbent, 10, 10, 1)
 
         Y = self.branin(X)
-        x = smbo.choose_next(X, Y)[0].get_array()
+        x = next(smbo.choose_next(X, Y)).get_array()
         assert x.shape == (2,)
 
     def test_choose_next_2(self):
@@ -128,9 +128,11 @@ class TestSMBO(unittest.TestCase):
         X = smbo.rng.rand(10, 2)
         Y = smbo.rng.rand(10, 1)
 
-        x = smbo.choose_next(X, Y)
+        challengers = smbo.choose_next(X, Y)
+        x = [c for c in challengers]
 
         self.assertEqual(smbo.model.train.call_count, 1)
+
         self.assertEqual(len(x), 2002)
         num_random_search = 0
         num_local_search = 0
@@ -166,7 +168,8 @@ class TestSMBO(unittest.TestCase):
         X = smbo.rng.rand(10, 2)
         Y = smbo.rng.rand(10, 1)
 
-        x = smbo.choose_next(X, Y)
+        challengers = smbo.choose_next(X, Y)
+        x = [c for c in challengers]
 
         self.assertEqual(smbo.model.train.call_count, 1)
         self.assertEqual(len(x), 2020)


### PR DESCRIPTION
This pull request is work in progress and and right now just a proof of concept. I'll add unit tests and documentation if the general ideas is approved.

Currently, the challengers are all created before calling the intensify function. As each second challenger is random, a lot of random samples are wasted creating this list of challengers. This PR replaces the ordinary python list by a custom list/iterator. Instead of holding a list of random configurations, it has all non-random configurations and a configuration sampler. In each second iteration, instead of returning the next element from the list of challengers, it samples a new random configuration.

On the RF example, this reduced the time to obtain a new list of challengers from 0.0181 to 0.0121 seconds (improvement of ~30%).