### PR TITLE
FIX #367 add zeros to parameter names

### DIFF
--- a/smac/facade/func_facade.py
+++ b/smac/facade/func_facade.py
@@ -52,8 +52,12 @@ def fmin_smac(func: callable,
     """
     # create configuration space
     cs = ConfigurationSpace()
+
+    # Adjust zero padding
+    tmplt = 'x{0:0' + str(len(str(len(bounds)))) + 'd}'
+
     for idx, (lower_bound, upper_bound) in enumerate(bounds):
-        parameter = UniformFloatHyperparameter(name="x%d" % (idx + 1),
+        parameter = UniformFloatHyperparameter(name=tmplt.format(idx + 1),
                                                lower=lower_bound,
                                                upper=upper_bound,
                                                default_value=x0[idx])

--- a/smac/facade/func_facade.py
+++ b/smac/facade/func_facade.py
@@ -81,11 +81,10 @@ def fmin_smac(func: callable,
     smac = SMAC(scenario=scenario, tae_runner=ta, rng=rng)
     smac.logger = logging.getLogger(smac.__module__ + "." + smac.__class__.__name__)
     incumbent = smac.optimize()
-
     config_id = smac.solver.runhistory.config_ids[incumbent]
     run_key = RunKey(config_id, None, 0)
     incumbent_performance = smac.solver.runhistory.data[run_key]
-    incumbent = np.array([incumbent['x%d' % (idx + 1)]
+    incumbent = np.array([incumbent[tmplt.format(idx + 1)]
                           for idx in range(len(bounds))], dtype=np.float)
     return incumbent, incumbent_performance.cost, \
            smac

--- a/test/test_facade/test_func_facade.py
+++ b/test/test_facade/test_func_facade.py
@@ -33,3 +33,18 @@ class TestSMACFacade(unittest.TestCase):
         self.assertEqual(type(f), type(f_s))
 
         self.output_dirs.append(smac.scenario.output_dir)
+
+    def test_parameter_order(self):
+        def func(x):
+            for i in range(len(x)):
+                self.assertLess(i - 1, x[i])
+                self.assertGreater(i, x[i])
+            return 1
+
+        default = [i - 0.5 for i in range(10)]
+        bounds = [(i - 1, i) for i in range(10)]
+        print(default, bounds)
+        fmin_smac(func=func, x0=default,
+                  bounds=bounds,
+                  maxfun=1,
+                  rng=1)

--- a/test/test_facade/test_func_facade.py
+++ b/test/test_facade/test_func_facade.py
@@ -44,7 +44,9 @@ class TestSMACFacade(unittest.TestCase):
         default = [i - 0.5 for i in range(10)]
         bounds = [(i - 1, i) for i in range(10)]
         print(default, bounds)
-        fmin_smac(func=func, x0=default,
-                  bounds=bounds,
-                  maxfun=1,
-                  rng=1)
+        _, _, smac = fmin_smac(func=func, x0=default,
+                               bounds=bounds,
+                               maxfun=1)
+
+        self.output_dirs.append(smac.scenario.output_dir)
+


### PR DESCRIPTION
Fixes issue #367 by padding zeros to parameter name such that sort returns correct order