### PR TITLE
Improve rng and run_id handling

### DIFF
--- a/examples/rosenbrock.py
+++ b/examples/rosenbrock.py
@@ -27,6 +27,6 @@ x, cost, _ = fmin_smac(func=rosenbrock_2d,
                        x0=[-3, -4],
                        bounds=[(-5, 5), (-5, 5)],
                        maxfun=325,
-                       rng=3)
+                       rng=3)  # Passing a seed makes fmin_smac determistic
 
 print("Best x: %s; with cost: %f"% (str(x), cost))

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -426,7 +426,7 @@ class SMAC(object):
             rng = np.random.RandomState()
             run_id = rng.randint(MAXINT)
         elif rng is None and isinstance(run_id, int):
-            self.logger.debug('No rng and no run_id given: using run_id %d as seed.' % run_id)
+            self.logger.debug('No rng and no run_id given: using run_id %d as seed.', run_id)
             rng = np.random.RandomState(seed=run_id)
         elif isinstance(rng, int):
             if run_id is None:
@@ -475,7 +475,7 @@ class SMAC(object):
         finally:
             self.solver.stats.save()
             self.solver.stats.print_stats()
-            self.logger.info("Final Incumbent: %s" % (self.solver.incumbent))
+            self.logger.info("Final Incumbent: %s", (self.solver.incumbent))
             self.runhistory = self.solver.runhistory
             self.trajectory = self.solver.intensifier.traj_logger.trajectory
 

--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -148,7 +148,7 @@ class SMAC(object):
             # restoring, the output-folder exists already and we omit creating it,
             # but set the self-output_dir to the dir.
             # necessary because we want to write traj to new output-dir in CLI.
-            self.output_dir = os.path.join(scenario.output_dir, "run_%d" % (run_id))
+            self.output_dir = scenario.output_dir_for_this_run
 
         if (
             scenario.deterministic is True

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -58,20 +58,24 @@ class TestSMACFacade(unittest.TestCase):
         self.assertIs(smac.solver.intensifier.tae_runner.ta, target_algorithm)
 
     def test_pass_invalid_tae_runner(self):
-        self.assertRaisesRegexp(TypeError, "Argument 'tae_runner' is <class "
-                                           "'int'>, but must be either a "
-                                           "callable or an instance of "
-                                           "ExecuteTaRun.",
-                                SMAC, tae_runner=1, scenario=self.scenario)
+        self.assertRaisesRegex(
+            TypeError,
+            "Argument 'tae_runner' is <class 'int'>, but must be either a callable or an instance of ExecuteTaRun.",
+            SMAC,
+            tae_runner=1,
+            scenario=self.scenario,
+        )
 
     def test_pass_tae_runner_objective(self):
-        tae = ExecuteTAFuncDict(lambda: 1,
-                                run_obj='runtime')
-        self.assertRaisesRegexp(ValueError, "Objective for the target algorithm"
-                                            " runner and the scenario must be "
-                                            "the same, but are 'runtime' and "
-                                            "'quality'",
-                                SMAC, tae_runner=tae, scenario=self.scenario)
+        tae = ExecuteTAFuncDict(lambda: 1, run_obj='runtime')
+        self.assertRaisesRegex(
+            ValueError,
+            "Objective for the target algorithm runner and the scenario must be the same, but are 'runtime' and "
+            "'quality'",
+            SMAC,
+            tae_runner=tae,
+            scenario=self.scenario,
+        )
 
     @unittest.mock.patch.object(SMAC, '__init__')
     def test_check_random_states(self, patch):

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -2,6 +2,7 @@ from contextlib import suppress
 import os
 import shutil
 import unittest
+import unittest.mock
 
 import numpy as np
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter
@@ -72,44 +73,72 @@ class TestSMACFacade(unittest.TestCase):
                                             "'quality'",
                                 SMAC, tae_runner=tae, scenario=self.scenario)
 
-    def test_check_random_states(self):
-        ta = ExecuteTAFuncDict(lambda x: x**2)
+    @unittest.mock.patch.object(SMAC, '__init__')
+    def test_check_random_states(self, patch):
+        patch.return_value = None
+        smac = SMAC()
+        smac.logger = unittest.mock.MagicMock()
 
-        # Get state immediately or it will change with the next calltest_check_random_states
-
+        # Check some properties
         # Check whether different seeds give different random states
-        S1 = SMAC(tae_runner=ta, scenario=self.scenario, rng=1)
-        S1 = S1.solver.scenario.cs.random
+        _, rng_1 = smac._get_rng(1)
+        _, rng_2 = smac._get_rng(2)
+        self.assertNotEqual(sum(rng_1.get_state()[1] - rng_2.get_state()[1]), 0)
 
-        S2 = SMAC(tae_runner=ta, scenario=self.scenario, rng=2)
-        S2 = S2.solver.scenario.cs.random
-        self.assertNotEqual(sum(S1.get_state()[1] - S2.get_state()[1]), 0)
+        # Check whether no seeds gives different random states
+        _, rng_1 = smac._get_rng()
+        self.assertEqual(smac.logger.debug.call_count, 1)
+        _, rng_2 = smac._get_rng()
+        self.assertEqual(smac.logger.debug.call_count, 2)
 
-        # Check whether no seeds give the same random states (use default seed)
-        S1 = SMAC(tae_runner=ta, scenario=self.scenario)
-        S1 = S1.solver.scenario.cs.random
+        self.assertNotEqual(sum(rng_1.get_state()[1] - rng_2.get_state()[1]), 0)
 
-        S2 = SMAC(tae_runner=ta, scenario=self.scenario)
-        S2 = S2.solver.scenario.cs.random
-        self.assertEqual(sum(S1.get_state()[1] - S2.get_state()[1]), 0)
+        # Check whether the same int seeds give the same random states
+        _, rng_1 = smac._get_rng(1)
+        _, rng_2 = smac._get_rng(1)
+        self.assertEqual(sum(rng_1.get_state()[1] - rng_2.get_state()[1]), 0)
 
-        # Check whether the same seeds give the same random states
-        S1 = SMAC(tae_runner=ta, scenario=self.scenario, rng=1)
-        S1 = S1.solver.scenario.cs.random
+        # Check all execution paths
+        self.assertRaisesRegex(
+            TypeError,
+            "Argument rng accepts only arguments of type None, int or np.random.RandomState, "
+            "you provided <class 'str'>.",
+            smac._get_rng,
+            rng='ABC',
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Argument run_id accepts only arguments of type None, int or np.random.RandomState, "
+            "you provided <class 'str'>.",
+            smac._get_rng,
+            run_id='ABC'
+        )
 
-        S2 = SMAC(tae_runner=ta, scenario=self.scenario, rng=1)
-        S2 = S2.solver.scenario.cs.random
-        self.assertEqual(sum(S1.get_state()[1] - S2.get_state()[1]), 0)
+        run_id, rng_1 = smac._get_rng(rng=None, run_id=None)
+        self.assertIsInstance(run_id, int)
+        self.assertIsInstance(rng_1, np.random.RandomState)
+        self.assertEqual(smac.logger.debug.call_count, 3)
 
-        # Check whether the same RandomStates give the same random states
-        S1 = SMAC(tae_runner=ta, scenario=self.scenario,
-                  rng=np.random.RandomState(1))
-        S1 = S1.solver.scenario.cs.random
+        run_id, rng_1 = smac._get_rng(rng=None, run_id=1)
+        self.assertEqual(run_id, 1)
+        self.assertIsInstance(rng_1, np.random.RandomState)
 
-        S2 = SMAC(tae_runner=ta, scenario=self.scenario,
-                  rng=np.random.RandomState(1))
-        S2 = S2.solver.scenario.cs.random
-        self.assertEqual(sum(S1.get_state()[1] - S2.get_state()[1]), 0)
+        run_id, rng_1 = smac._get_rng(rng=1, run_id=None)
+        self.assertEqual(run_id, 1)
+        self.assertIsInstance(rng_1, np.random.RandomState)
+
+        run_id, rng_1 = smac._get_rng(rng=1, run_id=1337)
+        self.assertEqual(run_id, 1337)
+        self.assertIsInstance(rng_1, np.random.RandomState)
+
+        rs = np.random.RandomState(1)
+        run_id, rng_1 = smac._get_rng(rng=rs, run_id=None)
+        self.assertIsInstance(run_id, int)
+        self.assertIs(rng_1, rs)
+
+        run_id, rng_1 = smac._get_rng(rng=rs, run_id=2505)
+        self.assertEqual(run_id, 2505)
+        self.assertIs(rng_1, rs)
 
     def test_check_deterministic_rosenbrock(self):
         def rosenbrock_2d(x):

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -93,11 +93,14 @@ class TestSMBO(unittest.TestCase):
         self.assertIsInstance(smbo.num_run, int)
         self.assertIs(smbo.rng, rng)
         # ML: I don't understand the following line and it throws an error
-        self.assertRaisesRegexp(TypeError,
-                                "Unknown type <(class|type) 'str'> for argument "
-                                'rng. Only accepts None, int or '
-                                'np.random.RandomState',
-                                SMAC, self.scenario, rng='BLA')
+        self.assertRaisesRegexp(
+            TypeError,
+            "Argument rng accepts only arguments of type None, int or np.random.RandomState, you provided "
+            "<class 'str'>.",
+            SMAC,
+            self.scenario,
+            rng='BLA',
+        )
 
     def test_choose_next(self):
         seed = 42
@@ -110,7 +113,7 @@ class TestSMBO(unittest.TestCase):
         Y = self.branin(X)
         x = next(smbo.choose_next(X, Y)).get_array()
         assert x.shape == (2,)
-        
+
     def test_choose_next_w_empty_rh(self):
         seed = 42
         smbo = SMAC(self.scenario, rng=seed).solver
@@ -126,9 +129,9 @@ class TestSMBO(unittest.TestCase):
             **{"X":X, "Y":Y}
         )
 
-        x = next(smbo.choose_next(X, Y, incumbent_value=0.0)).get_array()        
+        x = next(smbo.choose_next(X, Y, incumbent_value=0.0)).get_array()
         assert x.shape == (2,)
-        
+
     def test_choose_next_empty_X(self):
         smbo = SMAC(self.scenario, rng=1).solver
         smbo.acquisition_func._compute = mock.Mock(
@@ -146,7 +149,7 @@ class TestSMBO(unittest.TestCase):
         self.assertEqual(x, [0, 1, 2])
         self.assertEqual(smbo._random_search.maximize.call_count, 1)
         self.assertEqual(smbo.acquisition_func._compute.call_count, 0)
-        
+
     def test_choose_next_empty_X_2(self):
         smbo = SMAC(self.scenario, rng=1).solver
 

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -93,7 +93,7 @@ class TestSMBO(unittest.TestCase):
         self.assertIsInstance(smbo.num_run, int)
         self.assertIs(smbo.rng, rng)
         # ML: I don't understand the following line and it throws an error
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Argument rng accepts only arguments of type None, int or np.random.RandomState, you provided "
             "<class 'str'>.",


### PR DESCRIPTION
Finally fixes #209. In case an rng is provided, run_id is sampled from it unless provided.