### PR TITLE
Feat names

### DIFF
--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -396,8 +396,9 @@ class Scenario(object):
         # read feature file
         if self.feature_fn:
             if os.path.isfile(self.feature_fn):
-                self.feature_dict = self.in_reader.read_instance_features_file(
-                    self.feature_fn)[1]
+                features = self.in_reader.read_instance_features_file(
+                    self.feature_fn)
+                self.feature_names, self.feature_dict = features
 
         if self.feature_dict:
             self.feature_array = []

--- a/smac/utils/io/input_reader.py
+++ b/smac/utils/io/input_reader.py
@@ -153,7 +153,7 @@ class InputReader(object):
             for line in lines[1:]:
                 tmp = line.strip().split(",")
                 instances[tmp[0]] = np.array(tmp[1:], dtype=np.double)
-        return lines[0].split(",")[1:], instances
+        return [f.strip() for f in lines[0].rstrip("\n").split(",")[1:]], instances
 
     def read_pcs_file(self, fn: str):
         """Encapsulates generating configuration space object

--- a/test/test_files/features_example.csv
+++ b/test/test_files/features_example.csv
@@ -1,0 +1,4 @@
+instance,feature1, feature2, feature3
+inst1,1.0,2.0, 3.0
+inst2,1.5,2.5 ,3.5
+inst3,1.7, 1.8,1.9

--- a/test/test_files/train_insts_example.txt
+++ b/test/test_files/train_insts_example.txt
@@ -1,0 +1,3 @@
+inst1
+inst2
+inst3

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -309,6 +309,14 @@ class ScenarioTest(unittest.TestCase):
         scen = scen.write_options_to_doc(path)
         self.assertTrue(os.path.exists(path))
 
+    def test_features(self):
+        scenario = Scenario(self.test_scenario_dict,
+                            cmd_args={'feature_file':
+                                      'test/test_files/features_example.csv',
+                                      'instance_file':
+                                      'test/test_files/train_insts_example.txt'})
+        self.assertEquals(scenario.feature_names,
+                          ['feature1', 'feature2', 'feature3'])
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_utils/io/test_inputreader.py
+++ b/test/test_utils/io/test_inputreader.py
@@ -1,0 +1,39 @@
+'''
+Created on Oct 16, 2017
+
+@author: Joshua Marben
+'''
+import os
+import unittest
+import logging
+
+import numpy as np
+
+from smac.utils.io.input_reader import InputReader
+
+
+class InputReaderTest(unittest.TestCase):
+
+    def setUp(self):
+        logging.basicConfig()
+        self.logger = logging.getLogger(self.__module__ + "." + self.__class__.__name__)
+        self.logger.setLevel(logging.DEBUG)
+        self.current_dir = os.getcwd()
+        base_directory = os.path.split(__file__)[0]
+        base_directory = os.path.abspath(os.path.join(base_directory, '..',
+                                                      '..', '..'))
+        os.chdir(base_directory)
+
+    def tearDown(self):
+        os.chdir(self.current_dir)
+
+    def test_feature_input(self):
+        feature_fn = "test/test_files/features_example.csv"
+        in_reader = InputReader()
+        feats = in_reader.read_instance_features_file(fn=feature_fn)
+        self.assertEqual(feats[0], ["feature1", "feature2", "feature3"])
+        feats_original = {"inst1":[1.0, 2.0, 3.0],
+                          "inst2":[1.5, 2.5, 3.5],
+                          "inst3":[1.7, 1.8, 1.9]}
+        for i in feats[1]:
+            self.assertEqual(feats_original[i], list(feats[1][i]))


### PR DESCRIPTION
This PR strips whitespaces and \n-ewlines from the feature-names in the input-reader.

Does anyone object to saving feature names in scenario-object as `scenario.feature_names`?