### PR TITLE
Generalize acquisition function

### DIFF
--- a/smac/optimizer/acquisition.py
+++ b/smac/optimizer/acquisition.py
@@ -1,9 +1,13 @@
 # encoding=utf8
 import abc
 import logging
-from scipy.stats import norm
-import numpy as np
+from typing import List
 
+import numpy as np
+from scipy.stats import norm
+
+from smac.configspace import Configuration
+from smac.configspace.util import convert_configurations_to_array
 from smac.epm.base_epm import AbstractEPM
 
 __author__ = "Aaron Klein, Marius Lindauer"
@@ -52,22 +56,21 @@ class AbstractAcquisitionFunction(object, metaclass=abc.ABCMeta):
         for key in kwargs:
             setattr(self, key, kwargs[key])
 
-    def __call__(self, X: np.ndarray):
+    def __call__(self, configurations: List[Configuration]):
         """Computes the acquisition value for a given X
 
         Parameters
         ----------
-        X : np.ndarray
-            The input points where the acquisition function
-            should be evaluated. The dimensionality of X is (N, D), with N as
-            the number of points to evaluate at and D is the number of
-            dimensions of one X.
+        configurations : list
+            The configurations where the acquisition function
+            should be evaluated. 
 
         Returns
         -------
         np.ndarray(N, 1)
             acquisition values for X
         """
+        X = convert_configurations_to_array(configurations)
         if len(X.shape) == 1:
             X = X[np.newaxis, :]
 

--- a/smac/optimizer/ei_optimization.py
+++ b/smac/optimizer/ei_optimization.py
@@ -120,8 +120,7 @@ class AcquisitionFunctionMaximizer(object, metaclass=abc.ABCMeta):
                 ordered by their acquisition function value
         """
 
-        config_array = convert_configurations_to_array(configs)
-        acq_values = self.acquisition_function(config_array)
+        acq_values = self.acquisition_function(configs)
 
         # From here
         # http://stackoverflow.com/questions/20197990/how-to-make-argsort-result-to-be-random-between-equal-values
@@ -261,8 +260,7 @@ class LocalSearch(AcquisitionFunctionMaximizer):
 
         incumbent = start_point
         # Compute the acquisition value of the incumbent
-        incumbent_array = convert_configurations_to_array([incumbent])
-        acq_val_incumbent = self.acquisition_function(incumbent_array, *args)[0]
+        acq_val_incumbent = self.acquisition_function([incumbent], *args)[0]
 
         local_search_steps = 0
         neighbors_looked_at = 0
@@ -287,12 +285,8 @@ class LocalSearch(AcquisitionFunctionMaximizer):
 
             for neighbor in all_neighbors:
                 s_time = time.time()
-                neighbor_array_ = convert_configurations_to_array([neighbor])
-
-                acq_val = self.acquisition_function(neighbor_array_, *args)
-
+                acq_val = self.acquisition_function([neighbor], *args)
                 neighbors_looked_at += 1
-
                 time_n.append(time.time() - s_time)
 
                 if acq_val > acq_val_incumbent + self.epsilon:

--- a/smac/optimizer/ei_optimization.py
+++ b/smac/optimizer/ei_optimization.py
@@ -226,6 +226,10 @@ class LocalSearch(AcquisitionFunctionMaximizer):
             )
         else:
             num_configurations_by_local_search = num_points
+        num_configurations_by_local_search = min(
+            stats.ta_runs,
+            num_configurations_by_local_search
+        )
         return num_configurations_by_local_search
 
     def _get_initial_points(self, num_configurations_by_local_search,

--- a/smac/optimizer/ei_optimization.py
+++ b/smac/optimizer/ei_optimization.py
@@ -195,7 +195,8 @@ class LocalSearch(AcquisitionFunctionMaximizer):
         """
 
         num_configurations_by_local_search = self._calculate_num_points(
-            num_points, stats)
+            num_points, stats, runhistory
+        )
         init_points = self._get_initial_points(
             num_configurations_by_local_search, runhistory)
         configs_acq = []
@@ -216,7 +217,7 @@ class LocalSearch(AcquisitionFunctionMaximizer):
 
         return configs_acq
 
-    def _calculate_num_points(self, num_points, stats):
+    def _calculate_num_points(self, num_points, stats, runhistory):
         if stats._ema_n_configs_per_intensifiy > 0:
             num_configurations_by_local_search = (
                 min(
@@ -227,7 +228,7 @@ class LocalSearch(AcquisitionFunctionMaximizer):
         else:
             num_configurations_by_local_search = num_points
         num_configurations_by_local_search = min(
-            stats.ta_runs,
+            len(runhistory.data),
             num_configurations_by_local_search
         )
         return num_configurations_by_local_search

--- a/smac/optimizer/epils.py
+++ b/smac/optimizer/epils.py
@@ -264,8 +264,7 @@ class EPILS_Solver(object):
             all_neighbors = list(get_one_exchange_neighbourhood(
                 incumbent, seed=self.rng.seed()))
 
-            neighbors_array = convert_configurations_to_array(all_neighbors)
-            acq_val = self.acquisition_func(neighbors_array)
+            acq_val = self.acquisition_func(all_neighbors)
             
             sorted_neighbors = sorted(zip(all_neighbors, acq_val), key=lambda x: x[1], reverse=True)
             prev_incumbent = incumbent

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -6,7 +6,6 @@ import typing
 
 from smac.configspace import Configuration, ConfigurationSpace
 from smac.tae.execute_ta_run import StatusType
-from smac.utils.constants import MAXINT
 
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2015, ML4AAD"

--- a/test/test_smbo/test/traj_old.csv
+++ b/test/test_smbo/test/traj_old.csv
@@ -1,0 +1,1 @@
+"CPU Time Used","Estimated Training Performance","Wallclock Time","Incumbent ID","Automatic Configurator (CPU) Time","Configuration..."

--- a/test/test_smbo/test_acquisition.py
+++ b/test/test_smbo/test_acquisition.py
@@ -1,8 +1,20 @@
 import unittest
+import unittest.mock
 
 import numpy as np
 
 from smac.optimizer.acquisition import EI, LogEI
+
+
+class ConfigurationMock(object):
+
+    def __init__(self, values=None):
+        self.values = values
+        self.configuration_space = unittest.mock.MagicMock()
+        self.configuration_space.get_hyperparameters.return_value = []
+
+    def get_array(self):
+        return self.values
 
 
 class MockModel(object):
@@ -23,17 +35,17 @@ class TestEI(unittest.TestCase):
 
     def test_1xD(self):
         self.ei.update(model=self.model, eta=1.0)
-        X = np.array([[1.0, 1.0, 1.0]])
-        acq = self.ei(X)
+        configurations = [ConfigurationMock([1.0, 1.0, 1.0])]
+        acq = self.ei(configurations)
         self.assertEqual(acq.shape, (1, 1))
         self.assertAlmostEqual(acq[0][0], 0.3989422804014327)
 
     def test_NxD(self):
         self.ei.update(model=self.model, eta=1.0)
-        X = np.array([[0.0, 0.0, 0.0],
-                      [0.1, 0.1, 0.1],
-                      [1.0, 1.0, 1.0]])
-        acq = self.ei(X)
+        configurations = ([ConfigurationMock([0.0, 0.0, 0.0]),
+                           ConfigurationMock([0.1, 0.1, 0.1]),
+                           ConfigurationMock([1.0, 1.0, 1.0])])
+        acq = self.ei(configurations)
         self.assertEqual(acq.shape, (3, 1))
         self.assertAlmostEqual(acq[0][0], 0.0)
         self.assertAlmostEqual(acq[1][0], 0.90020601136712231)
@@ -41,17 +53,17 @@ class TestEI(unittest.TestCase):
 
     def test_1x1(self):
         self.ei.update(model=self.model, eta=1.0)
-        X = np.array([[1.0]])
-        acq = self.ei(X)
+        configurations = [ConfigurationMock([1.0])]
+        acq = self.ei(configurations)
         self.assertEqual(acq.shape, (1, 1))
         self.assertAlmostEqual(acq[0][0], 0.3989422804014327)
 
     def test_Nx1(self):
         self.ei.update(model=self.model, eta=1.0)
-        X = np.array([[0.0001],
-                      [1.0],
-                      [2.0]])
-        acq = self.ei(X)
+        configurations = [ConfigurationMock([0.0001]),
+                          ConfigurationMock([1.0]),
+                          ConfigurationMock([2.0])]
+        acq = self.ei(configurations)
         self.assertEqual(acq.shape, (3, 1))
         self.assertAlmostEqual(acq[0][0], 0.9999)
         self.assertAlmostEqual(acq[1][0], 0.3989422804014327)
@@ -70,17 +82,17 @@ class TestLogEI(unittest.TestCase):
         
     def test_1xD(self):
         self.ei.update(model=self.model, eta=1.0)
-        X = np.array([[1.0, 1.0, 1.0]])
-        acq = self.ei(X)
+        configurations = [ConfigurationMock([1.0, 1.0, 1.0])]
+        acq = self.ei(configurations)
         self.assertEqual(acq.shape, (1, 1))
         self.assertAlmostEqual(acq[0][0], 0.056696236230553559)
         
     def test_NxD(self):
         self.ei.update(model=self.model, eta=1.0)
-        X = np.array([[0.0, 0.0, 0.0],
-                      [0.1, 0.1, 0.1],
-                      [1.0, 1.0, 1.0]])
-        acq = self.ei(X)
+        configurations = [ConfigurationMock([0.0, 0.0, 0.0]),
+                          ConfigurationMock([0.1, 0.1, 0.1]),
+                          ConfigurationMock([1.0, 1.0, 1.0])]
+        acq = self.ei(configurations)
         self.assertEqual(acq.shape, (3, 1))
         self.assertAlmostEqual(acq[0][0], 0.0)
         self.assertAlmostEqual(acq[1][0], 0.069719643222631633)


### PR DESCRIPTION
Instead of accepting a numpy array, the acquisition function is now
called with a list of configurations, giving the user more flexibility
what to do with that in the acquisition function calculation.