### PR TITLE
MAINT move abort-on-first-run-crash to tae

### DIFF
--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -224,7 +224,8 @@ class SMAC(object):
                                          run_obj=scenario.run_obj,
                                          runhistory=runhistory,
                                          par_factor=scenario.par_factor,
-                                         cost_for_crash=scenario.cost_for_crash)
+                                         cost_for_crash=scenario.cost_for_crash,
+                                         abort_on_first_run_crash=scenario.abort_on_first_run_crash)
         # Second case, the tae_runner is a function to be optimized
         elif callable(tae_runner):
             tae_runner = ExecuteTAFuncDict(ta=tae_runner,
@@ -233,7 +234,8 @@ class SMAC(object):
                                            memory_limit=scenario.memory_limit,
                                            runhistory=runhistory,
                                            par_factor=scenario.par_factor,
-                                           cost_for_crash=scenario.cost_for_crash)
+                                           cost_for_crash=scenario.cost_for_crash,
+                                           abort_on_first_run_crash=scenario.abort_on_first_run_crash)
         # Third case, if it is an ExecuteTaRun we can simply use the
         # instance. Otherwise, the next check raises an exception
         elif not isinstance(tae_runner, ExecuteTARun):

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -141,11 +141,8 @@ class SMBO(object):
         self.stats.start_timing()
         # Initialization, depends on input
         if self.stats.ta_runs == 0 and self.incumbent is None:
-            try:
-                self.incumbent = self.initial_design.run()
-            except FirstRunCrashedException as err:
-                if self.scenario.abort_on_first_run_crash:
-                    raise
+            self.incumbent = self.initial_design.run()
+
         elif self.stats.ta_runs > 0 and self.incumbent is None:
             raise ValueError("According to stats there have been runs performed, "
                              "but the optimizer cannot detect an incumbent. Did "

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -158,6 +158,10 @@ class SMBO(object):
             self.logger.info("State restored with following budget:")
             self.stats.print_stats()
 
+        # To be on the safe side -> never return "None" as incumbent
+        if not self.incumbent:
+            self.incumbent = self.scenario.cs.get_default_configuration()
+
     def run(self):
         """Runs the Bayesian optimization loop
 

--- a/smac/tae/execute_func.py
+++ b/smac/tae/execute_func.py
@@ -29,8 +29,9 @@ class AbstractTAFunc(ExecuteTARun):
     """
 
     def __init__(self, ta, stats=None, runhistory=None, run_obj:str="quality",
-                 memory_limit:int=None, par_factor:int=1, 
+                 memory_limit:int=None, par_factor:int=1,
                  cost_for_crash:float=float(MAXINT),
+                 abort_on_first_run_crash: bool=False,
                  use_pynisher:bool=True):
 
         super().__init__(ta=ta, stats=stats, runhistory=runhistory,
@@ -38,7 +39,7 @@ class AbstractTAFunc(ExecuteTARun):
                          cost_for_crash=cost_for_crash)
         """
         Abstract class for having a function as target algorithm
-        
+
         Parameters
         ----------
         ta : callable

--- a/smac/tae/execute_ta_run.py
+++ b/smac/tae/execute_ta_run.py
@@ -81,7 +81,8 @@ class ExecuteTARun(object):
 
     def __init__(self, ta, stats=None, runhistory=None,
                  run_obj: str="runtime", par_factor: int=1,
-                 cost_for_crash: float=float(MAXINT)):
+                 cost_for_crash: float=float(MAXINT),
+                 abort_on_first_run_crash: bool=False):
         """Constructor
 
         Parameters
@@ -99,6 +100,8 @@ class ExecuteTARun(object):
         crash_cost : float
             cost that is used in case of crashed runs (including runs
             that returned NaN or inf)
+        abort_on_first_run_crash: bool
+            if true and first run crashes, raise FirstRunCrashedException
         """
         self.ta = ta
         self.stats = stats
@@ -107,6 +110,7 @@ class ExecuteTARun(object):
 
         self.par_factor = par_factor
         self.crash_cost = cost_for_crash
+        self.abort_on_first_run_crash = abort_on_first_run_crash
 
         self.logger = logging.getLogger(
             self.__module__ + '.' + self.__class__.__name__)
@@ -215,13 +219,13 @@ class ExecuteTARun(object):
 
         if status == StatusType.CAPPED:
             raise CappedRunException("")
-        
-        if self.stats.ta_runs == 1 and status == StatusType.CRASHED:
+
+        if self.abort_on_first_run_crash and self.stats.ta_runs == 1 and status == StatusType.CRASHED:
             raise FirstRunCrashedException("First run crashed, abort. "
                                            "Please check your setup -- "
                                            "we assume that your default"
                                            "configuration does not crashes. "
-                                           "(To deactivate this exception," 
+                                           "(To deactivate this exception,"
                                            " use the SMAC scenario option "
                                            "'abort_on_first_run_crash')")
 

--- a/smac/tae/execute_ta_run.py
+++ b/smac/tae/execute_ta_run.py
@@ -82,7 +82,7 @@ class ExecuteTARun(object):
     def __init__(self, ta, stats=None, runhistory=None,
                  run_obj: str="runtime", par_factor: int=1,
                  cost_for_crash: float=float(MAXINT),
-                 abort_on_first_run_crash: bool=False):
+                 abort_on_first_run_crash: bool=True):
         """Constructor
 
         Parameters

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -296,6 +296,7 @@ class TestSMBO(unittest.TestCase):
     def test_no_initial_design(self):
         self.scenario.output_dir = "test"
         smac = SMAC(self.scenario)
+        self.output_dirs.append(smac.output_dir)
         smbo = smac.solver
         with mock.patch.object(SingleConfigInitialDesign, "run", return_value=None) as initial_mock:
             smbo.start()

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -293,6 +293,14 @@ class TestSMBO(unittest.TestCase):
                               repetitions=1, use_epm=True, n_jobs=-1, backend='threading')
                 self.assertTrue(epm_validation_mock.called)
 
+    def test_no_initial_design(self):
+        self.scenario.output_dir = "test"
+        smac = SMAC(self.scenario)
+        smbo = smac.solver
+        with mock.patch.object(SingleConfigInitialDesign, "run", return_value=None) as initial_mock:
+            smbo.start()
+            self.assertEqual(smbo.incumbent, smbo.scenario.cs.get_default_configuration())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_tae/test_exec_tae_run.py
+++ b/test/test_tae/test_exec_tae_run.py
@@ -84,7 +84,8 @@ class TaeTest(unittest.TestCase):
                                   'output_dir': ''}, cmd_args=None)
         stats = Stats(scen)
         stats.start_timing()
-        eta = ExecuteTARun(ta=lambda *args: None, stats=stats, run_obj="quality")
+        eta = ExecuteTARun(ta=lambda *args: None, stats=stats,
+                           run_obj="quality", abort_on_first_run_crash=True)
 
         self.assertRaises(
             FirstRunCrashedException, eta.start, config={}, instance=1)


### PR DESCRIPTION
Fix #410, add `abort-on-first-run-crash` argument to tae, so that initial design is not interrupted.