### PR TITLE
FIX consider crashed runs for qual scenarios since cost_for_crash avail

### DIFF
--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -280,7 +280,8 @@ class SMAC(object):
             elif scenario.run_obj == 'quality':
                 runhistory2epm = RunHistory2EPM4Cost(scenario=scenario, num_params=num_params,
                                                      success_states=[
-                                                         StatusType.SUCCESS, ],
+                                                         StatusType.SUCCESS, 
+                                                         StatusType.CRASHED],
                                                      impute_censored_data=False, impute_state=None)
 
             else:

--- a/smac/runhistory/runhistory2epm.py
+++ b/smac/runhistory/runhistory2epm.py
@@ -223,6 +223,7 @@ class AbstractRunHistory2EPM(object):
             X = np.vstack((X, tX))
             Y = np.concatenate((Y, tY))
 
+        self.logger.debug("Converted %d observations" %(X.shape[0]))
         return X, Y
 
     def get_X_y(self, runhistory: RunHistory):


### PR DESCRIPTION
FIX consider crashed runs for qual scenarios since cost_for_crash avail

* ADD one further debug output to get some feedback runhistory2epm 