### PR TITLE
travis-ci: install different compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ matrix:
 
   include:
   - os: linux
-    env: PYTHON_VERSION="3.4" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86_64.sh"
+    env: PYTHON_VERSION="3.4" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
   - os: linux
-    env: PYTHON_VERSION="3.5" COVERAGE="true" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86_64.sh"
+    env: PYTHON_VERSION="3.5" COVERAGE="true" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
   - os: linux
-    env: PYTHON_VERSION="3.6" COVERAGE="true" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86_64.sh"
+    env: PYTHON_VERSION="3.6" COVERAGE="true" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
 
   # Disable OSX building because it takes too long and hinders progress
   # Set language to generic to not break travis-ci
@@ -43,11 +43,9 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - if [[ `which conda` ]]; then echo 'Conda installation successful'; else exit 1; fi
-  - conda create -n testenv --yes python=$PYTHON_VERSION pip wheel nose
+  - conda create -n testenv --yes python=$PYTHON_VERSION pip wheel nose gxx_linux-64 gcc_linux-64 swig
   - source activate testenv
-  - conda install --yes gcc swig
   - echo "Using GCC at "`which gcc`
-  - export CC=`which gcc`
 
 install:
   - pip install pep8 codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
 
   include:
   - os: linux
-    env: PYTHON_VERSION="3.4" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
-  - os: linux
     env: PYTHON_VERSION="3.5" COVERAGE="true" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
   - os: linux
     env: PYTHON_VERSION="3.6" COVERAGE="true" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
@@ -15,10 +13,6 @@ matrix:
   # https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-195620855
   # so far, this issue is still open and there is no good solution
   # python will then be installed by anaconda
-  #- os: osx
-  #  sudo: required
-  #  language: generic
-  #  env: PYTHON_VERSION="3.4" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-4.3.21-MacOSX-x86_64.sh"
   #- os: osx
   #  sudo: required
   #  language: generic
@@ -45,7 +39,6 @@ before_install:
   - if [[ `which conda` ]]; then echo 'Conda installation successful'; else exit 1; fi
   - conda create -n testenv --yes python=$PYTHON_VERSION pip wheel nose gxx_linux-64 gcc_linux-64 swig
   - source activate testenv
-  - echo "Using GCC at "`which gcc`
 
 install:
   - pip install pep8 codecov

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Status for development branch
 
 # OVERVIEW
 
-SMAC is a tool for algorithm configuration 
-to optimize the parameters of arbitrary algorithms across a set of instances.
-This also includes hyperparameter optimization of ML algorithms.
-The main core consists of Bayesian Optimization in combination with a simple racing mechanism to
+SMAC is a tool for algorithm configuration to optimize the parameters of
+arbitrary algorithms across a set of instances. This also includes
+hyperparameter optimization of ML algorithms. The main core consists of
+Bayesian Optimization in combination with a simple racing mechanism to
 efficiently decide which of two configuration performs better.
 
 For a detailed description of its main idea,
@@ -35,12 +35,14 @@ we refer to
     In: Proceedings of the conference on Learning and Intelligent OptimizatioN (LION 5)
 
 
-SMAC v3 is written in python3 and continuously tested with python3.4 and python3.5. 
-Its [Random Forest](https://bitbucket.org/aadfreiburg/random_forest_run) is written in C++.
+SMAC v3 is written in python3 and continuously tested with python3.4 and
+python3.5. Its [Random Forest](https://bitbucket.org/aadfreiburg/random_forest_run)
+is written in C++.
 
 # Installation
 
-Besides the listed requirements (see `requirements.txt`), the random forest used in SMAC3 requires SWIG (>= 3.0).
+Besides the listed requirements (see `requirements.txt`), the random forest
+used in SMAC3 requires SWIG (>= 3.0).
 
 	apt-get install swig 
 
@@ -48,9 +50,10 @@ Besides the listed requirements (see `requirements.txt`), the random forest used
     
     python setup.py install
     
-If you use Anaconda as your Python environment, you have to install two packages before you can install SMAC:
+If you use Anaconda as your Python environment, you have to install three
+packages before you can install SMAC:
 
-	conda install gcc swig
+	conda install gxx_linux-64 gcc_linux-64 swig
     
 # License
 
@@ -68,15 +71,18 @@ If not, see <https://opensource.org/licenses/BSD-3-Clause>.
 # USAGE
 
 The usage of SMAC v3 is mainly the same as provided with [SMAC v2.08](http://www.cs.ubc.ca/labs/beta/Projects/SMAC/v2.08.00/manual.pdf).
-It supports the same parameter configuration space syntax and interface to target algorithms.
-Please note that we do not support the extended parameter configuration syntax introduced in SMACv2.10.
+It supports the same parameter configuration space syntax and interface to
+target algorithms. Please note that we do not support the extended parameter
+configuration syntax introduced in SMACv2.10.
 
 # Examples
 
 See examples/
 
-  * examples/rosenbrock.py - example on how to optimize a Python function (REQUIRES [PYNISHER](https://github.com/sfalkner/pynisher) )
-  * examples/spear_qcp/run.sh - example on how to optimize the SAT solver Spear on a set of SAT formulas
+  * examples/rosenbrock.py - example on how to optimize a Python function
+    (REQUIRES [PYNISHER](https://github.com/sfalkner/pynisher) )
+  * examples/spear_qcp/run.sh - example on how to optimize the SAT solver Spear
+    on a set of SAT formulas
  
 # Contact
  

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
     - sudo -E apt-get -yq update
     - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra
     # Conda installation
-    - wget http://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86_64.sh -O ~/miniconda.sh
+    - wget "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O ~/miniconda.sh
     - bash ~/miniconda.sh -b -p $HOME/miniconda
     - conda create -n testenv --yes python=3.6 pip wheel nose gxx_linux-64 gcc_linux-64 swig
 

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ dependencies:
     # Conda installation
     - wget http://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86_64.sh -O ~/miniconda.sh
     - bash ~/miniconda.sh -b -p $HOME/miniconda
-    - conda create -n testenv --yes python=3.6 pip wheel nose gcc swig
+    - conda create -n testenv --yes python=3.6 pip wheel nose gxx_linux-64 gcc_linux-64 swig
 
   # The --user is needed to let sphinx see the source and the binaries
   # The pipefail is requested to propagate exit code

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -8,13 +8,15 @@ or try to run the installation first.
 
 .. rubric:: pyrfr raises cryptic import errors.
 
-Ensure that the gcc used to compile the pyrfr is the same as used for linking during execution.
-This often happens with Anaconda -- see `Installation <installation.html>`_ for a solution.
+Ensure that the gcc used to compile the pyrfr is the same as used for linking
+during execution. This often happens with Anaconda -- see
+`Installation <installation.html>`_ for a solution.
 
 .. rubric:: My target algorithm is not accepted, when using the scenario-file.
 
-Make sure that your algorithm accepts commandline options as provided by *SMAC*.
-Refer to `commandline execution <basic_usage.html#commandline>`_ for details on how to wrap your algorithm.
+Make sure that your algorithm accepts commandline options as provided by
+*SMAC*. Refer to `commandline execution <basic_usage.html#commandline>`_ for
+details on how to wrap your algorithm.
 
 You can also run SMAC with :code:`--verbose DEBUG` to see how *SMAC* tried to call your algorithm.
 
@@ -22,12 +24,15 @@ You can also run SMAC with :code:`--verbose DEBUG` to see how *SMAC* tried to ca
 
 Use the `restore-option <basic_usage.html#restorestate>`_.
 
-.. rubric:: I discovered a bug/have criticism or ideas on *SMAC*. Where should I report to?
+.. rubric:: I discovered a bug/have criticism or ideas on *SMAC*. Where should
+I report to?
 
-*SMAC* uses the `GitHub issue-tracker <https://github.com/automl/SMAC3/issues>`_ to take care of bugs and questions. If you
-experience problems with *SMAC*, try to provide a full error report with all the
-typical information (OS, version, console-output, minimum working example, ...).
-This makes it a lot easier to reproduce the error and locate the problem.
+*SMAC* uses the
+`GitHub issue-tracker <https://github.com/automl/SMAC3/issues>`_ to take care
+of bugs and questions. If you experience problems with *SMAC*, try to provide
+a full error report with all the typical information (OS, version,
+console-output, minimum working example, ...). This makes it a lot easier to
+reproduce the error and locate the problem.
 
 
 .. rubric:: **Glossary**

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -16,17 +16,18 @@ please call:
     sudo apt-get install build-essential swig
 
 If you use Anaconda, you have to install both gcc and SWIG from Anaconda to
-prevent broken links:
+prevent compilation errors:
 
 .. code-block:: bash
 
-    conda install gcc swig
+    conda install gxx_linux-64 gcc_linux-64 swig
 
 .. _installation_pypi:
 
 Installation from pypi
 ----------------------
-To install SMAC3 from pypi, please use the following command on the command line:
+To install SMAC3 from pypi, please use the following command on the command
+line:
 
 .. code-block:: bash
 
@@ -39,7 +40,8 @@ permissions), please add the option :code:`--user` or create a virtualenv.
 
 Manual Installation
 -------------------
-To install SMAC3 from command line, please type the following commands on the command line
+To install SMAC3 from command line, please type the following commands on the
+command line:
 
 .. code-block:: bash
 


### PR DESCRIPTION
I know, it's failing right now, but I got the tests for python3.5 and python3.6 running again. I don't know how to get 3.4 running with Anaconda, though. Therefore, I propose to drop python3.4 support/testing and move on.

@KEggensperger @mlindauer @AndreBiedenkapp 

If you agree, I will remove python3.4 from the tests.

Here's a blog post explaining the changes: https://www.anaconda.com/blog/developer-blog/utilizing-the-new-compilers-in-anaconda-distribution-5/