### PR TITLE
FIX #376, make fmin_smac deterministic

### DIFF
--- a/smac/facade/func_facade.py
+++ b/smac/facade/func_facade.py
@@ -19,7 +19,6 @@ def fmin_smac(func: callable,
               x0: list,
               bounds: list,
               maxfun: int=-1,
-              maxtime: int=-1,
               rng: np.random.RandomState=None):
     """ Minimize a function func using the SMAC algorithm.
     This function is a convenience wrapper for the SMAC class.
@@ -33,8 +32,6 @@ def fmin_smac(func: callable,
     bounds : list
         ``(min, max)`` pairs for each element in ``x``, defining the bound on
         that parameters.
-    maxtime : int, optional
-        Maximum runtime in seconds.
     maxfun : int, optional
         Maximum number of function evaluations.
     rng : np.random.RandomState, optional
@@ -67,15 +64,15 @@ def fmin_smac(func: callable,
     ta = ExecuteTAFuncArray(ta=func)
 
     # create scenario
-    scenario_dict = {"run_obj": "quality",
-                     "cs": cs,
-                     "deterministic": "true",
-                     "initial_incumbent": "DEFAULT"
-                     }
+    scenario_dict = {
+        "run_obj": "quality",
+        "cs": cs,
+        "deterministic": "true",
+        "initial_incumbent": "DEFAULT",
+        "intensification_percentage": 0.000001,
+    }
     if maxfun > 0:
         scenario_dict["runcount_limit"] = maxfun
-    if maxtime > 0:
-        scenario_dict["wallclock_limit"] = maxtime
     scenario = Scenario(scenario_dict)
 
     smac = SMAC(scenario=scenario, tae_runner=ta, rng=rng)

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -1,11 +1,7 @@
 import os
-import itertools
 import logging
 import numpy as np
-import random
 import time
-import typing
-import math
 
 from smac.configspace import Configuration
 from smac.epm.rf_with_instances import RandomForestWithInstances
@@ -13,8 +9,8 @@ from smac.initial_design.initial_design import InitialDesign
 from smac.intensification.intensification import Intensifier
 from smac.optimizer import pSMAC
 from smac.optimizer.acquisition import AbstractAcquisitionFunction
-from smac.optimizer.ei_optimization import InterleavedLocalAndRandomSearch, \
-    AcquisitionFunctionMaximizer, RandomSearch
+from smac.optimizer.ei_optimization import AcquisitionFunctionMaximizer, \
+    RandomSearch
 from smac.runhistory.runhistory import RunHistory
 from smac.runhistory.runhistory2epm import AbstractRunHistory2EPM
 from smac.scenario.scenario import Scenario

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -134,12 +134,14 @@ class TestSMACFacade(unittest.TestCase):
             smac = SMAC(scenario=scenario, rng=np.random.RandomState(42),
                         tae_runner=rosenbrock_2d)
             incumbent = smac.optimize()
-            return incumbent
+            return incumbent, smac.scenario.output_dir
 
-        i1 = opt_rosenbrock()
+        i1, output_dir = opt_rosenbrock()
+        self.output_dirs.append(output_dir)
         x1_1 = i1.get('x1')
         x2_1 = i1.get('x2')
-        i2 = opt_rosenbrock()
+        i2, output_dir = opt_rosenbrock()
+        self.output_dirs.append(output_dir)
         x1_2 = i2.get('x1')
         x2_2 = i2.get('x2')
         self.assertAlmostEqual(x1_1, x1_2)


### PR DESCRIPTION
Pretty simple, it removes the time limit functionality from `func_facade`, and instead adds `intensification_percentage` as a scenario argument.

Fixes #376.

Can be confirmed by running
```python
import numpy as np

# Import ConfigSpace and different types of parameters
from smac.configspace import ConfigurationSpace
from ConfigSpace.hyperparameters import UniformFloatHyperparameter

# Import SMAC-utilities
from smac.scenario.scenario import Scenario
from smac.facade.smac_facade import SMAC
from smac.facade.func_facade import fmin_smac


def rosenbrock_2d(x):
    x1 = x['x1']
    x2 = x['x2']

    val = 100. * (x2 - x1 ** 2.) ** 2. + (1 - x1) ** 2.
    return val


def rosenbrock_2d_array(x):
    return rosenbrock_2d({'x1': x[0], 'x2': x[1]})

fixture = 6

for i in range(20):

    np.random.seed(3)
    cs = ConfigurationSpace()

    cs.add_hyperparameter(
        UniformFloatHyperparameter("x1", -5, 5, default_value=-3))
    cs.add_hyperparameter(
        UniformFloatHyperparameter("x2", -5, 5, default_value=-4))

    scenario = Scenario(
        {"run_obj": "quality",  # we optimize quality (alternatively runtime)
         "runcount-limit": 50,  # maximum function evaluations
         "cs": cs,  # configuration space
         "deterministic": "true",
         "initial_incumbent": "DEFAULT",
         "intensification_percentage": 0.000001
         })

    smac = SMAC(scenario=scenario, rng=5,
                tae_runner=rosenbrock_2d)
    incumbent = smac.optimize()

    cost_smac_facade = rosenbrock_2d(incumbent)

    np.random.seed(3)
    x, cost_func_facade, _ = fmin_smac(
        func=rosenbrock_2d_array,
        x0=[-3, -4],
        bounds=[(-5, 5), (-5, 5)],
        maxfun=50,
        rng=5,
    )

    print(cost_smac_facade, cost_func_facade)
    np.testing.assert_almost_equal(cost_func_facade, fixture, decimal=3)
    np.testing.assert_almost_equal(cost_smac_facade, fixture, decimal=3)
```