### PR TITLE
Change local search starting points

### DIFF
--- a/smac/epm/rf_with_instances.py
+++ b/smac/epm/rf_with_instances.py
@@ -207,7 +207,7 @@ class RandomForestWithInstances(AbstractEPM):
                 third_dimension = max(max_num_leaf_data, third_dimension)
 
             # Transform list of 2d arrays into a 3d array
-            preds_as_array = np.empty((X.shape[0], self.rf_opts.num_trees, third_dimension)) * np.NaN
+            preds_as_array = np.zeros((X.shape[0], self.rf_opts.num_trees, third_dimension)) * np.NaN
             for i, preds_per_tree in enumerate(all_preds):
                 for j, pred in enumerate(preds_per_tree):
                     preds_as_array[i, j, :len(pred)] = pred

--- a/smac/facade/smac_hpo_facade.py
+++ b/smac/facade/smac_hpo_facade.py
@@ -76,7 +76,7 @@ class SMAC4HPO(SMAC4AC):
         # better improve acquisition function optimization
         # 1. increase number of sls iterations
         acquisition_function_optimizer_kwargs = kwargs.get('acquisition_function_optimizer_kwargs', dict())
-        acquisition_function_optimizer_kwargs['n_sls_iterations'] = 100
+        acquisition_function_optimizer_kwargs['n_sls_iterations'] = 10
         kwargs['acquisition_function_optimizer_kwargs'] = acquisition_function_optimizer_kwargs
 
         super().__init__(**kwargs)

--- a/smac/optimizer/ei_optimization.py
+++ b/smac/optimizer/ei_optimization.py
@@ -377,11 +377,6 @@ class LocalSearch(AcquisitionFunctionMaximizer):
 
                             # Found a better configuration
                             if acq_val[acq_index] > acq_val_incumbents[i]:
-                                self.logger.debug(
-                                    "Local search %d: Switch to one of the neighbors (after %d configurations).",
-                                    i,
-                                    neighbors_looked_at[i],
-                                )
                                 incumbents[i] = neighbors[acq_index]
                                 acq_val_incumbents[i] = acq_val[acq_index]
                                 new_neighborhood[i] = True

--- a/smac/optimizer/ei_optimization.py
+++ b/smac/optimizer/ei_optimization.py
@@ -377,6 +377,11 @@ class LocalSearch(AcquisitionFunctionMaximizer):
 
                             # Found a better configuration
                             if acq_val[acq_index] > acq_val_incumbents[i]:
+                                self.logger.debug(
+                                    "Local search %d: Switch to one of the neighbors (after %d configurations).",
+                                    i,
+                                    neighbors_looked_at[i],
+                                )
                                 incumbents[i] = neighbors[acq_index]
                                 acq_val_incumbents[i] = acq_val[acq_index]
                                 new_neighborhood[i] = True
@@ -666,8 +671,8 @@ class InterleavedLocalAndRandomSearch(AcquisitionFunctionMaximizer):
         )
         next_configs_by_acq_value.sort(reverse=True, key=lambda x: x[0])
         self.logger.debug(
-            "First 10 acq func (origin) values of selected configurations: %s",
-            str([[_[0], _[1].origin] for _ in next_configs_by_acq_value])
+            "First 5 acq func (origin) values of selected configurations: %s",
+            str([[_[0], _[1].origin] for _ in next_configs_by_acq_value[:5]])
         )
         next_configs_by_acq_value = [_[1] for _ in next_configs_by_acq_value]
 

--- a/test/test_smbo/test_ei_optimization.py
+++ b/test/test_smbo/test_ei_optimization.py
@@ -160,13 +160,19 @@ class TestLocalSearch(unittest.TestCase):
             self.assertEqual(rval[i][1].origin, 'Local Search')
 
     def test_local_search_finds_minimum(self):
-        def acquisition_function(arrays):
-            rval = []
-            for array in arrays:
-                rval.append([-rosenbrock_4d(array)])
-            return np.array(rval)
+
+        class AcquisitionFunction:
+
+            model = None
+
+            def __call__(self, arrays):
+                rval = []
+                for array in arrays:
+                    rval.append([-rosenbrock_4d(array)])
+                return np.array(rval)
+
         ls = LocalSearch(
-            acquisition_function=acquisition_function,
+            acquisition_function=AcquisitionFunction(),
             config_space=self.cs,
             n_steps_plateau_walk=10,
             max_steps=np.inf,

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -223,8 +223,8 @@ class TestSMBO(unittest.TestCase):
 
         # For each configuration it is randomly sampled whether to take it from the list of challengers or to sample it
         # completely at random. Therefore, it is not guaranteed to obtain twice the number of configurations selected
-        # by EI.
-        self.assertEqual(len(challengers), 9977)
+        # by EI. Interestingly, we obtain a different number of configurations with Python3.5 on travis-ci (9983)
+        self.assertIn(len(challengers), [9977, 9983])
         num_random_search_sorted = 0
         num_random_search = 0
         num_local_search = 0

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import mock
+import sys
 import shutil
 from nose.plugins.attrib import attr
 
@@ -192,6 +193,7 @@ class TestSMBO(unittest.TestCase):
         self.assertEqual(num_random_search_sorted, 5000)
         self.assertEqual(num_random_search, 4929)
 
+    @unittest.skipIf(sys.version_info < (3, 6), 'Test not deterministic for Python 3.5 and earlier')
     def test_choose_next_3(self):
         # Test with ten configurations in the runhistory
         def side_effect(X):
@@ -223,8 +225,8 @@ class TestSMBO(unittest.TestCase):
 
         # For each configuration it is randomly sampled whether to take it from the list of challengers or to sample it
         # completely at random. Therefore, it is not guaranteed to obtain twice the number of configurations selected
-        # by EI. Interestingly, we obtain a different number of configurations with Python3.5 on travis-ci (9983)
-        self.assertIn(len(challengers), [9977, 9983])
+        # by EI
+        self.assertEqual(len(challengers), 9977)
         num_random_search_sorted = 0
         num_random_search = 0
         num_local_search = 0

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -173,7 +173,7 @@ class TestSMBO(unittest.TestCase):
         # For each configuration it is randomly sampled whether to take it from the list of challengers or to sample it
         # completely at random. Therefore, it is not guaranteed to obtain twice the number of configurations selected
         # by EI.
-        self.assertEqual(len(challengers), 9922)
+        self.assertEqual(len(challengers), 9940)
         num_random_search_sorted = 0
         num_random_search = 0
         num_local_search = 0
@@ -188,9 +188,9 @@ class TestSMBO(unittest.TestCase):
             else:
                 raise ValueError((c.origin, 'Local Search' == c.origin, type('Local Search'), type(c.origin)))
 
-        self.assertEqual(num_local_search, 1)
-        self.assertEqual(num_random_search_sorted, 4999)
-        self.assertEqual(num_random_search, 4922)
+        self.assertEqual(num_local_search, 11)
+        self.assertEqual(num_random_search_sorted, 5000)
+        self.assertEqual(num_random_search, 4929)
 
     def test_choose_next_3(self):
         # Test with ten configurations in the runhistory
@@ -224,7 +224,7 @@ class TestSMBO(unittest.TestCase):
         # For each configuration it is randomly sampled whether to take it from the list of challengers or to sample it
         # completely at random. Therefore, it is not guaranteed to obtain twice the number of configurations selected
         # by EI.
-        self.assertEqual(len(challengers), 9908)
+        self.assertEqual(len(challengers), 9977)
         num_random_search_sorted = 0
         num_random_search = 0
         num_local_search = 0
@@ -239,9 +239,9 @@ class TestSMBO(unittest.TestCase):
             else:
                 raise ValueError(c.origin)
 
-        self.assertEqual(num_local_search, 10)
-        self.assertEqual(num_random_search_sorted, 4990)
-        self.assertEqual(num_random_search, 4908)
+        self.assertEqual(num_local_search, 26)
+        self.assertEqual(num_random_search_sorted, 5000)
+        self.assertEqual(num_random_search, 4951)
 
     @mock.patch.object(InitialDesign, 'run')
     def test_abort_on_initial_design(self, patch):


### PR DESCRIPTION
Local search now starts from:

* the `num_points` observed configurations with the highest EI
* the `num_points` observed configurations with the lowest cost
* the `num_points` unobserved configurations with the highest EI, configurations obtained by random search

To account for the increased necessary computation (because of the up to three fold increase of initial points), we reduce the number of local searches from 100 to 10.