### PR TITLE
FIX #357 no output-dir no directory

### DIFF
--- a/smac/utils/io/output_directory.py
+++ b/smac/utils/io/output_directory.py
@@ -28,10 +28,7 @@ def create_output_directory(
             "run_%d" % (run_id),
         )
     else:
-        output_dir = os.path.join(
-            os.path.abspath('.'),
-            "run_%d" % (run_id),
-        )
+        return ""
     if os.path.exists(output_dir):
         move_to = output_dir + ".OLD"
         while (os.path.exists(move_to)):

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -46,7 +46,8 @@ class TrajLogger(object):
         self.logger = logging.getLogger(self.__module__ + "." + self.__class__.__name__)
 
         self.output_dir = output_dir
-        if output_dir is None:
+        if output_dir is None or output_dir == "":
+            self.output_dir = None
             self.logger.info("No output directory for trajectory logging "
                              "specified -- trajectory will not be logged.")
 

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -192,3 +192,15 @@ class TestSMACFacade(unittest.TestCase):
         shutil.rmtree(smac.output_dir + '.OLD')
         shutil.rmtree(smac.output_dir)
         shutil.rmtree(smac4.output_dir)
+
+    def test_no_output(self):
+        """ Test whether a scenario with "" as output really does not create an
+        output. """
+        test_scenario_dict = {
+            'output_dir': '',
+            'run_obj': 'quality',
+            'cs': ConfigurationSpace()
+        }
+        scen1 = Scenario(test_scenario_dict)
+        smac = SMAC(scenario=scen1, run_id=1)
+        self.assertFalse(os.path.isdir(smac.output_dir))


### PR DESCRIPTION
fix `create_output_dir` to not create a directory if output-dir is set to "", add test and follow-up problems in trajectory logging.