### PR TITLE
FIX pSMAC

### DIFF
--- a/smac/optimizer/pSMAC.py
+++ b/smac/optimizer/pSMAC.py
@@ -9,7 +9,7 @@ from smac.runhistory.runhistory import RunHistory
 from smac.configspace import ConfigurationSpace
 
 RUNHISTORY_FILEPATTERN = 'runhistory.json'
-RUNHISTORY_RE = r'runhistory\.json'
+RUNHISTORY_RE = r'runhistory\.json$'
 
 
 def read(run_history: RunHistory, 
@@ -47,6 +47,7 @@ def read(run_history: RunHistory,
             if match:
                 runhistory_file = os.path.join(output_directory,
                                                file_in_output_directory)
+                print(runhistory_file)
                 run_history.update_from_json(runhistory_file,
                                              configuration_space)
 
@@ -61,7 +62,8 @@ def read(run_history: RunHistory,
                  'runs.' % difference)
 
 
-def write(run_history: RunHistory, output_directory: str):
+def write(run_history: RunHistory, output_directory: str,
+          logger: logging.Logger):
     """Write the runhistory to the output directory.
 
     Overwrites previously outputted runhistories.
@@ -72,9 +74,13 @@ def write(run_history: RunHistory, output_directory: str):
         RunHistory object to be saved.
 
     output_directory : str
+    
+    logger : logging.Logger
     """
 
     output_filename = os.path.join(output_directory, RUNHISTORY_FILEPATTERN)
+    
+    logging.debug("Saving runhistory to %s" %(output_filename))
 
     with tempfile.NamedTemporaryFile('wb', dir=output_directory,
                                      delete=False) as fh:

--- a/smac/optimizer/pSMAC.py
+++ b/smac/optimizer/pSMAC.py
@@ -47,7 +47,6 @@ def read(run_history: RunHistory,
             if match:
                 runhistory_file = os.path.join(output_directory,
                                                file_in_output_directory)
-                print(runhistory_file)
                 run_history.update_from_json(runhistory_file,
                                              configuration_space)
 

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -189,7 +189,8 @@ class SMBO(object):
 
             if self.scenario.shared_model:
                 pSMAC.write(run_history=self.runhistory,
-                            output_directory=self.scenario.output_dir_for_this_run)
+                            output_directory=self.scenario.output_dir_for_this_run,
+                            logger=self.logger)
 
             logging.debug("Remaining budget: %f (wallclock), %f (ta costs), %f (target runs)" % (
                 self.stats.get_remaing_time_budget(),

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -431,8 +431,8 @@ class Scenario(object):
 
         if self.shared_model and self.input_psmac_dirs is None:
             # per default, we assume that
-            # all psmac runs write to the same directory
-            self.input_psmac_dirs = [self.output_dir]
+            # all pSMAC runs write to the default output dir
+            self.input_psmac_dirs = "smac3-output*/run*/"
 
     def __getstate__(self):
         d = dict(self.__dict__)

--- a/test/test_smbo/test_pSMAC.py
+++ b/test/test_smbo/test_pSMAC.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import unittest
+import logging
 
 from smac.runhistory.runhistory import RunHistory, RunKey, DataOrigin
 from smac.utils import test_helpers
@@ -75,7 +76,16 @@ class TestPSMAC(unittest.TestCase):
         run_history.add(config_5, 1, 1, StatusType.SUCCESS, seed=1,
                         origin=DataOrigin.EXTERNAL_SAME_INSTANCES)
 
-        pSMAC.write(run_history, self.tmp_dir)
+        logger = logging.getLogger("Test")
+        pSMAC.write(run_history, self.tmp_dir, logger=logger)
+        r_size = len(run_history.data)
+        pSMAC.read(run_history=run_history, 
+                   output_dirs=[self.tmp_dir], 
+                   configuration_space=configuration_space, 
+                   logger=logger)
+        self.assertEqual(r_size, len(run_history.data), 
+                         "Runhistory should be the same and not changed after reading")
+        
 
         output_filename = os.path.join(self.tmp_dir, 'runhistory.json')
         self.assertTrue(os.path.exists(output_filename))
@@ -84,7 +94,7 @@ class TestPSMAC(unittest.TestCase):
         with open(output_filename) as fh:
             output = json.load(fh, object_hook=StatusType.enum_hook)
         self.assertEqual(output, fixture)
-
+        
     def test_load(self):
         configuration_space = test_helpers.get_branin_config_space()
 


### PR DESCRIPTION
* FIX default path for input_psmac_dirs
* FIX parsing of runhistory files; skip lock files
* ADD debug statement to see runhistory location in logs