### PR TITLE
Fix combination of travis-ci with numpy 1.17

### DIFF
--- a/ci_scripts/run_unittests.sh
+++ b/ci_scripts/run_unittests.sh
@@ -1,2 +1,3 @@
 echo Testing revision $(git rev-parse HEAD) ...
+echo Testing from directory `pwd`
 make test && bash scripts/test_no_files_left.sh

--- a/ci_scripts/run_unittests.sh
+++ b/ci_scripts/run_unittests.sh
@@ -1,3 +1,4 @@
 echo Testing revision $(git rev-parse HEAD) ...
 echo Testing from directory `pwd`
+conda list
 make test && bash scripts/test_no_files_left.sh

--- a/smac/facade/experimental/psmac_facade.py
+++ b/smac/facade/experimental/psmac_facade.py
@@ -192,8 +192,8 @@ class PSMAC(object):
         else:
             _, val_ids, _, est_ids = self.get_best_incumbents_ids(incs)  # determine the best incumbents
             if val_ids:
-                return incs[val_ids]
-            return incs[est_ids]
+                return [inc for i, inc in enumerate(incs) if i in val_ids]
+            return [inc for i, inc in enumerate(incs) if i in est_ids]
 
     def get_best_incumbents_ids(self, incs: typing.List[Configuration]):
         """

--- a/test/test_facade/test_psmac_facade.py
+++ b/test/test_facade/test_psmac_facade.py
@@ -2,6 +2,7 @@ from contextlib import suppress
 import shutil
 import os
 import glob
+import joblib
 import unittest
 from unittest.mock import patch
 
@@ -28,15 +29,16 @@ class TestPSMACFacade(unittest.TestCase):
 
     @patch('smac.facade.smac_ac_facade.SMBO', new=MockSMBO)
     def test_psmac(self):
-        optimizer = PSMAC(self.scenario, n_optimizers=3, n_incs=2, validate=False)
-        incs = optimizer.optimize()
-        self.assertEquals(len(incs), 2)
-        optimizer = PSMAC(self.scenario, n_optimizers=1, n_incs=4, validate=False)
-        incs = optimizer.optimize()
-        self.assertEquals(len(incs), 2)
-        optimizer = PSMAC(self.scenario, n_optimizers=5, n_incs=4, validate=False)
-        incs = optimizer.optimize()
-        self.assertEquals(len(incs), 4)
+        with joblib.parallel_backend('multiprocessing', n_jobs=1):
+            optimizer = PSMAC(self.scenario, n_optimizers=3, n_incs=2, validate=False)
+            incs = optimizer.optimize()
+            self.assertEqual(len(incs), 2)
+            optimizer = PSMAC(self.scenario, n_optimizers=1, n_incs=4, validate=False)
+            incs = optimizer.optimize()
+            self.assertEqual(len(incs), 2)
+            optimizer = PSMAC(self.scenario, n_optimizers=5, n_incs=4, validate=False)
+            incs = optimizer.optimize()
+            self.assertEqual(len(incs), 4)
 
     def tearDown(self):
         hydras = glob.glob1('.', 'psmac*')


### PR DESCRIPTION
This PR

* replaces multiprocessing by joblib to easily obtain the stdout and stderr as well as the return value of the parallelized function
* uses pseudo-parallelism for the unit test