### PR TITLE
Make sure that installed ConfigSpace version is <0.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
-# 0.7
+# 0.7.2
+
+* Introduce version upper bound on ConfigSpace dependency (<0.4)
+
+# 0.7.1
 
 * FIX #193, restoring the scenario now possible
 * ADD #271 validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ scipy>=0.18.1
 six
 psutil
 pynisher>=0.4.1
-ConfigSpace>=0.3.8
+ConfigSpace>=0.3.8,<0.4
 scikit-learn>=0.18.0
 typing
 pyrfr>=0.5.0

--- a/smac/__version__.py
+++ b/smac/__version__.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.7.1"
+__version__ = "0.7.2"


### PR DESCRIPTION
Necessary to safely release a new version of the ConfigSpace which is not backwards compatible.