### PR TITLE
ADD flat output folder hierarchy

### DIFF
--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -94,6 +94,8 @@ class SMAC(object):
         self.logger = logging.getLogger(
             self.__module__ + "." + self.__class__.__name__)
 
+        scenario.write()
+
         aggregate_func = average_cost
 
         # initialize stats object

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -108,12 +108,15 @@ class Scenario(object):
 
         if self.output_dir:
             self.output_dir = os.path.join(self.output_dir, "run%d"%(run_id))
-        self.out_writer.write_scenario_file(self)
 
         self.logger.debug("Scenario Options:")
         for arg_name, arg_value in parsed_arguments.items():
             if isinstance(arg_value,(int,str,float)):
                 self.logger.debug("%s = %s" %(arg_name,arg_value))
+
+    def write(self):
+        """ Write scenario to self.output_dir/scenario.txt. """
+        self.out_writer.write_scenario_file(self)
 
     def add_argument(self, name, help, callback=None, default=None,
                      dest=None, required=False, mutually_exclusive_group=None,
@@ -275,7 +278,7 @@ class Scenario(object):
                           default="smac3-output_%s" % (
                               datetime.datetime.fromtimestamp(
                                   time.time()).strftime(
-                                  '%Y-%m-%d_%H:%M:%S_(%f)')))
+                                  '%Y-%m-%d_%H:%M:%S_%f')))
         self.add_argument(name='input_psmac_dirs', help=None,
                           default=None)
         self.add_argument(name='shared_model', help=None, default='0',

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -8,7 +8,6 @@ import time
 import datetime
 import copy
 import typing
-import shutil
 
 from smac.utils.io.input_reader import InputReader
 from smac.utils.io.output_writer import OutputWriter
@@ -109,18 +108,6 @@ class Scenario(object):
 
         if self.output_dir:
             self.output_dir = os.path.join(self.output_dir, "run%d"%(run_id))
-            if os.path.exists(self.output_dir):
-                # Move old directory (without checking whether still used)
-                move_to = self.output_dir + ".OLD"
-                while os.path.exists(move_to):
-                    move_to += ".OLD"
-                os.mkdir(move_to)
-                for fn in os.listdir(self.output_dir):
-                    shutil.move(os.path.join(self.output_dir, fn),
-                                os.path.join(move_to, fn))
-            else:
-                os.makedirs(self.output_dir)
-
         self.out_writer.write_scenario_file(self)
 
         self.logger.debug("Scenario Options:")

--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -18,7 +18,7 @@ class OutputWriter(object):
     def write_scenario_file(self, scenario):
         """
             Write scenario to a file (format is compatible with input_reader).
-            Will overwrite if file exists.
+            If output_dir exists, move everything to output_dir.OLD.
             If you have arguments that need special parsing when saving, specify so
             in the _parse_argument-function.
 
@@ -30,6 +30,7 @@ class OutputWriter(object):
             Sideeffects:
             ----------
                 - creates output-directory if it doesn't exist.
+                - if it does, move everything to output.OLD
 
             Returns:
             ----------
@@ -48,6 +49,15 @@ class OutputWriter(object):
             except OSError:
                 raise OSError("Could not make output directory: "
                               "{}.".format(scenario.output_dir))
+        else:
+            # Move old directory (without checking whether still used)
+            move_to = scenario.output_dir + ".OLD"
+            while os.path.exists(move_to):
+                move_to += ".OLD"
+            os.mkdir(move_to)
+            for fn in os.listdir(scenario.output_dir):
+                shutil.move(os.path.join(scenario.output_dir, fn),
+                            os.path.join(move_to, fn))
 
         # options_dest2name maps scenario._arguments from dest -> name
         options_dest2name = {(scenario._arguments[v]['dest'] if

--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -55,9 +55,7 @@ class OutputWriter(object):
             while os.path.exists(move_to):
                 move_to += ".OLD"
             os.mkdir(move_to)
-            for fn in os.listdir(scenario.output_dir):
-                shutil.move(os.path.join(scenario.output_dir, fn),
-                            os.path.join(move_to, fn))
+            shutil.move(scenario.output_dir, move_to, fn)
 
         # options_dest2name maps scenario._arguments from dest -> name
         options_dest2name = {(scenario._arguments[v]['dest'] if

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -10,6 +10,7 @@ import logging
 import unittest
 import pickle
 import copy
+import shutil
 
 import numpy as np
 
@@ -71,6 +72,7 @@ class ScenarioTest(unittest.TestCase):
 
     def tearDown(self):
         os.chdir(self.current_dir)
+        shutil.rmtree(self.test_scenario_dict['output_dir'], ignore_errors=True)
 
     def test_Exception(self):
         with self.assertRaises(TypeError):

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -250,6 +250,7 @@ class ScenarioTest(unittest.TestCase):
         # First check with file-paths defined
         self.test_scenario_dict['feature_file'] = 'test/test_files/scenario_test/features_multiple.txt'
         scenario = Scenario(self.test_scenario_dict)
+        scenario.write()
         path = os.path.join(scenario.output_dir, 'scenario.txt')
         scenario_reloaded = Scenario(path)
         check_scen_eq(scenario, scenario_reloaded)
@@ -270,11 +271,13 @@ class ScenarioTest(unittest.TestCase):
         patch_isdir.return_value = False
         patch_mkdirs.side_effect = OSError()
         with self.assertRaises(OSError) as cm:
-            Scenario(self.test_scenario_dict)
+            scen = Scenario(self.test_scenario_dict)
+            scen.write()
 
     def test_no_output_dir(self):
         self.test_scenario_dict['output_dir'] = ""
         scenario = Scenario(self.test_scenario_dict)
+        scenario.write()
         self.assertFalse(scenario.out_writer.write_scenario_file(scenario))
 
     def test_par_factor(self):


### PR DESCRIPTION
Introducing output folder hierarchy as specified by @KEggensperger in issue #240:

> We introduce a flat folder hierarchy. If the user does not specifie otherwise a SMAC experiment will have the following structure:
> 
> smac_<date>/run_<run_id>/*.json
> 
> The user can specify a output directory, e.g. ./myExperiment or ./myExperiment/ which results in:
> 
> ./myExperiment/run_<run_id>/*.json
> 
> If smac is about to write to an already existing directory, smac will move the folder (without checking whether other processes still use that folder):
> 
> ./myExperiment/run_<run_id>/*.json -> ./myExperiment/run_<run_id>.OLD/*.json
> 
> if run_<run_id>.OLD already exists, then another .OLD is appended (run_<run_id>.OLD.OLD)