### PR TITLE
Fix forest options

### DIFF
--- a/smac/epm/rf_with_instances.py
+++ b/smac/epm/rf_with_instances.py
@@ -62,7 +62,7 @@ class RandomForestWithInstances(AbstractEPM):
                  min_samples_leaf=3,
                  max_depth=20,
                  eps_purity=1e-8,
-                 max_num_nodes=1000,
+                 max_num_nodes=2**20,
                  seed=42,
                  **kwargs):
 
@@ -78,12 +78,12 @@ class RandomForestWithInstances(AbstractEPM):
         self.rf_opts.do_bootstrapping = do_bootstrapping
         max_features = 0 if ratio_features >= 1.0 else \
             max(1, int(types.shape[0] * ratio_features))
-        self.rf_opts.max_features = max_features
-        self.rf_opts.min_samples_to_split = min_samples_split
-        self.rf_opts.min_samples_in_leaf = min_samples_leaf
-        self.rf_opts.max_depth = max_depth
-        self.rf_opts.epsilon_purity = eps_purity
-        self.rf_opts.max_num_nodes = max_num_nodes
+        self.rf_opts.tree_opts.max_features = max_features
+        self.rf_opts.tree_opts.min_samples_to_split = min_samples_split
+        self.rf_opts.tree_opts.min_samples_in_leaf = min_samples_leaf
+        self.rf_opts.tree_opts.max_depth = max_depth
+        self.rf_opts.tree_opts.epsilon_purity = eps_purity
+        self.rf_opts.tree_opts.max_num_nodes = max_num_nodes
 
         self.n_points_per_tree = n_points_per_tree
         self.rf = None  # type: regression.binary_rss_forest

--- a/smac/epm/rf_with_instances.py
+++ b/smac/epm/rf_with_instances.py
@@ -76,7 +76,7 @@ class RandomForestWithInstances(AbstractEPM):
         self.rf_opts.num_trees = num_trees
         self.rf_opts.seed = seed
         self.rf_opts.do_bootstrapping = do_bootstrapping
-        max_features = 0 if ratio_features >= 1.0 else \
+        max_features = 0 if ratio_features > 1.0 else \
             max(1, int(types.shape[0] * ratio_features))
         self.rf_opts.tree_opts.max_features = max_features
         self.rf_opts.tree_opts.min_samples_to_split = min_samples_split

--- a/test/test_epm/test_rfr_with_instances.py
+++ b/test/test_epm/test_rfr_with_instances.py
@@ -148,7 +148,8 @@ class TestRFWithInstances(unittest.TestCase):
         # print(X.shape, y.shape)
         model = RandomForestWithInstances(types=np.array([0, 0, 0], dtype=np.uint),
                                           bounds=np.array([(0, np.nan), (0, np.nan), (0, np.nan)], dtype=object),
-                                          instance_features=None, seed=12345)
+                                          instance_features=None, seed=12345,
+                                          ratio_features=1.0)
         model.train(np.vstack((X, X, X, X, X, X, X, X)), np.vstack((y, y, y, y, y, y, y, y)))
         # for idx, x in enumerate(X):
         #     print(model.rf.all_leaf_values(x))

--- a/test/test_runhistory/test_runhistory2epm.py
+++ b/test/test_runhistory/test_runhistory2epm.py
@@ -62,7 +62,8 @@ class RunhistoryTest(unittest.TestCase):
                                         self.scen.cutoff * self.scen.par_factor),
                                     model=RandomForestWithInstances(types=self.types, bounds=self.bounds,
                                                                     instance_features=None,
-                                                                    seed=12345)
+                                                                    seed=12345,
+                                                                    ratio_features=1.0)
                                     )
 
         rh2epm = runhistory2epm.RunHistory2EPM4LogCost(num_params=2,
@@ -99,12 +100,13 @@ class RunhistoryTest(unittest.TestCase):
                     additional_info={"start_time": 10})
 
         X, y = rh2epm.transform(self.rh)
-        print(y)
-        self.assertTrue(np.allclose(
-            X, np.array([[0.005, 0.995], [0.995, 0.005], [0.995, 0.995]]), atol=0.001))
+        np.testing.assert_array_almost_equal(X, np.array([[0.005, 0.995],
+                                                          [0.995, 0.005],
+                                                          [0.995, 0.995]]),
+                                             decimal=3)
         # both timeouts should be imputed to a PAR10
-        self.assertTrue(
-            np.allclose(y, np.array([[0.], [2.301], [2.301]]), atol=0.001))
+        np.testing.assert_array_almost_equal(y, np.array([[0.], [2.301], [2.301]]),
+                                             decimal=3)
 
     def test_log_cost_without_imputation(self):
         '''
@@ -153,11 +155,13 @@ class RunhistoryTest(unittest.TestCase):
         '''
 
         self.imputor = RFRImputator(rs=np.random.RandomState(seed=12345),
+
                                     cutoff=self.scen.cutoff,
                                     threshold=self.scen.cutoff * self.scen.par_factor,
                                     model=RandomForestWithInstances(types=self.types, bounds=self.bounds,
                                                                     instance_features=None,
-                                                                    seed=12345, n_points_per_tree=90)
+                                                                    seed=12345, n_points_per_tree=90,
+                                                                    ratio_features=1.0)
                                     )
 
         rh2epm = runhistory2epm.RunHistory2EPM4Cost(num_params=2,
@@ -194,11 +198,12 @@ class RunhistoryTest(unittest.TestCase):
                     additional_info={"start_time": 10})
 
         X, y = rh2epm.transform(self.rh)
-        print(y)
-        self.assertTrue(np.allclose(
-            X, np.array([[0.005, 0.995], [0.995, 0.005], [0.995, 0.995]]), atol=0.001))
-        self.assertTrue(
-            np.allclose(y, np.array([[1.], [16.422], [200.]]), atol=0.001))
+        np.testing.assert_array_almost_equal(X, np.array([[0.005, 0.995],
+                                                          [0.995, 0.005],
+                                                          [0.995, 0.995]]),
+                                             decimal=3)
+        np.testing.assert_array_almost_equal(y, np.array([[1.], [16.422], [200.]]),
+                                             decimal=3)
 
     def test_cost_without_imputation(self):
         '''


### PR DESCRIPTION
Apparently, a lot of features which were so far passed to the random forest options object need to be passed to a tree options object. This PR does the necessary changes. Furthermore, as having only 1000 nodes per tree only allows to model ~3000 distinct values, I increased the number to ~1M nodes per tree. Please keep in mind that there was no limit at all so far.