### PR TITLE
Issue 478 json pcs

### DIFF
--- a/smac/utils/io/cmd_reader.py
+++ b/smac/utils/io/cmd_reader.py
@@ -7,6 +7,7 @@ import re
 import shlex
 import sys
 from smac.configspace import pcs, pcs_new
+from smac.configspace import json as pcs_json
 from smac.utils.constants import MAXINT, N_TREES
 from smac.utils.io.input_reader import InputReader
 import time
@@ -133,13 +134,18 @@ class ReadPCSFileAction(Action):
         fn = values
         if fn:
             if os.path.isfile(fn):
+                # Three possible formats: json, pcs and pcs_new. We prefer json.
                 with open(fn) as fp:
-                    pcs_str = fp.readlines()
-                    try:
-                        parsed_scen_args["cs"] = pcs.read(pcs_str)
-                    except:
-                        logger.debug("Could not parse pcs file with old format; trying new format ...")
-                        parsed_scen_args["cs"] = pcs_new.read(pcs_str)
+                    if fn.endswith('.json'):
+                        parsed_scen_args['cs'] = pcs_json.read(fp.read())
+                        logger.debug("Loading pcs as json from: %s", fn)
+                    else:
+                        pcs_str = fp.readlines()
+                        try:
+                            parsed_scen_args["cs"] = pcs.read(pcs_str)
+                        except:
+                            logger.debug("Could not parse pcs file with old format; trying new format ...")
+                            parsed_scen_args["cs"] = pcs_new.read(pcs_str)
                     parsed_scen_args["cs"].seed(42)
             else:
                 parser.exit(1, "Could not find pcs file: {}".format(fn))

--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -90,13 +90,13 @@ class OutputWriter(object):
                     return value  # File is already in output_dir
             elif key == 'pcs_fn' and scenario.cs is not None:
                 try:
-                    new_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.pcs')
-                    self.save_configspace(scenario.cs, new_path, 'pcs_new')
+                    pcs_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.pcs')
+                    self.save_configspace(scenario.cs, pcs_path, 'pcs_new')
                 except TypeError:
                     self.logger.error("Could not write pcs file to disk."
                     " ConfigSpace not compatible with (new) pcs format.")
-                json_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.json')
-                self.save_configspace(scenario.cs, json_path, 'json')
+                new_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.json')
+                self.save_configspace(scenario.cs, new_path, 'json')
             elif key == 'train_inst_fn' and scenario.train_insts != [None]:
                 new_path = os.path.join(scenario.output_dir_for_this_run, 'train_insts.txt')
                 self.write_inst_file(scenario.train_insts, new_path)

--- a/smac/utils/io/output_writer.py
+++ b/smac/utils/io/output_writer.py
@@ -85,9 +85,15 @@ class OutputWriter(object):
             # Copy if file exists, else write to new file
             if value is not None and os.path.isfile(value):
                 try:
-                    return shutil.copy(value, scenario.output_dir_for_this_run)
+                    new_path = shutil.copy(value, scenario.output_dir_for_this_run)
                 except shutil.SameFileError:
-                    return value  # File is already in output_dir
+                    new_path = value  # File is already in output_dir
+                # For .pcs-file, also save with the same basename as json and use json-path!
+                if key == 'pcs_fn' and scenario.cs is not None and value.endswith('.pcs'):
+                    file_name = os.path.splitext(os.path.basename(value))[0]
+                    new_path = os.path.join(scenario.output_dir_for_this_run, file_name + '.json')
+                    self.save_configspace(scenario.cs, new_path, 'json')
+                    scenario.logger.debug("Setting the pcs_fn-attr of written scenario from %s to %s", value, new_path)
             elif key == 'pcs_fn' and scenario.cs is not None:
                 try:
                     pcs_path = os.path.join(scenario.output_dir_for_this_run, 'configspace.pcs')

--- a/test/test_scenario/test_scenario.py
+++ b/test/test_scenario/test_scenario.py
@@ -215,7 +215,7 @@ class ScenarioTest(unittest.TestCase):
                 name = dest if dest else name  # if 'dest' is None, use 'name'
                 if name in ["pcs_fn", "train_inst_fn", "test_inst_fn",
                             "feature_fn", "output_dir"]:
-                    continue  # Those values are changed upon logging
+                    continue  # Those values are allowed to change when writing to disk
                 elif name == 'cs':
                     # Using repr because of cs-bug
                     # (https://github.com/automl/ConfigSpace/issues/25)
@@ -242,6 +242,10 @@ class ScenarioTest(unittest.TestCase):
         path = os.path.join(scenario.output_dir, 'scenario.txt')
         scenario_reloaded = Scenario(path)
         check_scen_eq(scenario, scenario_reloaded)
+        # Test whether json is the default pcs_fn
+        self.assertTrue(os.path.exists(os.path.join(scenario.output_dir, 'param.pcs')))
+        self.assertTrue(os.path.exists(os.path.join(scenario.output_dir, 'param.json')))
+        self.assertEqual(scenario_reloaded.pcs_fn, os.path.join(scenario.output_dir, 'param.json'))
 
         # Now create new scenario without filepaths
         self.test_scenario_dict.update({
@@ -254,6 +258,10 @@ class ScenarioTest(unittest.TestCase):
         scenario_no_fn = Scenario(self.test_scenario_dict)
         scenario_reloaded = Scenario(path)
         check_scen_eq(scenario_no_fn, scenario_reloaded)
+        # Test whether json is the default pcs_fn
+        self.assertTrue(os.path.exists(os.path.join(scenario.output_dir, 'param.pcs')))
+        self.assertTrue(os.path.exists(os.path.join(scenario.output_dir, 'param.json')))
+        self.assertEqual(scenario_reloaded.pcs_fn, os.path.join(scenario.output_dir, 'param.json'))
 
     @mock.patch.object(os, 'makedirs')
     @mock.patch.object(os.path, 'isdir')


### PR DESCRIPTION
Fixing #478, always write pcs as json when writing scenario. If it was in pcs-format before, we write the json additionally to the pcs-format and set the path in the scenario to the json-file. Generally, both get written if possible.