### PR TITLE
Fixing bugs of func_facade

### DIFF
--- a/smac/facade/func_facade.py
+++ b/smac/facade/func_facade.py
@@ -53,7 +53,7 @@ def fmin_smac(func: callable,
     # create configuration space
     cs = ConfigurationSpace()
     for idx, (lower_bound, upper_bound) in enumerate(bounds):
-        parameter = UniformFloatHyperparameter(name="x%d" % (idx + 1),
+        parameter = UniformFloatHyperparameter(name="x%03d" % (idx + 1),
                                                lower=lower_bound,
                                                upper=upper_bound,
                                                default_value=x0[idx])


### PR DESCRIPTION
Change hyperparameter name format.
If the length of x0 is larger than 10.
The original name format will mess up the order of the hyperparameters.