### PR TITLE
Do not pass run_id to scenario file

### DIFF
--- a/smac/facade/epils_facade.py
+++ b/smac/facade/epils_facade.py
@@ -30,6 +30,7 @@ from smac.epm.base_epm import AbstractEPM
 from smac.utils.util_funcs import get_types
 from smac.utils.io.traj_logging import TrajLogger
 from smac.utils.constants import MAXINT
+from smac.utils.io.output_directory import create_output_directory
 from smac.configspace import Configuration
 
 
@@ -62,7 +63,8 @@ class EPILS(object):
                  initial_design: InitialDesign=None,
                  initial_configurations: typing.List[Configuration]=None,
                  stats: Stats=None,
-                 rng: np.random.RandomState=None):
+                 rng: np.random.RandomState=None,
+                 run_id: int=1):
         """Constructor
 
         Parameters
@@ -98,6 +100,8 @@ class EPILS(object):
             optional stats object
         rng: np.random.RandomState
             Random number generator
+        run_id: int, (default: 1)
+            Run ID will be used as subfolder for output_dir.
         """
         self.logger = logging.getLogger(
             self.__module__ + "." + self.__class__.__name__)
@@ -109,6 +113,9 @@ class EPILS(object):
             self.stats = stats
         else:
             self.stats = Stats(scenario)
+
+        self.output_dir = create_output_directory(scenario, run_id)
+        scenario.write()
 
         # initialize empty runhistory
         if runhistory is None:
@@ -126,7 +133,7 @@ class EPILS(object):
 
         # initial Trajectory Logger
         traj_logger = TrajLogger(
-            output_dir=scenario.output_dir, stats=self.stats)
+            output_dir=self.output_dir, stats=self.stats)
 
         # initial EPM
         types, bounds = get_types(scenario.cs, scenario.feature_array)
@@ -361,10 +368,10 @@ class EPILS(object):
             self.runhistory = self.solver.runhistory
             self.trajectory = self.solver.intensifier.traj_logger.trajectory
 
-            if self.solver.scenario.output_dir is not None:
+            if self.output_dir is not None:
                 self.solver.runhistory.save_json(
-                    fn=os.path.join(self.solver.scenario.output_dir,
-                                    "runhistory.json"))
+                    fn=os.path.join(self.output_dir, "runhistory.json")
+                )
         return incumbent
 
     def get_tae_runner(self):

--- a/smac/facade/roar_facade.py
+++ b/smac/facade/roar_facade.py
@@ -40,7 +40,8 @@ class ROAR(SMAC):
                  initial_design: InitialDesign=None,
                  initial_configurations: typing.List[Configuration]=None,
                  stats: Stats=None,
-                 rng: np.random.RandomState=None):
+                 rng: np.random.RandomState=None,
+                 run_id: int=1):
         """Constructor
 
         Parameters
@@ -67,6 +68,8 @@ class ROAR(SMAC):
             optional stats object
         rng: np.random.RandomState
             Random number generator
+        run_id: int, (default: 1)
+            Run ID will be used as subfolder for output_dir.
         """
         self.logger = logging.getLogger(self.__module__ + "." + self.__class__.__name__)
 

--- a/smac/optimizer/epils.py
+++ b/smac/optimizer/epils.py
@@ -208,7 +208,7 @@ class EPILS_Solver(object):
 
             if self.scenario.shared_model:
                 pSMAC.write(run_history=self.runhistory,
-                            output_directory=self.scenario.output_dir,
+                            output_directory=self.stats.output_dir,
                             num_run=self.num_run)
                 
             iteration += 1

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -193,7 +193,7 @@ class SMBO(object):
 
             if self.scenario.shared_model:
                 pSMAC.write(run_history=self.runhistory,
-                            output_directory=self.scenario.output_dir)
+                            output_directory=self.stats.output_dir)
 
             logging.debug("Remaining budget: %f (wallclock), %f (ta costs), %f (target runs)" % (
                 self.stats.get_remaing_time_budget(),
@@ -281,9 +281,9 @@ class SMBO(object):
         runhistory: RunHistory
             runhistory containing all specified runs
         """
-        traj_fn = os.path.join(self.scenario.output_dir, "traj_aclib2.json")
+        traj_fn = os.path.join(self.scenario.output_dir_for_this_run, "traj_aclib2.json")
         trajectory = TrajLogger.read_traj_aclib_format(fn=traj_fn, cs=self.scenario.cs)
-        new_rh_path = os.path.join(self.scenario.output_dir, "validated_runhistory.json")
+        new_rh_path = os.path.join(self.scenario.output_dir_for_this_run, "validated_runhistory.json")
 
         validator = Validator(self.scenario, trajectory, new_rh_path, self.rng)
         if use_epm:

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -193,7 +193,7 @@ class SMBO(object):
 
             if self.scenario.shared_model:
                 pSMAC.write(run_history=self.runhistory,
-                            output_directory=self.stats.output_dir)
+                            output_directory=self.scenario.output_dir_for_this_run)
 
             logging.debug("Remaining budget: %f (wallclock), %f (ta costs), %f (target runs)" % (
                 self.stats.get_remaing_time_budget(),

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -8,7 +8,6 @@ import time
 import datetime
 import copy
 import typing
-import shutil
 
 from smac.utils.io.input_reader import InputReader
 from smac.utils.io.output_writer import OutputWriter
@@ -44,7 +43,7 @@ class Scenario(object):
 
     """
 
-    def __init__(self, scenario, cmd_args: dict=None, run_id: int=1):
+    def __init__(self, scenario, cmd_args: dict=None):
         """ Creates a scenario-object. The output_dir will be
         "output_dir/run_id/" and if that exists already, the old folder and its
         content will be moved (without any checks on whether it's still used by
@@ -58,8 +57,6 @@ class Scenario(object):
             If dict, it will be directly to get all scenario related information
         cmd_args : dict
             Command line arguments that were not processed by argparse
-        run_id: int
-            Run ID will be used as subfolder for output_dir
         """
         self.logger = logging.getLogger(
             self.__module__ + '.' + self.__class__.__name__)
@@ -67,6 +64,8 @@ class Scenario(object):
 
         self.in_reader = InputReader()
         self.out_writer = OutputWriter()
+
+        self.output_dir_for_this_run = None
 
         if type(scenario) is str:
             scenario_fn = scenario
@@ -114,19 +113,6 @@ class Scenario(object):
             setattr(self, arg_name, arg_value)
 
         self._transform_arguments()
-
-        if self.output_dir:
-            self.output_dir = os.path.join(self.output_dir, "run_%d" % (run_id))
-            if os.path.exists(self.output_dir):
-                move_to = self.output_dir + ".OLD"
-                while (os.path.exists(move_to)):
-                    move_to += ".OLD"
-                shutil.move(self.output_dir, move_to)
-                self.logger.warning("Output directory \"%s\" already exists! "
-                                    "Moving old folder to \"%s\".",
-                                    self.output_dir, move_to)
-
-        self.write()
 
         self.logger.debug("Scenario Options:")
         for arg_name, arg_value in parsed_arguments.items():

--- a/smac/stats/stats.py
+++ b/smac/stats/stats.py
@@ -33,6 +33,8 @@ class Stats(object):
         Parameters
         ----------
         scenario : Scenario
+
+        output_dir : str
         """
         self.__scenario = scenario
 
@@ -55,7 +57,7 @@ class Stats(object):
         """
         Save all relevant attributes to json-dictionary.
         """
-        if not self.__scenario.output_dir:
+        if not self.__scenario.output_dir_for_this_run:
             self._logger.debug("No scenario.output_dir: not saving stats!")
             return
         # Set used_wallclock_time
@@ -67,7 +69,9 @@ class Stats(object):
             if not v in ['_Stats__scenario', '_logger', '_start_time']:
                 data[v] = getattr(self, v)
 
-        path = os.path.join(self.__scenario.output_dir, "stats.json")
+        path = os.path.join(
+            self.__scenario.output_dir_for_this_run, "stats.json"
+        )
         self._logger.debug("Saving stats to %s", path)
         with open(path, 'w') as fh:
             json.dump(data, fh)
@@ -83,7 +87,9 @@ class Stats(object):
             in the current scenario is used.
         """
         if not fn:
-            fn = os.path.join(self.__scenario.output_dir, "stats.json")
+            fn = os.path.join(
+                self.__scenario.output_dir_for_this_run, "stats.json"
+            )
         with open(fn, 'r') as fh:
             data = json.load(fh)
 

--- a/smac/utils/io/output_directory.py
+++ b/smac/utils/io/output_directory.py
@@ -1,0 +1,45 @@
+from logging import Logger
+
+import os
+import shutil
+
+from smac.scenario.scenario import Scenario
+
+
+def create_output_directory(
+        scenario: Scenario,
+        run_id: int,
+        logger: Logger=None,
+):
+    """Create output directory for this run.
+
+    Side effect: Adds the current output directory to the scenario object!
+
+    Parameters:
+    -----------
+
+    scenario : ~smac.scenario.scenario.Scenario
+
+    run_id : int
+    """
+    if scenario.output_dir:
+        output_dir = os.path.join(
+            scenario.output_dir,
+            "run_%d" % (run_id),
+        )
+    else:
+        output_dir = os.path.join(
+            os.path.abspath('.'),
+            "run_%d" % (run_id),
+        )
+    if os.path.exists(output_dir):
+        move_to = output_dir + ".OLD"
+        while (os.path.exists(move_to)):
+            move_to += ".OLD"
+        shutil.move(output_dir, move_to)
+        if logger is not None:
+            logger.warning("Output directory \"%s\" already exists! "
+                           "Moving old folder to \"%s\".",
+                           output_dir, move_to)
+    scenario.output_dir_for_this_run = output_dir
+    return output_dir

--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -29,26 +29,26 @@ class OutputWriter(object):
             status: False or None
                 False indicates that writing process failed
         """
-        if scenario.output_dir is None or scenario.output_dir == "":
+        if scenario.output_dir_for_this_run is None or scenario.output_dir_for_this_run == "":
             scenario.logger.info("No output directory for scenario logging "
                                  "specified -- scenario will not be logged.")
             return False
         # Create output-dir if necessary
-        if not os.path.isdir(scenario.output_dir):
+        if not os.path.isdir(scenario.output_dir_for_this_run):
             scenario.logger.debug("Output directory does not exist! Will be "
                               "created.")
             try:
-                os.makedirs(scenario.output_dir)
+                os.makedirs(scenario.output_dir_for_this_run)
             except OSError:
                 raise OSError("Could not make output directory: "
-                              "{}.".format(scenario.output_dir))
+                              "{}.".format(scenario.output_dir_for_this_run))
 
         # options_dest2name maps scenario._arguments from dest -> name
         options_dest2name = {(scenario._arguments[v]['dest'] if
             scenario._arguments[v]['dest'] else v) : v for v in scenario._arguments}
 
         # Write all options into "output_dir/scenario.txt"
-        path = os.path.join(scenario.output_dir, "scenario.txt")
+        path = os.path.join(scenario.output_dir_for_this_run, "scenario.txt")
         scenario.logger.debug("Writing scenario-file to {}.".format(path))
         with open(path, 'w') as fh:
             for key in options_dest2name:
@@ -85,20 +85,20 @@ class OutputWriter(object):
             # Copy if file exists, else write to new file
             if value is not None and os.path.isfile(value):
                 try:
-                    return shutil.copy(value, scenario.output_dir)
+                    return shutil.copy(value, scenario.output_dir_for_this_run)
                 except shutil.SameFileError:
                     return value  # File is already in output_dir
             elif key == 'pcs_fn' and scenario.cs is not None:
-                new_path = os.path.join(scenario.output_dir, "configspace.pcs")
+                new_path = os.path.join(scenario.output_dir_for_this_run, "configspace.pcs")
                 self.write_pcs_file(scenario.cs, new_path)
             elif key == 'train_inst_fn' and scenario.train_insts != [None]:
-                new_path = os.path.join(scenario.output_dir, 'train_insts.txt')
+                new_path = os.path.join(scenario.output_dir_for_this_run, 'train_insts.txt')
                 self.write_inst_file(scenario.train_insts, new_path)
             elif key == 'test_inst_fn' and scenario.test_insts != [None]:
-                new_path = os.path.join(scenario.output_dir, 'test_insts.txt')
+                new_path = os.path.join(scenario.output_dir_for_this_run, 'test_insts.txt')
                 self.write_inst_file(scenario.test_insts, new_path)
             elif key == 'feature_fn' and scenario.feature_dict != {}:
-                new_path = os.path.join(scenario.output_dir, 'features.txt')
+                new_path = os.path.join(scenario.output_dir_for_this_run, 'features.txt')
                 self.write_inst_features_file(scenario.n_features,
                                               scenario.feature_dict, new_path)
             else:

--- a/test/test_cli/test_restore_state.py
+++ b/test/test_cli/test_restore_state.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import unittest
 import shutil
@@ -19,6 +20,12 @@ from smac.stats.stats import Stats
 class TestSMACCLI(unittest.TestCase):
 
     def setUp(self):
+        base_directory = os.path.split(__file__)[0]
+        base_directory = os.path.abspath(
+            os.path.join(base_directory, '..', '..'))
+        self.current_dir = os.getcwd()
+        os.chdir(base_directory)
+
         self.output_one = "test/test_files/test_restore_state/run_1"  # From scenario_one.txt
         self.output_two = "test/test_files/test_restored_state/run_1" # From scenario_two.txt
         self.smaccli = SMACCLI()
@@ -28,6 +35,7 @@ class TestSMACCLI(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.output_one, ignore_errors=True)
         shutil.rmtree(self.output_two, ignore_errors=True)
+        os.chdir(self.current_dir)
 
     def test_run_and_restore(self):
         """

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 import unittest
 
 import numpy as np
@@ -158,3 +160,35 @@ class TestSMACFacade(unittest.TestCase):
         self.assertIsInstance(init_design.stats, Stats)
         self.assertIsInstance(init_design.traj_logger, TrajLogger)
         self.assertIsInstance(rh2epm.scenario, Scenario)
+
+    def test_output_structure(self):
+        """Test whether output-dir is moved correctly."""
+        test_scenario_dict = {
+            'output_dir': 'test/test_files/scenario_test/tmp_output',
+            'run_obj': 'quality',
+            'cs': ConfigurationSpace()
+        }
+        scen1 = Scenario(test_scenario_dict)
+        smac = SMAC(scenario=scen1, run_id=1)
+
+        self.assertEqual(smac.output_dir, os.path.join(
+            test_scenario_dict['output_dir'], 'run_1'))
+        self.assertTrue(os.path.isdir(smac.output_dir))
+
+        smac2 = SMAC(scenario=scen1, run_id=1)
+        self.assertTrue(os.path.isdir(smac2.output_dir + '.OLD'))
+
+        smac3 = SMAC(scenario=scen1, run_id=1)
+        self.assertTrue(os.path.isdir(smac3.output_dir + '.OLD.OLD'))
+
+        smac4 = SMAC(scenario=scen1, run_id=2)
+        self.assertEqual(smac4.output_dir, os.path.join(
+            test_scenario_dict['output_dir'], 'run_2'))
+        self.assertTrue(os.path.isdir(smac4.output_dir))
+        self.assertFalse(os.path.isdir(smac4.output_dir + '.OLD.OLD.OLD'))
+
+        # clean up (at least whats not cleaned up by tearDown)
+        shutil.rmtree(smac.output_dir + '.OLD.OLD')
+        shutil.rmtree(smac.output_dir + '.OLD')
+        shutil.rmtree(smac.output_dir)
+        shutil.rmtree(smac4.output_dir)


### PR DESCRIPTION
Currently, the `run_id` needs to be passed to the scenario object. This PR removes this necessity. I would like to have this feature to pass a scenario dict to the user in Auto-sklearn and allow the user to create the scenario object from this, without having to deal with extra arguments.