### PR TITLE
MAINT improve oserror-message/traceback

### DIFF
--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -40,7 +40,6 @@ class OutputWriter(object):
                                   "created.")
             try:
                 os.makedirs(scenario.output_dir_for_this_run)
-                raise OSError()
             except OSError:
                 scenario.logger.debug("Could not make output directory.", exc_info=1)
                 raise OSError("Could not make output directory: "

--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -42,10 +42,9 @@ class OutputWriter(object):
                 os.makedirs(scenario.output_dir_for_this_run)
                 raise OSError()
             except OSError:
-                scenario.logger.error("Could not make output directory: "
-                                      "{}.".format(scenario.output_dir_for_this_run),
-                                      exc_info=1)
-                sys.exit(3)
+                scenario.logger.debug("Could not make output directory.", exc_info=1)
+                raise OSError("Could not make output directory: "
+                              "{}.".format(scenario.output_dir_for_this_run))
 
         # options_dest2name maps scenario._arguments from dest -> name
         options_dest2name = {(scenario._arguments[v]['dest'] if

--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import shutil
 
 import typing
@@ -36,12 +37,15 @@ class OutputWriter(object):
         # Create output-dir if necessary
         if not os.path.isdir(scenario.output_dir_for_this_run):
             scenario.logger.debug("Output directory does not exist! Will be "
-                              "created.")
+                                  "created.")
             try:
                 os.makedirs(scenario.output_dir_for_this_run)
+                raise OSError()
             except OSError:
-                raise OSError("Could not make output directory: "
-                              "{}.".format(scenario.output_dir_for_this_run))
+                scenario.logger.error("Could not make output directory: "
+                                      "{}.".format(scenario.output_dir_for_this_run),
+                                      exc_info=1)
+                sys.exit(3)
 
         # options_dest2name maps scenario._arguments from dest -> name
         options_dest2name = {(scenario._arguments[v]['dest'] if

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -56,9 +56,9 @@ class TrajLogger(object):
                 try:
                     os.makedirs(output_dir)
                 except OSError:
-                    self.logger.error("Could not make output directory: "
-                                      "{}.".format(output_dir), exc_info=1)
-                    sys.exit(3)
+                    self.logger.debug("Could not make output directory.", exc_info=1)
+                    raise OSError("Could not make output directory: "
+                                  "{}.".format(output_dir))
 
             self.old_traj_fn = os.path.join(output_dir, "traj_old.csv")
             if not os.path.isfile(self.old_traj_fn):

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -56,8 +56,8 @@ class TrajLogger(object):
                 try:
                     os.makedirs(output_dir)
                 except OSError:
-                    self.logger.error(
-                        "Could not make output directory: %s" % (output_dir))
+                    self.logger.error("Could not make output directory: "
+                                      "{}.".format(output_dir), exc_info=1)
                     sys.exit(3)
 
             self.old_traj_fn = os.path.join(output_dir, "traj_old.csv")

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -41,6 +41,15 @@ class TrajLoggerTest(unittest.TestCase):
         self.assertFalse(os.path.exists('smac3-output'))
         self.assertTrue(os.path.exists('tmp_test_folder'))
 
+    def test_oserror(self):
+        scen = Scenario(scenario={'run_obj': 'quality', 'cs': self.cs,
+                                  'output_dir': ''}, cmd_args=None)
+        stats = Stats(scen)
+        # test OSError
+        with patch('os.makedirs') as osMock:
+            osMock.side_effect = OSError()
+            self.assertRaises(OSError, TrajLogger, output_dir='./tmp_test_folder', stats=stats)
+
     @patch('smac.stats.stats.Stats')
     def test_add_entry(self, mock_stats):
 
@@ -148,10 +157,12 @@ class TrajLoggerTest(unittest.TestCase):
         self.assertTrue("param_a='0.5'" in json_dicts[0]['incumbent'])
 
     def tearDown(self):
-        os.remove('tmp_test_folder/traj_old.csv')
+        if os.path.exists('tmp_test_folder/traj_old.csv'):
+            os.remove('tmp_test_folder/traj_old.csv')
         if os.path.exists('tmp_test_folder/traj_aclib2.json'):
             os.remove('tmp_test_folder/traj_aclib2.json')
-        os.rmdir('tmp_test_folder')
+        if os.path.exists('tmp_test_folder'):
+            os.rmdir('tmp_test_folder')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
regarding issue #405, I think it makes sense to provide the user with more information about `OSError`s. I found different behaviours throughout SMAC, is this one good? Mainly, do you think `sys.exit` or simply reraising `OSError`s would be more appropriate?