### PR TITLE
MAINT speed up rf predictions for log transformed data

### DIFF
--- a/smac/epm/base_epm.py
+++ b/smac/epm/base_epm.py
@@ -7,6 +7,8 @@ from sklearn.decomposition import PCA
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.exceptions import NotFittedError
 
+from smac.utils.constants import VERY_SMALL_NUMBER
+
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2016, ML4AAD"
 __license__ = "3-clause BSD"
@@ -92,7 +94,7 @@ class AbstractEPM(object):
             self.scaler = MinMaxScaler()
 
         # Never use a lower variance than this
-        self.var_threshold = 10 ** -5
+        self.var_threshold = VERY_SMALL_NUMBER
 
         self.bounds = bounds
         self.types = types

--- a/smac/epm/rf_with_instances.py
+++ b/smac/epm/rf_with_instances.py
@@ -5,7 +5,7 @@ import numpy as np
 from pyrfr import regression
 
 from smac.epm.base_epm import AbstractEPM
-from smac.utils.constants import N_TREES
+from smac.utils.constants import N_TREES, VERY_SMALL_NUMBER
 
 
 __author__ = "Aaron Klein"
@@ -213,7 +213,7 @@ class RandomForestWithInstances(AbstractEPM):
                     preds_as_array[i, j, :len(pred)] = pred
 
             # Do all necessary computation with vectorized functions
-            preds_as_array = np.log(np.nanmean(np.exp(preds_as_array), axis=2) + 1e-10)
+            preds_as_array = np.log(np.nanmean(np.exp(preds_as_array), axis=2) + VERY_SMALL_NUMBER)
 
             # Compute the mean and the variance across the different trees
             means = preds_as_array.mean(axis=1)

--- a/smac/epm/rf_with_instances.py
+++ b/smac/epm/rf_with_instances.py
@@ -200,7 +200,8 @@ class RandomForestWithInstances(AbstractEPM):
             all_means_per_tree = []
             for row_X in X:
                 preds_per_tree = self.rf.all_leaf_values(row_X)
-                means_per_tree = [math.log(np.exp(preds).mean()) for preds in preds_per_tree]
+                # Adding 1e-8 to avoid a math domain error which can happen if np.exp(preds) is almost zero
+                means_per_tree = [math.log(np.exp(preds).mean() + 1e-8) for preds in preds_per_tree]
                 all_means_per_tree.append(means_per_tree)
             means = np.mean(all_means_per_tree, axis=1)
             vars_ = np.var(all_means_per_tree, axis=1)

--- a/smac/epm/rf_with_instances.py
+++ b/smac/epm/rf_with_instances.py
@@ -1,5 +1,4 @@
 import logging
-import math
 import typing
 
 import numpy as np
@@ -41,16 +40,16 @@ class RandomForestWithInstances(AbstractEPM):
     def __init__(self, types: np.ndarray,
                  bounds: typing.List[typing.Tuple[float, float]],
                  seed: int,
-                 log_y: bool=False,
-                 num_trees: int=N_TREES,
-                 do_bootstrapping: bool=True,
-                 n_points_per_tree: int=-1,
-                 ratio_features: float=5. / 6.,
-                 min_samples_split: int=3,
-                 min_samples_leaf: int=3,
-                 max_depth: int=2**20,
-                 eps_purity: float=1e-8,
-                 max_num_nodes: int=2**20,
+                 log_y: bool = False,
+                 num_trees: int = N_TREES,
+                 do_bootstrapping: bool = True,
+                 n_points_per_tree: int = -1,
+                 ratio_features: float = 5. / 6.,
+                 min_samples_split: int = 3,
+                 min_samples_leaf: int = 3,
+                 max_depth: int = 2**20,
+                 eps_purity: float = 1e-8,
+                 max_num_nodes: int = 2**20,
                  **kwargs):
         """
         Parameters
@@ -125,7 +124,7 @@ class RandomForestWithInstances(AbstractEPM):
         ----------
         X : np.ndarray [n_samples, n_features (config + instance features)]
             Input data points.
-        Y : np.ndarray [n_samples, ]
+        y : np.ndarray [n_samples, ]
             The corresponding target values.
 
         Returns
@@ -310,5 +309,3 @@ class RandomForestWithInstances(AbstractEPM):
             var = var.reshape((-1, 1))
 
         return mean_, var
-
-

--- a/smac/optimizer/ei_optimization.py
+++ b/smac/optimizer/ei_optimization.py
@@ -289,7 +289,7 @@ class LocalSearch(AcquisitionFunctionMaximizer):
                 if acq_val == acq_val_incumbent:
                     neighbors.append(neighbor)
                 if acq_val > acq_val_incumbent:
-                    self.logger.debug("Switch to one of the neighbors")
+                    self.logger.debug("Switch to one of the neighbors (after %d configurations).", neighbors_looked_at)
                     incumbent = neighbor
                     acq_val_incumbent = acq_val
                     changed_inc = True

--- a/smac/runhistory/runhistory2epm.py
+++ b/smac/runhistory/runhistory2epm.py
@@ -461,6 +461,7 @@ class RunHistory2EPM4InvScaledCost(RunHistory2EPM4Cost):
         """
 
         min_y = self.min_y - (self.perc - self.min_y)  # Subtract the difference between the percentile and the minimum
+        min_y -= 1e-5  # Minimal value to avoid numerical issues in the log scaling below
         # linear scaling
         if min_y == self.max_y:
             # prevent diving by zero
@@ -523,6 +524,7 @@ class RunHistory2EPM4LogScaledCost(RunHistory2EPM4Cost):
         """
 
         min_y = self.min_y - (self.perc - self.min_y)  # Subtract the difference between the percentile and the minimum
+        min_y -= 1e-5  # Minimal value to avoid numerical issues in the log scaling below
         # linear scaling
         if min_y == self.max_y:
             # prevent diving by zero

--- a/smac/runhistory/runhistory2epm.py
+++ b/smac/runhistory/runhistory2epm.py
@@ -461,7 +461,7 @@ class RunHistory2EPM4InvScaledCost(RunHistory2EPM4Cost):
         """
 
         min_y = self.min_y - (self.perc - self.min_y)  # Subtract the difference between the percentile and the minimum
-        min_y -= 1e-5  # Minimal value to avoid numerical issues in the log scaling below
+        min_y -= constants.VERY_SMALL_NUMBER  # Minimal value to avoid numerical issues in the log scaling below
         # linear scaling
         if min_y == self.max_y:
             # prevent diving by zero
@@ -524,7 +524,7 @@ class RunHistory2EPM4LogScaledCost(RunHistory2EPM4Cost):
         """
 
         min_y = self.min_y - (self.perc - self.min_y)  # Subtract the difference between the percentile and the minimum
-        min_y -= 1e-5  # Minimal value to avoid numerical issues in the log scaling below
+        min_y -= constants.VERY_SMALL_NUMBER  # Minimal value to avoid numerical issues in the log scaling below
         # linear scaling
         if min_y == self.max_y:
             # prevent diving by zero

--- a/smac/utils/constants.py
+++ b/smac/utils/constants.py
@@ -1,5 +1,7 @@
 MAXINT = 2 ** 31 - 1
-MINIMAL_COST_FOR_LOG = 0.00001 
+MINIMAL_COST_FOR_LOG = 0.00001
 MAX_CUTOFF = 65535
+# The very small number is used to avoid numerical instabilities or dividing by zero
+VERY_SMALL_NUMBER = 1e-10,
 
 N_TREES = 10

--- a/smac/utils/constants.py
+++ b/smac/utils/constants.py
@@ -2,6 +2,6 @@ MAXINT = 2 ** 31 - 1
 MINIMAL_COST_FOR_LOG = 0.00001
 MAX_CUTOFF = 65535
 # The very small number is used to avoid numerical instabilities or dividing by zero
-VERY_SMALL_NUMBER = 1e-10,
+VERY_SMALL_NUMBER = 1e-10
 
 N_TREES = 10

--- a/test/test_epm/test_rf_with_instances.py
+++ b/test/test_epm/test_rf_with_instances.py
@@ -251,4 +251,4 @@ class TestRFWithInstances(unittest.TestCase):
                 model.train(X_train, y_train)
                 y_hat, mu_hat = model.predict(X_test)
                 mae = np.mean(np.abs(y_hat - y_test), dtype=np.float128)
-                self.assertAlmostEqual(mae, maes[i])
+                self.assertAlmostEqual(mae, maes[i], msg=('Do log: %s, iteration %i' % (str(do_log), i)))

--- a/test/test_epm/test_rf_with_instances.py
+++ b/test/test_epm/test_rf_with_instances.py
@@ -150,7 +150,7 @@ class TestRFWithInstances(unittest.TestCase):
         self.assertEqual(vars.shape, (11, 1))
         for i in range(11):
             self.assertEqual(means[i], 0.)
-            self.assertEqual(vars[i], 1.e-05)
+            self.assertEqual(vars[i], 1.e-10)
 
     def test_predict_with_actual_values(self):
         X = np.array([


### PR DESCRIPTION
by reshuffling the for loop for computing the mean performance.