### PR TITLE
Issue #373: Add Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
 
 # command to run tests, e.g. python setup.py test
 script:
-  - nosetests -sv --with-coverage --cover-package=smac && bash scripts/test_no_files_left.sh
+  - echo Testing revision $(git rev-parse HEAD) ...
+  - make test && bash scripts/test_no_files_left.sh
 after_success:
   - codecov

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 
 .PHONY: test
 test:
-	python3.6 -m nose -sv --with-coverage --cover-package=smac
+	nosetests -sv --with-coverage --cover-package=smac
 
 .PHONY: test-fast
 test-fast:
-	python3.6 -m nose -a '!slow' -sv --with-coverage --cover-package=smac
+	nosetests -a '!slow' -sv --with-coverage --cover-package=smac
 
 .PHONY: test-runtimes
 test-runtimes:
 	# requires nose-timer
-	python3.6 -m nose -sv --with-timer --timer-top-n 15
+	nosetests -sv --with-timer --timer-top-n 15
 
 .PHONY: doc
 doc:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+
+.PHONY: test
+test:
+	python3.6 -m nose -sv --with-coverage --cover-package=smac
+
+.PHONY: test-fast
+test-fast:
+	python3.6 -m nose -a '!slow' -sv --with-coverage --cover-package=smac
+
+.PHONY: test-runtimes
+test-runtimes:
+	# requires nose-timer
+	python3.6 -m nose -sv --with-timer --timer-top-n 15
+
+.PHONY: doc
+doc:
+	make -C doc html
+
+.PHONY: clean
+clean: clean-data
+	make -C doc clean
+
+.PHONY: clean-data
+clean-data:
+	# remove all files that could have been left by test cases or by manual runs
+	# feel free to add more lines
+	find . -maxdepth 3 -iname 'smac3-output_*-*-*_*' | tac | while read -r TESTDIR ; do rm -Rf "$${TESTDIR}" ; done
+	rm -Rf run_*
+	rm -Rf test/test_files/scenario_test/tmp_output_*
+	rm -Rf test/test_files/test_*_run1
+	rm  -f test/test_files/test_scenario_options_to_doc.txt
+	rm  -f test/test_files/validation/test_validation_rh.json
+	rm -Rf test/run_*
+	rm -Rf test/test_smbo/run_*
+	rm -Rf test/test_files/test_restore_state/
+	rm -Rf test/test_files/test_restored_state/
+	rm -Rf test/test_files/validation/test/
+	rm  -f test/test_files/validation/validated_runhistory.json*
+	rm  -f test/test_files/validation/validated_runhistory_EPM.json*

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -25,7 +25,7 @@ You can also run SMAC with :code:`--verbose DEBUG` to see how *SMAC* tried to ca
 Use the `restore-option <basic_usage.html#restorestate>`_.
 
 .. rubric:: I discovered a bug/have criticism or ideas on *SMAC*. Where should
-I report to?
+   I report to?
 
 *SMAC* uses the
 `GitHub issue-tracker <https://github.com/automl/SMAC3/issues>`_ to take care

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pyrfr>=0.5.0
 sphinx
 sphinx_rtd_theme
 joblib
+nose>=1.3.0

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -422,9 +422,9 @@ class SMAC(object):
         config_mode: str or list<Configuration>
             string or directly a list of Configuration
             str from [def, inc, def+inc, wallclock_time, cpu_time, all]
-                time evaluates at cpu- or wallclock-timesteps of:
-                [max_time/2^0, max_time/2^1, max_time/2^3, ..., default]
-                with max_time being the highest recorded time
+            time evaluates at cpu- or wallclock-timesteps of:
+            [max_time/2^0, max_time/2^1, max_time/2^3, ..., default]
+            with max_time being the highest recorded time
         instance_mode: string
             what instances to use for validation, from [train, test, train+test]
         repetitions: int

--- a/test/test_cli/test_restore_state.py
+++ b/test/test_cli/test_restore_state.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+from nose.plugins.attrib import attr
 import shutil
 
 import numpy as np
@@ -41,6 +42,7 @@ class TestSMACCLI(unittest.TestCase):
                 shutil.rmtree(output_dir, ignore_errors=True)
         os.chdir(self.current_dir)
 
+    @attr('slow')
     def test_run_and_restore(self):
         """
         Testing basic restore functionality.

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -1,4 +1,5 @@
 import unittest
+from nose.plugins.attrib import attr
 
 import logging
 import numpy as np
@@ -204,6 +205,7 @@ class TestIntensify(unittest.TestCase):
 
         self.assertEqual(inc, self.config2)
 
+    @attr('slow')
     def test_race_challenger_2(self):
         '''
            test _race_challenger with adaptive capping
@@ -236,6 +238,7 @@ class TestIntensify(unittest.TestCase):
         # self.assertTrue(False)
         self.assertEqual(inc, self.config1)
 
+    @attr('slow')
     def test_race_challenger_3(self):
         '''
            test _race_challenger with adaptive capping on a previously capped configuration  

--- a/test/test_runhistory/test_rfr_imputor.py
+++ b/test/test_runhistory/test_rfr_imputor.py
@@ -1,6 +1,7 @@
 import copy
 import unittest
 import logging
+from nose.plugins.attrib import attr
 import numpy
 
 from ConfigSpace import Configuration, ConfigurationSpace
@@ -99,6 +100,7 @@ class ImputorTest(unittest.TestCase):
                 types=types, bounds=bounds,
                 instance_features=None, seed=1234567980)
 
+    @attr('slow')
     def testRandomImputation(self):
         rs = numpy.random.RandomState(1)
 

--- a/test/test_tae/test_exec_func.py
+++ b/test/test_tae/test_exec_func.py
@@ -3,6 +3,7 @@ import sys
 import time
 import unittest
 import unittest.mock
+from nose.plugins.attrib import attr
 
 import numpy as np
 
@@ -111,7 +112,7 @@ class TestExecuteFunc(unittest.TestCase):
             raise ValueError('Test cannot be performed on platform %s' %
                              sys.platform)
 
-
+    @attr('slow')
     def test_timeout(self):
         def run_over_time(*args):
             time.sleep(5)
@@ -123,6 +124,7 @@ class TestExecuteFunc(unittest.TestCase):
         self.assertGreaterEqual(rval[2], 0.0)
         self.assertEqual(rval[3], dict())
 
+    @attr('slow')
     def test_timeout_runtime(self):
         def run_over_time(*args):
             time.sleep(5)

--- a/test/test_utils/test_validate.py
+++ b/test/test_utils/test_validate.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import unittest
+from nose.plugins.attrib import attr
 import logging
 import shutil
 
@@ -177,6 +178,7 @@ class ValidationTest(unittest.TestCase):
         runs = validator.get_runs(['config1'], insts, repetitions=1)
         self.assertEqual(runs[0], expected)
 
+    @attr('slow')
     def test_validate(self):
         ''' test validation '''
         scen = Scenario(self.scen_fn,


### PR DESCRIPTION
* Add Makefile with `test`, `test-fast`, `test-runtimes`, `clean`, `clean-data` and `doc` targets.
* Fix rst files and docstrings which sphinx reported errors/warnings on.
* Print revision being tested on travis.
* Add 'slow' attribute on test cases slower than 1s.