### PR TITLE
parser argument use_ta_time type to 'truthy'

### DIFF
--- a/smac/utils/io/cmd_reader.py
+++ b/smac/utils/io/cmd_reader.py
@@ -464,7 +464,7 @@ class CMDReader(object):
                                default=3, type=int,
                                help="[dev] number of hydra iterations. Only active if mode is set to Hydra")
         smac_opts.add_argument("--use-ta-time", "--use_ta_time", dest="use_ta_time",
-                               default=False, type=bool,
+                               default=False, type=truthy,
                                help="[dev] Instead of measuring SMAC's wallclock time, "
                                "only consider time reported by the target algorithm (ta).")
 


### PR DESCRIPTION
I switched to the development version of SMAC since I started using AutoFolio. I noticed that my computing cluster started cancelling jobs because of time limits. For some reason, SMAC had set my 'wallclock_limit' time to 'algo_runs_timelimit' without me specifying the 'use_ta_time' argument.

I think this was the cause, as the standard value for 'use_ta_time' ((str) False) was sent to the argparser and interpreted as (Bool)True.