### PR TITLE
ADD option to use only time reported by TA

### DIFF
--- a/smac/facade/smac_facade.py
+++ b/smac/facade/smac_facade.py
@@ -289,6 +289,7 @@ class SMAC(object):
                                       run_obj_time=scenario.run_obj == "runtime",
                                       always_race_against=scenario.cs.get_default_configuration()
                                       if scenario.always_race_default else None,
+                                      use_ta_time_bound=scenario.use_ta_time,
                                       instance_specifics=scenario.instance_specific,
                                       minR=scenario.minR,
                                       maxR=scenario.maxR,

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -48,6 +48,9 @@ class Intensifier(object):
     always_race_against: Configuration
         if incumbent changes race this configuration always against new incumbent;
         can sometimes prevent over-tuning
+    use_ta_time_bound: bool,
+        if true, trust time reported by the target algorithms instead of
+        measuring the wallclock time for limiting the time of intensification
     run_limit : int
         Maximum number of target algorithm runs per call to intensify.
     maxR : int
@@ -71,6 +74,7 @@ class Intensifier(object):
                  run_obj_time: bool=True,
                  always_race_against: Configuration=None,
                  run_limit: int=MAXINT,
+                 use_ta_time_bound: bool=False,
                  minR: int=1, maxR: int=2000,
                  adaptive_capping_slackfactor: float=1.2,
                  min_chall: int=2):
@@ -108,8 +112,11 @@ class Intensifier(object):
         self._num_run = 0
         self._chall_indx = 0
 
+        self._ta_time = 0
+        self.use_ta_time_bound = use_ta_time_bound
         self._min_time = 10**-5
         self.min_chall = min_chall
+        
 
     def intensify(self, challengers: typing.List[Configuration],
                   incumbent: Configuration,
@@ -145,6 +152,7 @@ class Intensifier(object):
             empirical performance of incumbent configuration
         """
         self.start_time = time.time()
+        self._ta_time = 0
 
         if time_bound < self._min_time:
             raise ValueError("time_bound must be >= %f" %(self._min_time))
@@ -195,10 +203,15 @@ class Intensifier(object):
                     self.logger.debug(
                         "Maximum #runs for intensification reached")
                     break
-                elif tm - self.start_time - time_bound >= 0:
-                    self.logger.debug("Timelimit for intensification reached ("
-                                      "used: %f sec, available: %f sec)" %
-                                      (tm - self.start_time, time_bound))
+                if not self.use_ta_time_bound and tm - self.start_time - time_bound >= 0:
+                    self.logger.debug("Wallclock time limit for intensification reached ("
+                                        "used: %f sec, available: %f sec)" %
+                                        (tm - self.start_time, time_bound))
+                    break
+                elif self._ta_time - time_bound >= 0:
+                    self.logger.debug("TA time limit for intensification reached ("
+                                          "used: %f sec, available: %f sec)" %
+                                          (self._ta_time, time_bound))
                     break
 
         # output estimated performance of incumbent
@@ -268,7 +281,7 @@ class Intensifier(object):
                         seed=next_seed,
                         cutoff=self.cutoff,
                         instance_specific=self.instance_specifics.get(next_instance, "0"))
-
+                    self._ta_time += dur
                     self._num_run += 1
                 else:
                     self.logger.debug("No further instance-seed pairs for "
@@ -366,6 +379,7 @@ class Intensifier(object):
                         capped=(self.cutoff is not None) and
                                (cutoff < self.cutoff))
                     self._num_run += 1
+                    self._ta_time += dur
                 except CappedRunException:
                     return incumbent
 

--- a/smac/scenario/scenario.py
+++ b/smac/scenario/scenario.py
@@ -3,6 +3,8 @@ import numpy
 import copy
 import typing
 
+import numpy as np
+
 from smac.utils.io.input_reader import InputReader
 from smac.utils.io.output_writer import OutputWriter
 from smac.utils.io.cmd_reader import CMDReader
@@ -121,6 +123,11 @@ class Scenario(object):
                 self.feature_array.append(self.feature_dict[inst_])
             self.feature_array = numpy.array(self.feature_array)
             self.n_features = self.feature_array.shape[1]
+
+        if self.use_ta_time:
+            if self.algo_runs_timelimit is None or not np.isfinite(self.algo_runs_timelimit):
+                self.algo_runs_timelimit = self.wallclock_limit
+            self.wallclock_limit = np.inf
 
     def __getstate__(self):
         d = dict(self.__dict__)

--- a/smac/utils/io/cmd_reader.py
+++ b/smac/utils/io/cmd_reader.py
@@ -463,6 +463,10 @@ class CMDReader(object):
         smac_opts.add_argument("--hydra-iterations", "--hydra_iterations", dest="hydra_iterations",
                                default=3, type=int,
                                help="[dev] number of hydra iterations. Only active if mode is set to Hydra")
+        smac_opts.add_argument("--use-ta-time", "--use_ta_time", dest="use_ta_time",
+                               default=False, type=bool,
+                               help="[dev] Instead of measuring SMAC's wallclock time, "
+                               "only consider time reported by the target algorithm (ta).")
 
         # Hyperparameters
         smac_opts.add_argument("--always-race-default", "--always_race_default", dest='always_race_default',


### PR DESCRIPTION
required for use with surrogate benchmarks since wallclock time should be much smaller than time reported by TA