### PR TITLE
Issue #52 make run_obj mandatory

### DIFF
--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -244,7 +244,7 @@ class Scenario(object):
         self.add_argument(name='paramfile', help=None, dest='pcs_fn',
                           mutually_exclusive_group='cs')
         self.add_argument(name='run_obj', help=None, default='runtime',
-                          required=True)
+                          required=True, choice=['runtime', 'quality'])
         self.add_argument(name='overall_obj', help=None, default='par10')
         self.add_argument(name='cost_for_crash', default=float(MAXINT),
                           help="Defines the cost-value for crashed runs "
@@ -258,8 +258,8 @@ class Scenario(object):
                           callback=float)
         self.add_argument(name='wallclock_limit', help=None, default=numpy.inf,
                           callback=float)
-        self.add_argument(name='always_race_default', 
-                          help="Race new incumbents always against default configuration", 
+        self.add_argument(name='always_race_default',
+                          help="Race new incumbents always against default configuration",
                           default=False,
                           callback=_is_truthy, dest="always_race_default")
         self.add_argument(name='runcount_limit', help=None, default=numpy.inf,

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -78,7 +78,7 @@ class Scenario(object):
         self._add_arguments()
 
         # Make cutoff mandatory if run_obj is runtime
-        if 'run_obj' in scenario and scenario['run_obj'] == 'runtime':
+        if scenario['run_obj'] == 'runtime':
             self._arguments['cutoff_time']['required'] = True
 
         # Parse arguments

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -77,6 +77,10 @@ class Scenario(object):
         self._groups = defaultdict(set)
         self._add_arguments()
 
+        # Make cutoff mandatory if run_obj is runtime
+        if 'run_obj' in scenario and scenario['run_obj'] == 'runtime':
+            self._arguments['cutoff_time']['required'] = True
+
         # Parse arguments
         parsed_arguments = {}
         for key, value in self._arguments.items():
@@ -239,7 +243,8 @@ class Scenario(object):
                           help=None, callback=float)
         self.add_argument(name='paramfile', help=None, dest='pcs_fn',
                           mutually_exclusive_group='cs')
-        self.add_argument(name='run_obj', help=None, default='runtime')
+        self.add_argument(name='run_obj', help=None, default='runtime',
+                          required=True)
         self.add_argument(name='overall_obj', help=None, default='par10')
         self.add_argument(name='cost_for_crash', default=float(MAXINT),
                           help="Defines the cost-value for crashed runs "

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -45,6 +45,7 @@ class TestIntensify(unittest.TestCase):
                                      values={'a': 100, 'b': 100})
 
         self.scen = Scenario({"cutoff_time": 2, 'cs': self.cs,
+                              "run_obj": 'runtime',
                               "output_dir": ''})
         self.stats = Stats(scenario=self.scen)
         self.stats.start_timing()

--- a/test/test_runhistory/test_runhistory2epm.py
+++ b/test/test_runhistory/test_runhistory2epm.py
@@ -47,9 +47,10 @@ class RunhistoryTest(unittest.TestCase):
         self.config3 = Configuration(self.cs,
                                      values={'a': 100, 'b': 100})
 
-        self.scen = Scenario({"cutoff_time": 20, 'cs': self.cs})
+        self.scen = Scenario({'run_obj': 'runtime', 'cutoff_time': 20,
+                              'cs': self.cs})
         self.types, self.bounds = get_types(self.cs, None)
-        self.scen = Scenario({"cutoff_time": 20, 'cs': self.cs,
+        self.scen = Scenario({'run_obj': 'runtime', 'cutoff_time': 20, 'cs': self.cs,
                               'output_dir': ''})
 
     def test_log_runtime_with_imputation(self):
@@ -279,8 +280,9 @@ class RunhistoryTest(unittest.TestCase):
         '''
             add some data to RH and check returned values in X,y format
         '''
-        
-        self.scen = Scenario({"cutoff_time": 20, 'cs': self.cs, 
+
+        self.scen = Scenario({'cutoff_time': 20, 'cs': self.cs,
+                              'run_obj': 'runtime', 
                               'instances': [['1'],['2']],
                               'features': {
                                   '1': [1,1],

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -296,7 +296,8 @@ class ScenarioTest(unittest.TestCase):
 
     def test_str_cast_instances(self):
         self.scen = Scenario({'cs': None,
-                              'instances': [[1], [2]]})
+                              'instances': [[1], [2]],
+                              'run_obj': 'quality'})
         self.assertIsInstance(self.scen.train_insts[0], str)
         self.assertIsInstance(self.scen.train_insts[1], str)
 

--- a/test/test_tae/test_exec_func.py
+++ b/test/test_tae/test_exec_func.py
@@ -17,6 +17,7 @@ class TestExecuteFunc(unittest.TestCase):
     def setUp(self):
         self.cs = ConfigurationSpace()
         self.scenario = Scenario({'cs': self.cs,
+                                  'run_obj': 'quality',
                                   'output_dir': ''})
         self.stats = Stats(scenario=self.scenario)
 

--- a/test/test_tae/test_exec_tae_run.py
+++ b/test/test_tae/test_exec_tae_run.py
@@ -41,7 +41,8 @@ class TaeTest(unittest.TestCase):
             testing exhausted budget
         '''
         # Set time-limit negative in scenario-options to trigger exception
-        scen = Scenario(scenario={'wallclock_limit': -1, 'cs': ConfigurationSpace(), 
+        scen = Scenario(scenario={'wallclock_limit': -1, 'cs': ConfigurationSpace(),
+                                  'run_obj': 'quality',
                                   'output_dir': ''}, cmd_args=None)
         stats = Stats(scen)
         stats.start_timing()
@@ -61,6 +62,7 @@ class TaeTest(unittest.TestCase):
         test_run.return_value = StatusType.ABORT, 12345.0, 1.2345, {}
 
         scen = Scenario(scenario={'cs': ConfigurationSpace(),
+                                  'run_obj': 'quality',
                                   'output_dir': ''}, cmd_args=None)
         stats = Stats(scen)
         stats.start_timing()
@@ -78,6 +80,7 @@ class TaeTest(unittest.TestCase):
         test_run.return_value = StatusType.CRASHED, 12345.0, 1.2345, {}
 
         scen = Scenario(scenario={'cs': ConfigurationSpace(),
+                                  'run_obj': 'quality',
                                   'output_dir': ''}, cmd_args=None)
         stats = Stats(scen)
         stats.start_timing()
@@ -142,7 +145,8 @@ class TaeTest(unittest.TestCase):
             test cost on crashed runs
         '''
         # Patch run-function for custom-return
-        scen = Scenario(scenario={'cs': ConfigurationSpace()}, cmd_args=None)
+        scen = Scenario(scenario={'cs': ConfigurationSpace(),
+                                  'run_obj': 'quality'}, cmd_args=None)
         stats = Stats(scen)
         stats.start_timing()
         stats.ta_runs += 1

--- a/test/test_tae/test_tae_aclib.py
+++ b/test/test_tae/test_tae_aclib.py
@@ -30,6 +30,7 @@ class TaeOldTest(unittest.TestCase):
             running some simple algo in aclib 2.0 style
         '''
         scen = Scenario(scenario={'cs': ConfigurationSpace(),
+                                  'run_obj': 'quality',
                                   'output_dir': ''}, cmd_args=None)
         stats = Stats(scen)
 

--- a/test/test_tae/test_tae_old.py
+++ b/test/test_tae/test_tae_old.py
@@ -30,6 +30,7 @@ class TaeOldTest(unittest.TestCase):
             running some simple algo in old style
         '''
         scen = Scenario(scenario={'cs': ConfigurationSpace(),
+                                  'run_obj': 'quality',
                                   'output_dir': ''}, cmd_args=None)
         stats = Stats(scen)
 

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -34,7 +34,8 @@ class TrajLoggerTest(unittest.TestCase):
         self.cs = ConfigurationSpace()
 
     def test_init(self):
-        scen = Scenario(scenario={'cs': self.cs, 'output_dir': ''}, cmd_args=None)
+        scen = Scenario(scenario={'run_obj': 'quality', 'cs': self.cs,
+                                  'output_dir': ''}, cmd_args=None)
         stats = Stats(scen)
         TrajLogger(output_dir='./tmp_test_folder', stats=stats)
         self.assertFalse(os.path.exists('smac3-output'))


### PR DESCRIPTION
Fixing issue #52, making run_obj mandatory and cutoff_time mandatory if run_obj is runtime.