### PR TITLE
Fix RS

### DIFF
--- a/smac/facade/roar_facade.py
+++ b/smac/facade/roar_facade.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from smac.optimizer.objective import average_cost
 from smac.optimizer.ei_optimization import RandomSearch
-from smac.optimizer.acquisition import EI
 from smac.tae.execute_ta_run import StatusType, ExecuteTARun
 from smac.stats.stats import Stats
 from smac.scenario.scenario import Scenario
@@ -13,7 +12,6 @@ from smac.runhistory.runhistory import RunHistory
 from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost
 from smac.initial_design.initial_design import InitialDesign
 from smac.intensification.intensification import Intensifier
-from smac.epm.random_epm import RandomEPM
 from smac.facade.smac_facade import SMAC
 from smac.configspace import Configuration
 
@@ -78,10 +76,6 @@ class ROAR(SMAC):
         # initial random number generator
         num_run, rng = self._get_rng(rng=rng)
 
-        # initial EPM
-        #use random predictions to simulate random sampling of configurations
-        model = RandomEPM(rng=rng)
-
         # initial conversion of runhistory into EPM data
         # since ROAR does not really use it the converted data
         # we simply use a cheap RunHistory2EPM here
@@ -101,7 +95,7 @@ class ROAR(SMAC):
 
         self.stats = Stats(scenario)
         rs = RandomSearch(
-            acquisition_function=EI(model=model),
+            acquisition_function=None,
             config_space=scenario.cs,
         )
 
@@ -111,7 +105,6 @@ class ROAR(SMAC):
             tae_runner=tae_runner,
             runhistory=runhistory,
             intensifier=intensifier,
-            model=model,
             runhistory2epm=runhistory2epm,
             initial_design=initial_design,
             initial_configurations=initial_configurations,

--- a/smac/facade/roar_facade.py
+++ b/smac/facade/roar_facade.py
@@ -3,8 +3,10 @@ import typing
 
 import numpy as np
 
-from smac.tae.execute_ta_run import ExecuteTARun
-from smac.tae.execute_ta_run import StatusType
+from smac.optimizer.objective import average_cost
+from smac.optimizer.ei_optimization import RandomSearch
+from smac.optimizer.acquisition import EI
+from smac.tae.execute_ta_run import StatusType, ExecuteTARun
 from smac.stats.stats import Stats
 from smac.scenario.scenario import Scenario
 from smac.runhistory.runhistory import RunHistory
@@ -89,6 +91,20 @@ class ROAR(SMAC):
              success_states=[StatusType.SUCCESS, ],
              impute_censored_data=False, impute_state=None)
 
+        aggregate_func = average_cost
+        # initialize empty runhistory
+        if runhistory is None:
+            runhistory = RunHistory(aggregate_func=aggregate_func)
+        # inject aggr_func if necessary
+        if runhistory.aggregate_func is None:
+            runhistory.aggregate_func = aggregate_func
+
+        self.stats = Stats(scenario)
+        rs = RandomSearch(
+            acquisition_function=EI(model=model),
+            config_space=scenario.cs,
+        )
+
         # use SMAC facade
         super().__init__(
             scenario=scenario,
@@ -102,4 +118,5 @@ class ROAR(SMAC):
             stats=stats,
             rng=rng,
             run_id=run_id,
+            acquisition_function_optimizer=rs,
         )


### PR DESCRIPTION
The fact that we previously used the full EI optimization machinery for ROAR it could happen that a configuration from local search gets a high EI value while being not strictly random. Using only random search as an EI optimization algorithm solves this issue.