### PR TITLE
Increase number of random configs for EI optimization

### DIFF
--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -162,7 +162,6 @@ class SMBO(object):
         self.start()
 
         # Main BO loop
-        iteration = 1
         while True:
             if self.scenario.shared_model:
                 pSMAC.read(run_history=self.runhistory,
@@ -193,8 +192,6 @@ class SMBO(object):
                 pSMAC.write(run_history=self.runhistory,
                             output_directory=self.scenario.output_dir)
 
-            iteration += 1
-
             logging.debug("Remaining budget: %f (wallclock), %f (ta costs), %f (target runs)" % (
                 self.stats.get_remaing_time_budget(),
                 self.stats.get_remaining_ta_budget(),
@@ -208,7 +205,7 @@ class SMBO(object):
         return self.incumbent
 
     def choose_next(self, X: np.ndarray, Y: np.ndarray,
-                    num_configurations_by_random_search_sorted: int=1000,
+                    num_configurations_by_random_search_sorted: int=5000,
                     num_configurations_by_local_search: int=None,
                     incumbent_value: float=None):
         """Choose next candidate solution with Bayesian optimization.

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -147,7 +147,7 @@ class TestSMBO(unittest.TestCase):
 
         self.assertEqual(smbo.model.train.call_count, 1)
 
-        self.assertEqual(len(x), 2002)
+        self.assertEqual(len(x), 10002)
         num_random_search = 0
         num_local_search = 0
         for i in range(0, 2002, 2):
@@ -186,10 +186,10 @@ class TestSMBO(unittest.TestCase):
         x = [c for c in challengers]
 
         self.assertEqual(smbo.model.train.call_count, 1)
-        self.assertEqual(len(x), 2020)
+        self.assertEqual(len(x), 10020)
         num_random_search = 0
         num_local_search = 0
-        for i in range(0, 2020, 2):
+        for i in range(0, 10020, 2):
             # print(x[i].origin)
             self.assertIsInstance(x[i], Configuration)
             if 'Random Search (sorted)' in x[i].origin:


### PR DESCRIPTION
As the sampling for random configuration is about 10 times faster (at least for Auto-sklearn) with the latest ConfigSpace, increasing this number should be a safe thing to do.