### PR TITLE
Maint/abstract ta func wo pynisher

### DIFF
--- a/smac/tae/execute_func.py
+++ b/smac/tae/execute_func.py
@@ -1,6 +1,7 @@
 import logging
 import inspect
 import math
+import time
 
 import numpy as np
 import pynisher
@@ -24,16 +25,44 @@ class AbstractTAFunc(ExecuteTARun):
     Attributes
     ----------
     memory_limit
+    use_pynisher
     """
 
-    def __init__(self, ta, stats=None, runhistory=None, run_obj="quality",
-                 memory_limit=None, par_factor=1, cost_for_crash=float(MAXINT)):
+    def __init__(self, ta, stats=None, runhistory=None, run_obj:str="quality",
+                 memory_limit:int=None, par_factor:int=1, 
+                 cost_for_crash:float=float(MAXINT),
+                 use_pynisher:bool=True):
 
         super().__init__(ta=ta, stats=stats, runhistory=runhistory,
                          run_obj=run_obj, par_factor=par_factor,
                          cost_for_crash=cost_for_crash)
         """
-        TODO
+        Abstract class for having a function as target algorithm
+        
+        Parameters
+        ----------
+        ta : callable
+            Function (target algorithm) to be optimized.
+        stats: Stats()
+             stats object to collect statistics about runtime and so on
+        runhistory: RunHistory
+            runhistory to keep track of all runs; only used if set
+        run_obj: str
+            run objective of SMAC
+        memory_limit : int, optional
+            Memory limit (in MB) that will be applied to the target algorithm.
+        par_factor: int
+            penalization factor
+        cost_for_crash : float
+            cost that is used in case of crashed runs (including runs
+            that returned NaN or inf)
+        use_pynisher: bool
+            use pynisher to limit resources; 
+            if disabled
+              * TA func can use as many resources 
+              as it wants (time and memory) --- use with caution
+              * all runs will be returned as SUCCESS if returned value is not None
+            
         """
 
         signature = inspect.signature(ta).parameters
@@ -43,6 +72,8 @@ class AbstractTAFunc(ExecuteTARun):
         if memory_limit is not None:
             memory_limit = int(math.ceil(memory_limit))
         self.memory_limit = memory_limit
+        
+        self.use_pynisher = use_pynisher
 
     def run(self, config, instance=None,
             cutoff=None,
@@ -90,37 +121,52 @@ class AbstractTAFunc(ExecuteTARun):
                      'wall_time_in_s': cutoff,
                      'mem_in_mb': self.memory_limit}
 
-        obj = pynisher.enforce_limits(**arguments)(self.ta)
-
         obj_kwargs = {}
         if self._accepts_seed:
             obj_kwargs['seed'] = seed
         if self._accepts_instance:
             obj_kwargs['instance'] = instance
 
-        rval = self._call_ta(obj, config, **obj_kwargs)
+        if self.use_pynisher:
 
-        if isinstance(rval, tuple):
-            result = rval[0]
-            additional_run_info = rval[1]
+            obj = pynisher.enforce_limits(**arguments)(self.ta)
+    
+            rval = self._call_ta(obj, config, **obj_kwargs)
+    
+            if isinstance(rval, tuple):
+                result = rval[0]
+                additional_run_info = rval[1]
+            else:
+                result = rval
+                additional_run_info = {}
+    
+            if obj.exit_status is pynisher.TimeoutException:
+                status = StatusType.TIMEOUT
+                cost = self.crash_cost
+            elif obj.exit_status is pynisher.MemorylimitException:
+                status = StatusType.MEMOUT
+                cost = self.crash_cost
+            elif obj.exit_status == 0 and result is not None:
+                status = StatusType.SUCCESS
+                cost = result
+            else:
+                status = StatusType.CRASHED
+                cost = self.crash_cost
+        
+            runtime = float(obj.wall_clock_time)
         else:
-            result = rval
+            start_time = time.time()
+            result = self.ta(config, **obj_kwargs)
+            
+            if result is not None:
+                status = StatusType.SUCCESS
+                cost = result
+            else:
+                status = StatusType.CRASHED
+                cost = self.crash_cost
+            
+            runtime = time.time() - start_time
             additional_run_info = {}
-
-        if obj.exit_status is pynisher.TimeoutException:
-            status = StatusType.TIMEOUT
-            cost = 1234567890
-        elif obj.exit_status is pynisher.MemorylimitException:
-            status = StatusType.MEMOUT
-            cost = 1234567890
-        elif obj.exit_status == 0 and result is not None:
-            status = StatusType.SUCCESS
-            cost = result
-        else:
-            status = StatusType.CRASHED
-            cost = 1234567890  # won't be used for the model
-
-        runtime = float(obj.wall_clock_time)
 
         return status, cost, runtime, additional_run_info
 

--- a/test/test_tae/test_exec_func.py
+++ b/test/test_tae/test_exec_func.py
@@ -52,6 +52,29 @@ class TestExecuteFunc(unittest.TestCase):
         self.assertEqual(rval[1], 4)
         self.assertGreaterEqual(rval[2], 0.0)
         self.assertEqual(rval[3], {'key': 12345, 'instance': 'test'})
+        
+    
+    def test_run_wo_pynisher(self):
+        target = lambda x: x**2
+        taf = ExecuteTAFuncDict(ta=target, stats=self.stats, use_pynisher=False)
+        rval = taf.run(config=2)
+        self.assertFalse(taf._accepts_instance)
+        self.assertFalse(taf._accepts_seed)
+        self.assertEqual(rval[0], StatusType.SUCCESS)
+        self.assertEqual(rval[1], 4)
+        self.assertGreaterEqual(rval[2], 0.0)
+        self.assertEqual(rval[3], dict())
+
+        target = lambda x: None
+        taf = ExecuteTAFuncDict(ta=target, stats=self.stats, use_pynisher=False)
+        rval = taf.run(config=2)
+        self.assertFalse(taf._accepts_instance)
+        self.assertFalse(taf._accepts_seed)
+        self.assertEqual(rval[0], StatusType.CRASHED)
+        self.assertEqual(rval[1], 2147483647.0)
+        self.assertGreaterEqual(rval[2], 0.0)
+        self.assertEqual(rval[3], dict())
+
 
     @unittest.mock.patch.object(Configuration, 'get_dictionary')
     def test_run_execute_func_for_fmin(self, mock):
@@ -79,7 +102,7 @@ class TestExecuteFunc(unittest.TestCase):
         print(platform, sys.platform)
         if platform == 'linux':
             self.assertEqual(rval[0], StatusType.MEMOUT)
-            self.assertEqual(rval[1], 1234567890)
+            self.assertEqual(rval[1], 2147483647.0)
             self.assertGreaterEqual(rval[2], 0.0)
             self.assertEqual(rval[3], dict())
         elif platform == 'osx':
@@ -96,7 +119,7 @@ class TestExecuteFunc(unittest.TestCase):
         taf = ExecuteTAFuncDict(ta=run_over_time, stats=self.stats)
         rval = taf.run(config=None, cutoff=1)
         self.assertEqual(rval[0], StatusType.TIMEOUT)
-        self.assertEqual(rval[1], 1234567890)
+        self.assertEqual(rval[1], 2147483647.0)
         self.assertGreaterEqual(rval[2], 0.0)
         self.assertEqual(rval[3], dict())
 
@@ -119,6 +142,6 @@ class TestExecuteFunc(unittest.TestCase):
         taf = ExecuteTAFuncDict(ta=function, stats=self.stats)
         rval = taf.run(config=None, cutoff=1)
         self.assertEqual(rval[0], StatusType.CRASHED)
-        self.assertEqual(rval[1], 1234567890)
+        self.assertEqual(rval[1], 2147483647.0)
         self.assertGreaterEqual(rval[2], 0.0)
         self.assertEqual(rval[3], dict())


### PR DESCRIPTION
Sometimes, I want to be able to deactivate the pynisher, e.g., to return a non-pickable object (which does not work with the pynisher). Therefore, I added an argument to disable the pynisher for `AbstractTAFunc`.