### PR TITLE
FIX catch writing of pcs

### DIFF
--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-import logging
+import traceback
 import typing
 
 from smac.configspace import pcs_new, json, ConfigurationSpace
@@ -10,7 +10,7 @@ class OutputWriter(object):
     """Writing scenario to file."""
 
     def __init__(self):
-        self.logger = logging.getLogger(self.__module__ + "." + self.__class__.__name__) 
+        pass
 
     def write_scenario_file(self, scenario):
         """Write scenario to a file (format is compatible with input_reader).
@@ -94,8 +94,7 @@ class OutputWriter(object):
                     new_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.pcs')
                     self.save_configspace(scenario.cs, new_path, 'pcs_new')
                 except TypeError:
-                    self.logger.warn("PCS format does not support given configuration space... "
-                                     "not written to disk")
+                    traceback.print_exc()
                 json_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.json')
                 self.save_configspace(scenario.cs, json_path, 'json')
             elif key == 'train_inst_fn' and scenario.train_insts != [None]:

--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-
+import logging
 import typing
 
 from smac.configspace import pcs_new, json, ConfigurationSpace
@@ -10,7 +10,7 @@ class OutputWriter(object):
     """Writing scenario to file."""
 
     def __init__(self):
-        pass
+        self.logger = logging.getLogger(self.__module__ + "." + self.__class__.__name__) 
 
     def write_scenario_file(self, scenario):
         """Write scenario to a file (format is compatible with input_reader).
@@ -90,8 +90,12 @@ class OutputWriter(object):
                 except shutil.SameFileError:
                     return value  # File is already in output_dir
             elif key == 'pcs_fn' and scenario.cs is not None:
-                new_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.pcs')
-                self.save_configspace(scenario.cs, new_path, 'pcs_new')
+                try:
+                    new_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.pcs')
+                    self.save_configspace(scenario.cs, new_path, 'pcs_new')
+                except TypeError:
+                    self.logger.warn("PCS format does not support given configuration space... "
+                                     "not written to disk")
                 json_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.json')
                 self.save_configspace(scenario.cs, json_path, 'json')
             elif key == 'train_inst_fn' and scenario.train_insts != [None]:

--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -4,13 +4,13 @@ import traceback
 import typing
 
 from smac.configspace import pcs_new, json, ConfigurationSpace
-
+from smac.utils.logging import PickableLoggerAdapter
 
 class OutputWriter(object):
     """Writing scenario to file."""
 
     def __init__(self):
-        pass
+        self.logger = PickableLoggerAdapter(name=self.__module__ + "." + self.__class__.__name__)
 
     def write_scenario_file(self, scenario):
         """Write scenario to a file (format is compatible with input_reader).
@@ -94,7 +94,8 @@ class OutputWriter(object):
                     new_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.pcs')
                     self.save_configspace(scenario.cs, new_path, 'pcs_new')
                 except TypeError:
-                    traceback.print_exc()
+                    self.logger.error("Could not write pcs file to disk." 
+                    " ConfigSpace not compatible with (new) pcs format.")
                 json_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.json')
                 self.save_configspace(scenario.cs, json_path, 'json')
             elif key == 'train_inst_fn' and scenario.train_insts != [None]:

--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import traceback
 import typing
 
 from smac.configspace import pcs_new, json, ConfigurationSpace
@@ -94,7 +93,7 @@ class OutputWriter(object):
                     new_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.pcs')
                     self.save_configspace(scenario.cs, new_path, 'pcs_new')
                 except TypeError:
-                    self.logger.error("Could not write pcs file to disk." 
+                    self.logger.error("Could not write pcs file to disk."
                     " ConfigSpace not compatible with (new) pcs format.")
                 json_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.json')
                 self.save_configspace(scenario.cs, json_path, 'json')


### PR DESCRIPTION
Writing the cs in pcs can fail if not all parameter values of cat parameter are strings. The json format can deal with it. Therefore, I added a catch and try block to prevent SMAC from crashing.