### PR TITLE
fix bug in uncorrelated_mo_rf_with_instances, improve tests

### DIFF
--- a/smac/epm/uncorrelated_mo_rf_with_instances.py
+++ b/smac/epm/uncorrelated_mo_rf_with_instances.py
@@ -3,6 +3,8 @@ import numpy as np
 from smac.epm.base_epm import AbstractEPM
 from smac.epm.rf_with_instances import RandomForestWithInstances
 
+from typing import List, Dict, Any, Optional
+
 
 class UncorrelatedMultiObjectiveRandomForestWithInstances(AbstractEPM):
 
@@ -20,8 +22,14 @@ class UncorrelatedMultiObjectiveRandomForestWithInstances(AbstractEPM):
     estimators
     """
 
-    def __init__(self, target_names, bounds: np.ndarray, types: np.ndarray,
-                 **kwargs):
+    def __init__(
+            self,
+            target_names: List[str],
+            bounds: np.ndarray,
+            types: np.ndarray,
+            rf_kwargs: Optional[Dict[str, Any]]=None,
+            **kwargs
+    ):
         """Constructor
 
         Parameters
@@ -40,10 +48,12 @@ class UncorrelatedMultiObjectiveRandomForestWithInstances(AbstractEPM):
             See :class:`~smac.epm.rf_with_instances.RandomForestWithInstances` documentation.
         """
         super().__init__(**kwargs)
+        if rf_kwargs is None:
+            rf_kwargs = {}
         
         self.target_names = target_names
         self.num_targets = len(self.target_names)
-        self.estimators = [RandomForestWithInstances(types, bounds, **kwargs)
+        self.estimators = [RandomForestWithInstances(types, bounds, **rf_kwargs)
                            for i in range(self.num_targets)]
 
     def _train(self, X: np.ndarray, Y: np.ndarray, **kwargs):

--- a/test/test_epm/test_uncorrelated_mo_rf_with_instances.py
+++ b/test/test_epm/test_uncorrelated_mo_rf_with_instances.py
@@ -19,10 +19,18 @@ class TestUncorrelatedMultiObjectiveWrapper(unittest.TestCase):
         X = rs.rand(20, 10)
         Y = rs.rand(10, 2)
         model = UncorrelatedMultiObjectiveRandomForestWithInstances(
-            ['cost', 'ln(runtime)'], types=np.zeros((10, ), dtype=np.uint), bounds=np.array([
+            ['cost', 'ln(runtime)'],
+            types=np.zeros((10, ), dtype=np.uint),
+            bounds=np.array([
                 (0, np.nan), (0, np.nan), (0, np.nan), (0, np.nan), (0, np.nan),
                 (0, np.nan), (0, np.nan), (0, np.nan), (0, np.nan), (0, np.nan)
-            ], dtype=object))
+            ], dtype=object),
+            rf_kwargs={'seed': 1},
+            pca_components=5
+        )
+        self.assertEqual(model.estimators[0].seed, 1)
+        self.assertEqual(model.estimators[1].seed, 1)
+        self.assertEqual(model.pca_components, 5)
         model.train(X[:10], Y)
         m, v = model.predict(X[10:])
         self.assertEqual(m.shape, (10, 2))
@@ -46,10 +54,13 @@ class TestUncorrelatedMultiObjectiveWrapper(unittest.TestCase):
         X = rs.rand(20, 10)
         Y = rs.rand(10, 3)
         model = UncorrelatedMultiObjectiveRandomForestWithInstances(
-            ['cost', 'ln(runtime)', 'foo'], types=np.zeros((10,), dtype=np.uint), bounds=np.array([
+            ['cost', 'ln(runtime)', 'foo'],
+            types=np.zeros((10,), dtype=np.uint),
+            bounds=np.array([
                 (0, np.nan), (0, np.nan), (0, np.nan), (0, np.nan), (0, np.nan),
                 (0, np.nan), (0, np.nan), (0, np.nan), (0, np.nan), (0, np.nan)
-            ], dtype=object))
+            ], dtype=object),
+        )
 
         model.train(X[:10], Y[:10])
         m_hat, v_hat = model.predict(X[10:])


### PR DESCRIPTION
It appears that the previous implementation expected the `BaseEPM` and the `RandomForestWithInstances` to accept the same arguments. This is apparently wrong and fixed in this PR.