### PR TITLE
update doc to point to contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,6 @@ See examples/
 
 SMAC3 is developed by the [AutoML Group of the University of Freiburg](http://www.automl.org/).
 
-If you found a bug, please report to https://github.com/automl/SMAC3
+If you found a bug, please report to <https://github.com/automl/SMAC3/issues>.
+
+Our guidelines for contributing to this package can be found [here](https://github.com/automl/SMAC3/blob/master/.github/CONTRIBUTING.md)

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -24,14 +24,25 @@ You can also run SMAC with :code:`--verbose DEBUG` to see how *SMAC* tried to ca
 
 Use the `restore-option <basic_usage.html#restorestate>`_.
 
-.. rubric:: I discovered a bug/have criticism or ideas on *SMAC*. Where should I report to?
+.. rubric:: I discovered a bug or SMAC does not behave as expected. Where should I report to?
 
-*SMAC* uses the
-`GitHub issue-tracker <https://github.com/automl/SMAC3/issues>`_ to take care
-of bugs and questions. If you experience problems with *SMAC*, try to provide
-a full error report with all the typical information (OS, version,
-console-output, minimum working example, ...). This makes it a lot easier to
-reproduce the error and locate the problem.
+Open an issue in our issue list on GitHub. Before you report a bug, please make sure that:
+
+  * Your bug hasn't already been reported in our issue tracker
+  * You are using the latest SMAC3 version.
+
+If you found an issue, please provide us with the following information:
+
+  * A description of the problem
+  * An example to reproduce the problem
+  * Any information about your setup that could be helpful to resolve the bug (such as installed python packages)
+  * Feel free, to add a screenshot showing the issue
+
+.. rubric:: I want to contribute code or discuss a new idea. Where should I report to?
+
+*SMAC* uses the `GitHub issue-tracker <https://github.com/automl/SMAC3/issues>`_ to also take care
+of questions and feedback and is the preferred location for discussing new features and ongoing work. Please also have a look at our
+`contribution guide <https://github.com/automl/SMAC3/blob/master/.github/CONTRIBUTING.md>`_.
 
 .. rubric:: What is the meaning of *deterministic*?
 
@@ -40,7 +51,6 @@ To evaluate a configuration of a non-deterministic algorithm, multiple runs with
 to determine the performance of that configuration on one instance.
 Deterministic algorithms don't depend on seeds, thus requiring only one evaluation of a configuration on an instance
 to evaluate the performance on that instance. Nevertheless the default seed 0 is still passed to the target algorithm.
-
 
 .. rubric:: **Glossary**
 


### PR DESCRIPTION
Slightly modifies the FAQ to point to our contribution guide (link will only work if merged to master) and provide information for contributing code.