### PR TITLE
FIX #489 reading in pcs_new and json with input_reader

### DIFF
--- a/smac/utils/io/cmd_reader.py
+++ b/smac/utils/io/cmd_reader.py
@@ -134,19 +134,8 @@ class ReadPCSFileAction(Action):
         fn = values
         if fn:
             if os.path.isfile(fn):
-                # Three possible formats: json, pcs and pcs_new. We prefer json.
-                with open(fn) as fp:
-                    if fn.endswith('.json'):
-                        parsed_scen_args['cs'] = pcs_json.read(fp.read())
-                        logger.debug("Loading pcs as json from: %s", fn)
-                    else:
-                        pcs_str = fp.readlines()
-                        try:
-                            parsed_scen_args["cs"] = pcs.read(pcs_str)
-                        except:
-                            logger.debug("Could not parse pcs file with old format; trying new format ...")
-                            parsed_scen_args["cs"] = pcs_new.read(pcs_str)
-                    parsed_scen_args["cs"].seed(42)
+                parsed_scen_args['cs'] = in_reader.read_pcs_file(fn)
+                parsed_scen_args["cs"].seed(42)
             else:
                 parser.exit(1, "Could not find pcs file: {}".format(fn))
         setattr(namespace, self.dest, values)

--- a/smac/utils/io/input_reader.py
+++ b/smac/utils/io/input_reader.py
@@ -1,5 +1,6 @@
 import numpy as np
-from smac.configspace import pcs
+from smac.configspace import pcs, pcs_new
+from smac.configspace import json as pcs_json
 
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2015, ML4AAD"
@@ -173,7 +174,8 @@ class InputReader(object):
         return [f.strip() for f in lines[0].rstrip("\n").split(",")[1:]], instances
 
     def read_pcs_file(self, fn: str):
-        """Encapsulates generating configuration space object
+        """Encapsulates generating configuration space object.
+        Automatically detects whether the cs is saved in json, pcs or pcs_new.
 
         Parameters
         ----------
@@ -184,5 +186,13 @@ class InputReader(object):
         -------
             ConfigSpace: ConfigSpace
         """
-        space = pcs.read(fn)
-        return space
+        with open(fn) as fp:
+            if fn.endswith('.json'):
+                cs = pcs_json.read(fp.read())
+            else:
+                pcs_str = fp.readlines()
+                try:
+                    cs = pcs.read(pcs_str)
+                except:
+                    cs = pcs_new.read(pcs_str)
+        return cs

--- a/smac/utils/io/input_reader.py
+++ b/smac/utils/io/input_reader.py
@@ -173,7 +173,7 @@ class InputReader(object):
                 instances[tmp[0]] = np.array(tmp[1:], dtype=np.double)
         return [f.strip() for f in lines[0].rstrip("\n").split(",")[1:]], instances
 
-    def read_pcs_file(self, fn: str):
+    def read_pcs_file(self, fn: str, logger=None):
         """Encapsulates generating configuration space object.
         Automatically detects whether the cs is saved in json, pcs or pcs_new.
 
@@ -186,13 +186,18 @@ class InputReader(object):
         -------
             ConfigSpace: ConfigSpace
         """
+        # Three possible formats: json, pcs and pcs_new. We prefer json.
         with open(fn) as fp:
             if fn.endswith('.json'):
                 cs = pcs_json.read(fp.read())
+                if logger:
+                    logger.debug("Loading pcs as json from: %s", fn)
             else:
                 pcs_str = fp.readlines()
                 try:
                     cs = pcs.read(pcs_str)
-                except:
+                except NotImplementedError:
+                    if logger:
+                        logger.debug("Could not parse pcs file with old format; trying new format ...")
                     cs = pcs_new.read(pcs_str)
         return cs

--- a/smac/utils/io/input_reader.py
+++ b/smac/utils/io/input_reader.py
@@ -174,7 +174,7 @@ class InputReader(object):
         return [f.strip() for f in lines[0].rstrip("\n").split(",")[1:]], instances
 
     @staticmethod
-    def read_pcs_file(self, fn: str, logger=None):
+    def read_pcs_file(fn: str, logger=None):
         """Encapsulates generating configuration space object from file.
 
         Automatically detects whether the cs is saved in json, pcs or pcs_new.

--- a/smac/utils/io/input_reader.py
+++ b/smac/utils/io/input_reader.py
@@ -173,8 +173,10 @@ class InputReader(object):
                 instances[tmp[0]] = np.array(tmp[1:], dtype=np.double)
         return [f.strip() for f in lines[0].rstrip("\n").split(",")[1:]], instances
 
+    @staticmethod
     def read_pcs_file(self, fn: str, logger=None):
-        """Encapsulates generating configuration space object.
+        """Encapsulates generating configuration space object from file.
+
         Automatically detects whether the cs is saved in json, pcs or pcs_new.
 
         Parameters

--- a/test/test_utils/io/test_inputreader.py
+++ b/test/test_utils/io/test_inputreader.py
@@ -62,19 +62,29 @@ class InputReaderTest(unittest.TestCase):
         hyp = UniformFloatHyperparameter('A', 0.0, 1.0, default_value=0.5)
         cs.add_hyperparameters([hyp])
 
-        # pcs_new
         output_writer = OutputWriter()
         input_reader = InputReader()
 
+        # pcs_new
         output_writer.save_configspace(cs, self.pcs_fn, 'pcs_new')
         restored_cs = input_reader.read_pcs_file(self.pcs_fn)
         self.assertEqual(cs, restored_cs)
+        restored_cs = input_reader.read_pcs_file(self.pcs_fn, self.logger)
+        self.assertEqual(cs, restored_cs)
 
+        # json
         output_writer.save_configspace(cs, self.json_fn, 'json')
         restored_cs = input_reader.read_pcs_file(self.json_fn)
         self.assertEqual(cs, restored_cs)
+        restored_cs = input_reader.read_pcs_file(self.json_fn, self.logger)
+        self.assertEqual(cs, restored_cs)
 
+        # pcs
         with open(self.pcs_fn, 'w') as fh:
             fh.write(pcs.write(cs))
         restored_cs = input_reader.read_pcs_file(self.pcs_fn)
+        self.assertEqual(cs, restored_cs)
+        restored_cs = input_reader.read_pcs_file(self.pcs_fn)
+        self.assertEqual(cs, restored_cs)
+        restored_cs = input_reader.read_pcs_file(self.pcs_fn, self.logger)
         self.assertEqual(cs, restored_cs)

--- a/test/test_utils/io/test_inputreader.py
+++ b/test/test_utils/io/test_inputreader.py
@@ -11,8 +11,7 @@ import numpy as np
 
 from smac.configspace import ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter
-from smac.configspace import pcs, pcs_new
-from smac.configspace import json as pcs_json
+from smac.configspace import pcs
 from smac.utils.io.input_reader import InputReader
 from smac.utils.io.output_writer import OutputWriter
 
@@ -40,7 +39,7 @@ class InputReaderTest(unittest.TestCase):
             if output_file:
                 try:
                     os.remove(output_file)
-                except FileNotFoundError as e:
+                except FileNotFoundError:
                     pass
 
         os.chdir(self.current_dir)
@@ -57,7 +56,7 @@ class InputReaderTest(unittest.TestCase):
             self.assertEqual(feats_original[i], list(feats[1][i]))
 
     def test_save_load_configspace(self):
-        """ Check if inputreader can load different config-spaces """
+        """Check if inputreader can load different config-spaces"""
         cs = ConfigurationSpace()
         hyp = UniformFloatHyperparameter('A', 0.0, 1.0, default_value=0.5)
         cs.add_hyperparameters([hyp])

--- a/test/test_utils/io/test_inputreader.py
+++ b/test/test_utils/io/test_inputreader.py
@@ -9,7 +9,12 @@ import logging
 
 import numpy as np
 
+from smac.configspace import ConfigurationSpace
+from ConfigSpace.hyperparameters import UniformFloatHyperparameter
+from smac.configspace import pcs, pcs_new
+from smac.configspace import json as pcs_json
 from smac.utils.io.input_reader import InputReader
+from smac.utils.io.output_writer import OutputWriter
 
 
 class InputReaderTest(unittest.TestCase):
@@ -24,7 +29,20 @@ class InputReaderTest(unittest.TestCase):
                                                       '..', '..'))
         os.chdir(base_directory)
 
+        # Files that will be created:
+        self.pcs_fn = "test/test_files/configspace.pcs"
+        self.json_fn = "test/test_files/configspace.json"
+
+        self.output_files = [self.pcs_fn, self.json_fn]
+
     def tearDown(self):
+        for output_file in self.output_files:
+            if output_file:
+                try:
+                    os.remove(output_file)
+                except FileNotFoundError as e:
+                    pass
+
         os.chdir(self.current_dir)
 
     def test_feature_input(self):
@@ -37,3 +55,26 @@ class InputReaderTest(unittest.TestCase):
                           "inst3":[1.7, 1.8, 1.9]}
         for i in feats[1]:
             self.assertEqual(feats_original[i], list(feats[1][i]))
+
+    def test_save_load_configspace(self):
+        """ Check if inputreader can load different config-spaces """
+        cs = ConfigurationSpace()
+        hyp = UniformFloatHyperparameter('A', 0.0, 1.0, default_value=0.5)
+        cs.add_hyperparameters([hyp])
+
+        # pcs_new
+        output_writer = OutputWriter()
+        input_reader = InputReader()
+
+        output_writer.save_configspace(cs, self.pcs_fn, 'pcs_new')
+        restored_cs = input_reader.read_pcs_file(self.pcs_fn)
+        self.assertEqual(cs, restored_cs)
+
+        output_writer.save_configspace(cs, self.json_fn, 'json')
+        restored_cs = input_reader.read_pcs_file(self.json_fn)
+        self.assertEqual(cs, restored_cs)
+
+        with open(self.pcs_fn, 'w') as fh:
+            fh.write(pcs.write(cs))
+        restored_cs = input_reader.read_pcs_file(self.pcs_fn)
+        self.assertEqual(cs, restored_cs)


### PR DESCRIPTION
Fix #489, add input_reader support for `pcs_new` and `json`.
Also, add tests.