### PR TITLE
new output structure

### DIFF
--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -113,7 +113,7 @@ class SMAC(object):
         self.logger = logging.getLogger(
             self.__module__ + "." + self.__class__.__name__)
 
-        scenario.output_writer.write_scenario_file(scenario)
+        scenario.write()
 
         aggregate_func = average_cost
 

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -113,8 +113,6 @@ class SMAC(object):
         self.logger = logging.getLogger(
             self.__module__ + "." + self.__class__.__name__)
 
-        scenario.write()
-
         aggregate_func = average_cost
 
         # initialize stats object

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -113,6 +113,8 @@ class SMAC(object):
         self.logger = logging.getLogger(
             self.__module__ + "." + self.__class__.__name__)
 
+        scenario.output_writer.write_scenario_file(scenario)
+
         aggregate_func = average_cost
 
         # initialize stats object

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -122,6 +122,9 @@ class Scenario(object):
                 while (os.path.exists(move_to)):
                     move_to += ".OLD"
                 shutil.move(self.output_dir, move_to)
+                self.logger.warning("Output directory \"%s\" already exists! "
+                                    "Moving old folder to \"%s\".",
+                                    self.output_dir, move_to)
 
         self.write()
 

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -8,6 +8,7 @@ import time
 import datetime
 import copy
 import typing
+import shutil
 
 from smac.utils.io.input_reader import InputReader
 from smac.utils.io.output_writer import OutputWriter
@@ -44,7 +45,11 @@ class Scenario(object):
     """
 
     def __init__(self, scenario, cmd_args: dict=None, run_id: int=1):
-        """Constructor
+        """ Creates a scenario-object. The output_dir will be
+        "output_dir/run_id/" and if that exists already, the old folder and its
+        content will be moved (without any checks on whether it's still used by
+        another process) to "output_dir/run_id.OLD". If that exists, ".OLD"s
+        will be appended until possible.
 
         Parameters
         ----------
@@ -112,6 +117,13 @@ class Scenario(object):
 
         if self.output_dir:
             self.output_dir = os.path.join(self.output_dir, "run_%d"%(run_id))
+            if os.path.exists(self.output_dir):
+                move_to = self.output_dir + ".OLD"
+                while (os.path.exists(move_to)):
+                    move_to += ".OLD"
+                shutil.move(self.output_dir, move_to)
+
+        self.write()
 
         self.logger.debug("Scenario Options:")
         for arg_name, arg_value in parsed_arguments.items():

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -113,8 +113,6 @@ class Scenario(object):
         if self.output_dir:
             self.output_dir += "_run%d" %(run_id)
 
-        self.out_writer.write_scenario_file(self)
-
         self.logger.debug("Scenario Options:")
         for arg_name, arg_value in parsed_arguments.items():
             if isinstance(arg_value,(int,str,float)):

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -116,7 +116,7 @@ class Scenario(object):
         self._transform_arguments()
 
         if self.output_dir:
-            self.output_dir = os.path.join(self.output_dir, "run_%d"%(run_id))
+            self.output_dir = os.path.join(self.output_dir, "run_%d" % (run_id))
             if os.path.exists(self.output_dir):
                 move_to = self.output_dir + ".OLD"
                 while (os.path.exists(move_to)):

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -54,7 +54,7 @@ class Scenario(object):
         cmd_args : dict
             Command line arguments that were not processed by argparse
         run_id: int
-            Run ID will be used as suffix for output_dir
+            Run ID will be used as subfolder for output_dir
         """
         self.logger = logging.getLogger(
             self.__module__ + '.' + self.__class__.__name__)
@@ -111,7 +111,7 @@ class Scenario(object):
         self._transform_arguments()
 
         if self.output_dir:
-            self.output_dir += "_run%d" %(run_id)
+            self.output_dir = os.path.join(self.output_dir, "run_%d"%(run_id))
 
         self.logger.debug("Scenario Options:")
         for arg_name, arg_value in parsed_arguments.items():
@@ -318,7 +318,7 @@ class Scenario(object):
                           default="smac3-output_%s" % (
                               datetime.datetime.fromtimestamp(
                                   time.time()).strftime(
-                                  '%Y-%m-%d_%H:%M:%S_(%f)')))
+                                  '%Y-%m-%d_%H:%M:%S_%f')))
         self.add_argument(name='input_psmac_dirs', default=None,
                           help="For parallel SMAC, multiple output-directories "
                                "are used.")
@@ -455,6 +455,10 @@ class Scenario(object):
         if warn_:
             self.logger.warn("All instances were casted to str.")
         return l
+
+    def write(self):
+        """ Write scenario to self.output_dir/scenario.txt. """
+        self.out_writer.write_scenario_file(self)
 
     def write_options_to_doc(self, path='scenario_options.rst'):
         """Writes the option-list to file for autogeneration in documentation.

--- a/smac/smac_cli.py
+++ b/smac/smac_cli.py
@@ -57,10 +57,26 @@ class SMACCLI(object):
         # remove default handler
         root_logger.removeHandler(root_logger.handlers[0])
 
+        # Create defaults
+        rh = None
+        initial_configs = None
+        stats = None
+        incumbent = None
+
+        # Restore state (needs to be before scenario-creation!)
+        if args_.restore_state:
+            root_logger.debug("Restoring state from %s...", args_.restore_state)
+            rh, stats, traj_list_aclib, traj_list_old = self.restore_state_before_scen(args_)
+
+        # Create scenario-object
         scen = Scenario(args_.scenario_file, misc_args,
                         run_id=args_.seed)
 
-        rh = None
+        # Restore state (continued, needs to be after scenario-creation!)
+        if args_.restore_state:
+            stats, incumbent = self.restore_state_after_scen(scen, stats,
+                                           traj_list_aclib, traj_list_old)
+
         if args_.warmstart_runhistory:
             aggregate_func = average_cost
             rh = RunHistory(aggregate_func=aggregate_func)
@@ -73,7 +89,6 @@ class SMACCLI(object):
                 cs=scen.cs,
                 aggregate_func=aggregate_func)
 
-        initial_configs = None
         if args_.warmstart_incumbent:
             initial_configs = [scen.cs.get_default_configuration()]
             for traj_fn in args_.warmstart_incumbent:
@@ -81,12 +96,6 @@ class SMACCLI(object):
                     fn=traj_fn, cs=scen.cs)
                 initial_configs.append(trajectory[-1]["incumbent"])
 
-        # Restore state
-        stats = None
-        incumbent = None
-        if args_.restore_state:
-            root_logger.debug("Restoring state from %s...", args_.restore_state)
-            rh, stats, incumbent = self.restore_state(args_, scen, root_logger)
 
         if args_.mode == "SMAC":
             optimizer = SMAC(
@@ -113,29 +122,50 @@ class SMACCLI(object):
         except (TAEAbortException, FirstRunCrashedException) as err:
             self.logger.error(err)
 
-    def restore_state(self, args_, scen, root_logger):
+    def restore_state_before_scen(self, args_):
+        """Read in files for state-restoration: runhistory, stats, trajectory.
+        """
+        # Construct dummy-scenario for object-creation (mainly cs is needed)
+        tmp_scen = InputReader().read_scenario_file(args_.scenario_file)
+        tmp_scen = Scenario(tmp_scen, cmd_args={'output_dir':''})
         # Check for folder and files
         rh_path = os.path.join(args_.restore_state, "runhistory.json")
         stats_path = os.path.join(args_.restore_state, "stats.json")
-        traj_path = os.path.join(args_.restore_state, "traj_aclib2.json")
+        traj_path_aclib = os.path.join(args_.restore_state, "traj_aclib2.json")
+        traj_path_old = os.path.join(args_.restore_state, "traj_old.csv")
         scen_path = os.path.join(args_.restore_state, "scenario.txt")
         if not os.path.isdir(args_.restore_state):
            raise FileNotFoundError("Could not find folder from which to restore.")
         # Load runhistory and stats
         rh = RunHistory(aggregate_func=None)
-        rh.load_json(rh_path, scen.cs)
-        root_logger.debug("Restored runhistory from %s", rh_path)
-        stats = Stats(scen)
+        rh.load_json(rh_path, tmp_scen.cs)
+        self.logger.debug("Restored runhistory from %s", rh_path)
+        stats = Stats(tmp_scen)  # Need to inject actual scenario later for output_dir!
         stats.load(stats_path)
-        root_logger.debug("Restored stats from %s", stats_path)
-        trajectory = TrajLogger.read_traj_aclib_format(
-            fn=traj_path, cs=scen.cs)
+        self.logger.debug("Restored stats from %s", stats_path)
+        with open(traj_path_aclib, 'r') as traj_fn:
+            traj_list_aclib = traj_fn.readlines()
+        with open(traj_path_old, 'r') as traj_fn:
+            traj_list_old = traj_fn.readlines()
+        return rh, stats, traj_list_aclib, traj_list_old
+
+    def restore_state_after_scen(self, scen, stats, traj_list_aclib,
+                                 traj_list_old):
+        """Finish processing files for state-restoration. The actual scenario
+        needs to be injected into stats, as well as the trajectory dealt with
+        (it is read in, but needs to be written to new output-folder after
+        scenario is constructed."""
+        stats.scenario = scen  # inject actual scen for output_dir
+        # write trajectory-list
+        traj_path_aclib = os.path.join(scen.output_dir, "traj_aclib2.json")
+        traj_path_old = os.path.join(scen.output_dir, "traj_old.csv")
+        with open(traj_path_aclib, 'w') as traj_fn:
+            traj_fn.writelines(traj_list_aclib)
+        with open(traj_path_old, 'w') as traj_fn:
+            traj_fn.writelines(traj_list_old)
+        # read trajectory to retrieve incumbent
+        trajectory = TrajLogger.read_traj_aclib_format(fn=traj_path_aclib, cs=scen.cs)
         incumbent = trajectory[-1]["incumbent"]
-        root_logger.debug("Restored incumbent %s from %s", incumbent, traj_path)
-        # Copy traj if output_dir of specified scenario-file is different than
-        # the output_dir of the scenario-file in the folder from which to restore.
-        if scen.output_dir != InputReader().read_scenario_file(scen_path)['output_dir']:
-            new_traj_path = os.path.join(scen.output_dir, "traj_aclib2.json")
-            shutil.copy(traj_path, new_traj_path)
-            root_logger.debug("Copied traj %s", rh_path)
-        return rh, stats, incumbent
+        self.logger.debug("Restored incumbent %s from %s", incumbent,
+                          traj_path_aclib)
+        return stats, incumbent

--- a/smac/stats/stats.py
+++ b/smac/stats/stats.py
@@ -55,6 +55,9 @@ class Stats(object):
         """
         Save all relevant attributes to json-dictionary.
         """
+        if not self.__scenario.output_dir:
+            self._logger.debug("No scenario.output_dir: not saving stats!")
+            return
         # Set used_wallclock_time
         self.wallclock_time_used = self.get_used_wallclock_time()
 

--- a/test/test_cli/test_restore_state.py
+++ b/test/test_cli/test_restore_state.py
@@ -4,10 +4,7 @@ import shutil
 
 import numpy as np
 
-if sys.version_info[0] == 2:
-    import mock
-else:
-    from unittest import mock
+from unittest import mock
 
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter
 
@@ -28,12 +25,14 @@ class TestSMACCLI(unittest.TestCase):
         self.scenario_one = "test/test_files/restore_scenario_one.txt"
         self.scenario_two = "test/test_files/restore_scenario_two.txt"
 
+    def tearDown(self):
+        shutil.rmtree(self.output_one, ignore_errors=True)
+        shutil.rmtree(self.output_two, ignore_errors=True)
+
     def test_run_and_restore(self):
         """
         Testing basic restore functionality.
         """
-        shutil.rmtree(self.output_one, ignore_errors=True)
-        shutil.rmtree(self.output_two, ignore_errors=True)
         # Run for 5 algo-calls
         testargs = ["python", "scripts/smac", "--scenario_file",
                     self.scenario_one, "--verbose", "DEBUG"]
@@ -73,3 +72,20 @@ class TestSMACCLI(unittest.TestCase):
         smac = SMAC(scen, restore_incumbent=incumbent,
                     rng=np.random.RandomState(42))
         self.assertRaises(ValueError, smac.optimize)
+
+    def test_same_dir(self):
+        """
+        Testing possible error using same dir for restore
+        """
+        # Run for 5 algo-calls
+        testargs = ["python", "scripts/smac", "--scenario_file",
+                    self.scenario_one, "--verbose", "DEBUG"]
+        with mock.patch.object(sys, 'argv', testargs):
+            self.smaccli.main_cli()
+        # Increase limit and run for 10 (so 5 more) by using restore_state
+        testargs = ["python", "scripts/smac", "--restore_state",
+                    self.output_one, "--scenario_file",
+                    self.scenario_one, "--verbose", "DEBUG"]
+        with mock.patch.object(sys, 'argv', testargs):
+            self.smaccli.main_cli()
+

--- a/test/test_cli/test_restore_state.py
+++ b/test/test_cli/test_restore_state.py
@@ -22,10 +22,8 @@ from smac.stats.stats import Stats
 class TestSMACCLI(unittest.TestCase):
 
     def setUp(self):
-        # TODO after merging PR #264 (flat folder hierarchy), this will fail.
-        # simply adjust path and remove this note
-        self.output_one = "test/test_files/test_restore_state_run1"  # From scenario_one.txt
-        self.output_two = "test/test_files/test_restored_state_run1" # From scenario_two.txt
+        self.output_one = "test/test_files/test_restore_state/run_1"  # From scenario_one.txt
+        self.output_two = "test/test_files/test_restored_state/run_1" # From scenario_two.txt
         self.smaccli = SMACCLI()
         self.scenario_one = "test/test_files/restore_scenario_one.txt"
         self.scenario_two = "test/test_files/restore_scenario_two.txt"

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -10,6 +10,7 @@ import logging
 import unittest
 import pickle
 import copy
+import shutil
 
 import numpy as np
 
@@ -317,6 +318,33 @@ class ScenarioTest(unittest.TestCase):
                                       'test/test_files/train_insts_example.txt'})
         self.assertEquals(scenario.feature_names,
                           ['feature1', 'feature2', 'feature3'])
+
+    def test_output_structure(self):
+        """Test whether output-dir is moved correctly."""
+        scen1 = Scenario(self.test_scenario_dict)
+        self.assertEqual(scen1.output_dir, os.path.join(
+                         self.test_scenario_dict['output_dir'], 'run_1'))
+        self.assertTrue(os.path.isdir(scen1.output_dir))
+
+        scen2 = Scenario(self.test_scenario_dict)
+        self.assertTrue(os.path.isdir(scen2.output_dir+'.OLD'))
+
+        scen3 = Scenario(self.test_scenario_dict)
+        self.assertTrue(os.path.isdir(scen3.output_dir+'.OLD.OLD'))
+
+        scen4 = Scenario(self.test_scenario_dict, run_id=2)
+        self.assertEqual(scen4.output_dir, os.path.join(
+                         self.test_scenario_dict['output_dir'], 'run_2'))
+        self.assertTrue(os.path.isdir(scen4.output_dir))
+        self.assertFalse(os.path.isdir(scen4.output_dir+'.OLD.OLD.OLD'))
+
+        # clean up (at least whats not cleaned up by tearDown)
+        shutil.rmtree(scen1.output_dir+'.OLD.OLD')
+        shutil.rmtree(scen1.output_dir+'.OLD')
+
+    def tearDown(self):
+        shutil.rmtree(self.test_scenario_dict['output_dir'], ignore_errors=True)
+        os.chdir(self.current_dir)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -327,20 +327,20 @@ class ScenarioTest(unittest.TestCase):
         self.assertTrue(os.path.isdir(scen1.output_dir))
 
         scen2 = Scenario(self.test_scenario_dict)
-        self.assertTrue(os.path.isdir(scen2.output_dir+'.OLD'))
+        self.assertTrue(os.path.isdir(scen2.output_dir + '.OLD'))
 
         scen3 = Scenario(self.test_scenario_dict)
-        self.assertTrue(os.path.isdir(scen3.output_dir+'.OLD.OLD'))
+        self.assertTrue(os.path.isdir(scen3.output_dir + '.OLD.OLD'))
 
         scen4 = Scenario(self.test_scenario_dict, run_id=2)
         self.assertEqual(scen4.output_dir, os.path.join(
                          self.test_scenario_dict['output_dir'], 'run_2'))
         self.assertTrue(os.path.isdir(scen4.output_dir))
-        self.assertFalse(os.path.isdir(scen4.output_dir+'.OLD.OLD.OLD'))
+        self.assertFalse(os.path.isdir(scen4.output_dir + '.OLD.OLD.OLD'))
 
         # clean up (at least whats not cleaned up by tearDown)
-        shutil.rmtree(scen1.output_dir+'.OLD.OLD')
-        shutil.rmtree(scen1.output_dir+'.OLD')
+        shutil.rmtree(scen1.output_dir + '.OLD.OLD')
+        shutil.rmtree(scen1.output_dir + '.OLD')
 
     def tearDown(self):
         shutil.rmtree(self.test_scenario_dict['output_dir'], ignore_errors=True)


### PR DESCRIPTION
Finally fixing issue #240.
Quoting from issue:

> We introduce a flat folder hierarchy. If the user does not specifie otherwise a SMAC experiment will have the following structure:
> 
> smac_<date>/run_<run_id>/*.json
> 
> The user can specify a output directory, e.g. ./myExperiment or ./myExperiment/ which results in:
> 
> ./myExperiment/run_<run_id>/*.json
> 
> If smac is about to write to an already existing directory, smac will move the folder (without checking whether other processes still use that folder):
> 
> ./myExperiment/run_<run_id>/*.json -> ./myExperiment/run_<run_id>.OLD/*.json
> 
> if run_<run_id>.OLD already exists, then another .OLD is appended (run_<run_id>.OLD.OLD)

Minor changes:
- stats now only saved if output-dir available
- restore-state now two functions (because of dependencies on scenario-creation)
- smac-cli slightly rearranged due to restore-state