### PR TITLE
Pull architecture (v0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: test
 test:
-	python -m nose -sv --with-coverage --cover-package=smac
+	python -m nose -v --with-coverage --cover-package=smac
 
 .PHONY: test-fast
 test-fast:
@@ -11,7 +11,7 @@ test-fast:
 .PHONY: test-runtimes
 test-runtimes:
 	# requires nose-timer
-	python -m nose -sv --with-timer --timer-top-n 15
+	python -m nose -v --with-timer --timer-top-n 15
 
 .PHONY: doc
 doc:

--- a/examples/SMAC4HPO_rf.py
+++ b/examples/SMAC4HPO_rf.py
@@ -82,7 +82,7 @@ max_leaf_nodes = UniformIntegerHyperparameter("max_leaf_nodes", 10, 1000, defaul
 cs.add_hyperparameters([num_trees, min_weight_frac_leaf, criterion,
         max_features, min_samples_to_split, min_samples_in_leaf, max_leaf_nodes])
 
-# SMAC scenario oject
+# SMAC scenario object
 scenario = Scenario({"run_obj": "quality",   # we optimize quality (alternative runtime)
                      "runcount-limit": 10,   # max. number of function evaluations; for this example set to a low number
                      "cs": cs,               # configuration space

--- a/examples/SMAC4HPO_sgd_hyperband_instances.py
+++ b/examples/SMAC4HPO_sgd_hyperband_instances.py
@@ -102,7 +102,7 @@ cs.add_hyperparameters([alpha, l1_ratio, learning_rate, eta0])
 scenario = Scenario({"run_obj": "quality",      # we optimize quality (alternative to runtime)
                      "wallclock-limit": 100,    # max duration to run the optimization (in seconds)
                      "cs": cs,                  # configuration space
-                     "deterministic": "true",
+                     "deterministic": True,
                      "limit_resources": True,   # Uses pynisher to limit memory and runtime
                      "memory_limit": 3072,      # adapt this to reasonable value for your hardware
                      "cutoff": 3,               # runtime limit for the target algorithm

--- a/examples/SMAC4HPO_sgd_hyperband_instances.py
+++ b/examples/SMAC4HPO_sgd_hyperband_instances.py
@@ -100,7 +100,7 @@ cs.add_hyperparameters([alpha, l1_ratio, learning_rate, eta0])
 
 # SMAC scenario object
 scenario = Scenario({"run_obj": "quality",      # we optimize quality (alternative to runtime)
-                     "wallclock-limit": 60,     # max duration to run the optimization (in seconds)
+                     "wallclock-limit": 100,    # max duration to run the optimization (in seconds)
                      "cs": cs,                  # configuration space
                      "deterministic": "true",
                      "limit_resources": True,   # Uses pynisher to limit memory and runtime

--- a/examples/spear_qcp/SMAC4AC_spear_qcp.py
+++ b/examples/spear_qcp/SMAC4AC_spear_qcp.py
@@ -18,10 +18,19 @@ if __name__ == '__main__':
     logging.basicConfig(level=20)  # 10: debug; 20: info
 
     scenario = Scenario('scenario.txt')
-    intensifier_kwargs = {'initial_budget': 1, 'eta': 2}
+
+    # provide arguments for the intensifier like this
+    intensifier_kwargs = {'n_seeds': 2,  # specify the number of seeds to evaluate for a
+                                         # non-deterministic target algorithm
+                          'initial_budget': 1,
+                          'eta': 3,
+                          }
+
     smac = SMAC4AC(scenario=scenario,  # scenario object
-                   intensifier_kwargs=intensifier_kwargs,  # parameters for Successive Halving
-                   intensifier=SuccessiveHalving)  # change intensifier to successive halving by passing the class
+                   intensifier_kwargs=intensifier_kwargs,  # arguments for Successive Halving
+                   intensifier=SuccessiveHalving  # change intensifier to successive halving by passing the class.
+                                                  # it must implement `AbstractRacer`
+                   )
 
     # Start optimization
     try:

--- a/examples/spear_qcp/scenario.txt
+++ b/examples/spear_qcp/scenario.txt
@@ -5,6 +5,6 @@ deterministic = 0
 run_obj = runtime
 overall_obj = PAR10
 cutoff_time = 5
-wallclock-limit = 30
+wallclock-limit = 60
 instance_file = instances.txt
 feature_file = features.txt

--- a/smac/facade/experimental/epils_facade.py
+++ b/smac/facade/experimental/epils_facade.py
@@ -268,12 +268,8 @@ class EPILS(object):
                 raise ValueError("Don't know what kind of initial_incumbent "
                                  "'%s' is" % scenario.initial_incumbent)
         # inject deps if necessary
-        if initial_design.tae_runner is None:
-            initial_design.tae_runner = tae_runner
-        if initial_design.scenario is None:
-            initial_design.scenario = scenario
-        if initial_design.stats is None:
-            initial_design.stats = self.stats
+        if initial_design.cs is None:
+            initial_design.cs = scenario.cs
         if initial_design.traj_logger is None:
             initial_design.traj_logger = traj_logger
 

--- a/smac/facade/experimental/epils_facade.py
+++ b/smac/facade/experimental/epils_facade.py
@@ -244,35 +244,25 @@ class EPILS(object):
                 "Either use initial_design or initial_configurations; but not both")
 
         if initial_configurations is not None:
-            initial_design = InitialDesign(tae_runner=tae_runner,
-                                           scenario=scenario,
-                                           stats=self.stats,
+            initial_design = InitialDesign(cs=scenario.cs,
                                            traj_logger=traj_logger,
-                                           runhistory=runhistory,
                                            rng=rng,
-                                           configs=initial_configurations,
-                                           intensifier=intensifier,
-                                           aggregate_func=aggregate_func)
+                                           ta_run_limit=scenario.ta_run_limit,
+                                           configs=initial_configurations)
         elif initial_design is None:
             if scenario.initial_incumbent == "DEFAULT":
-                initial_design = DefaultConfiguration(tae_runner=tae_runner,
-                                                      scenario=scenario,
-                                                      stats=self.stats,
+                initial_design = DefaultConfiguration(cs=scenario.cs,
                                                       traj_logger=traj_logger,
-                                                      runhistory=runhistory,
                                                       rng=rng,
-                                                      intensifier=intensifier,
-                                                      aggregate_func=aggregate_func,
+                                                      ta_run_limit=scenario.ta_run_limit,
+                                                      configs=initial_configurations,
                                                       max_config_fracs=0.0)
             elif scenario.initial_incumbent == "RANDOM":
-                initial_design = RandomConfigurations(tae_runner=tae_runner,
-                                                      scenario=scenario,
-                                                      stats=self.stats,
+                initial_design = RandomConfigurations(cs=scenario.cs,
                                                       traj_logger=traj_logger,
-                                                      runhistory=runhistory,
                                                       rng=rng,
-                                                      intensifier=intensifier,
-                                                      aggregate_func=aggregate_func,
+                                                      ta_run_limit=scenario.ta_run_limit,
+                                                      configs=initial_configurations,
                                                       max_config_fracs=0.0)
             else:
                 raise ValueError("Don't know what kind of initial_incumbent "

--- a/smac/facade/smac_ac_facade.py
+++ b/smac/facade/smac_ac_facade.py
@@ -426,7 +426,7 @@ class SMAC4AC(object):
             }
         if isinstance(intensifier, SuccessiveHalving):
             # If running successive halving, then you need multiple configurations for the initial design
-            n_configs = intensifier.num_initial_challengers / len(self.scenario.cs.get_hyperparameters())
+            n_configs = intensifier.n_configs_in_stage[0] / len(self.scenario.cs.get_hyperparameters())
             init_design_def_kwargs['n_configs_x_params'] = n_configs
             init_design_def_kwargs['run_first_config'] = False
             init_design_def_kwargs['fill_random_configs'] = True

--- a/smac/facade/smac_ac_facade.py
+++ b/smac/facade/smac_ac_facade.py
@@ -428,8 +428,6 @@ class SMAC4AC(object):
             # If running successive halving, then you need multiple configurations for the initial design
             n_configs = intensifier.n_configs_in_stage[0] / len(self.scenario.cs.get_hyperparameters())
             init_design_def_kwargs['n_configs_x_params'] = n_configs
-            init_design_def_kwargs['run_first_config'] = False
-            init_design_def_kwargs['fill_random_configs'] = True
         if initial_design_kwargs is not None:
             init_design_def_kwargs.update(initial_design_kwargs)
         if initial_configurations is not None:

--- a/smac/facade/smac_ac_facade.py
+++ b/smac/facade/smac_ac_facade.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 import os
-from typing import  List, Union, Optional, Type, Callable
+from typing import List, Union, Optional, Type, Callable
 
 import numpy as np
 
@@ -30,7 +30,6 @@ from smac.initial_design.sobol_design import SobolDesign
 # intensification
 from smac.intensification.intensification import Intensifier
 from smac.intensification.abstract_racer import AbstractRacer
-from smac.intensification.successive_halving import SuccessiveHalving
 # optimizer
 from smac.optimizer.smbo import SMBO
 from smac.optimizer.objective import average_cost

--- a/smac/facade/smac_ac_facade.py
+++ b/smac/facade/smac_ac_facade.py
@@ -412,22 +412,14 @@ class SMAC4AC(object):
                 "Either use initial_design or initial_configurations; but not both")
 
         init_design_def_kwargs = {
-            'tae_runner': tae_runner,
-            'scenario': scenario,
-            'stats': self.stats,
+            'cs': scenario.cs,
             'traj_logger': traj_logger,
-            'runhistory': runhistory,
             'rng': rng,
+            'ta_run_limit': scenario.ta_run_limit,
             'configs': initial_configurations,
-            'intensifier': intensifier,
-            'aggregate_func': aggregate_func,
             'n_configs_x_params': 0,
             'max_config_fracs': 0.0
             }
-        if isinstance(intensifier, SuccessiveHalving):
-            # If running successive halving, then you need multiple configurations for the initial design
-            n_configs = intensifier.n_configs_in_stage[0] / len(self.scenario.cs.get_hyperparameters())
-            init_design_def_kwargs['n_configs_x_params'] = n_configs
         if initial_design_kwargs is not None:
             init_design_def_kwargs.update(initial_design_kwargs)
         if initial_configurations is not None:

--- a/smac/initial_design/default_configuration_design.py
+++ b/smac/initial_design/default_configuration_design.py
@@ -24,6 +24,6 @@ class DefaultConfiguration(InitialDesign):
             Initial incumbent configuration.
         """
 
-        config = self.scenario.cs.get_default_configuration()
+        config = self.cs.get_default_configuration()
         config.origin = 'Default'
         return [config]

--- a/smac/initial_design/factorial_design.py
+++ b/smac/initial_design/factorial_design.py
@@ -2,7 +2,8 @@ import itertools
 import typing
 
 from ConfigSpace.configuration_space import Configuration
-from ConfigSpace.hyperparameters import Constant, NumericalHyperparameter, CategoricalHyperparameter, OrdinalHyperparameter
+from ConfigSpace.hyperparameters import Constant, NumericalHyperparameter, \
+    CategoricalHyperparameter, OrdinalHyperparameter
 from ConfigSpace.util import deactivate_inactive_hyperparameters
 import numpy as np
 
@@ -23,9 +24,6 @@ class FactorialInitialDesign(InitialDesign):
         List of configurations to be evaluated
         Don't pass configs to the constructor;
         otherwise factorial design is overwritten
-    intensifier
-    runhistory
-    aggregate_func
     """
 
     def _select_configurations(self) -> Configuration:
@@ -37,8 +35,7 @@ class FactorialInitialDesign(InitialDesign):
             initial incumbent configuration
         """
 
-        cs = self.scenario.cs
-        params = cs.get_hyperparameters()
+        params = self.cs.get_hyperparameters()
 
         values = []
         mid = []
@@ -61,16 +58,16 @@ class FactorialInitialDesign(InitialDesign):
         factorial_design = itertools.product(*values)
 
         self.logger.debug("Initial Design")
-        configs = [cs.get_default_configuration()]
+        configs = [self.cs.get_default_configuration()]
         # add middle point in space
-        conf_dict = dict([(p.name,v) for p,v in zip(params,mid)])
-        middle_conf = deactivate_inactive_hyperparameters(conf_dict, cs)
+        conf_dict = dict([(p.name, v) for p,v in zip(params, mid)])
+        middle_conf = deactivate_inactive_hyperparameters(conf_dict, self.cs)
         configs.append(middle_conf)
 
         # add corner points
         for design in factorial_design:
             conf_dict = dict([(p.name,v) for p,v in zip(params,design)])
-            conf = deactivate_inactive_hyperparameters(conf_dict, cs)
+            conf = deactivate_inactive_hyperparameters(conf_dict, self.cs)
             conf.origin = "Factorial Design"
             configs.append(conf)
             self.logger.debug(conf)

--- a/smac/initial_design/factorial_design.py
+++ b/smac/initial_design/factorial_design.py
@@ -60,7 +60,7 @@ class FactorialInitialDesign(InitialDesign):
         self.logger.debug("Initial Design")
         configs = [self.cs.get_default_configuration()]
         # add middle point in space
-        conf_dict = dict([(p.name, v) for p,v in zip(params, mid)])
+        conf_dict = dict([(p.name, v) for p, v in zip(params, mid)])
         middle_conf = deactivate_inactive_hyperparameters(conf_dict, self.cs)
         configs.append(middle_conf)
 

--- a/smac/initial_design/initial_design.py
+++ b/smac/initial_design/initial_design.py
@@ -46,8 +46,6 @@ class InitialDesign:
                  configs: typing.Optional[typing.List[Configuration]] = None,
                  n_configs_x_params: typing.Optional[int] = 10,
                  max_config_fracs: float = 0.25,
-                 run_first_config: bool = True,
-                 fill_random_configs: bool = False,
                  init_budget: typing.Optional[int] = None,
                  ):
         """Constructor
@@ -83,10 +81,6 @@ class InitialDesign:
             ``n_configs_x_params`` if given.
         max_config_fracs: float
             use at most X*budget in the initial design. Not active if a time limit is given.
-        run_first_config: bool
-            specify if target algorithm has to be run once on the first configuration before the intensify call
-        fill_random_configs: bool
-            fill budget with random configurations if initial incumbent sampling returns only 1 configuration
         init_budget : int, optional
             Maximal initial budget (disables the arguments ``n_configs_x_params`` and ``configs``
             if both are given). Either this, or ``n_configs_x_params`` or ``configs`` must be
@@ -143,6 +137,7 @@ class InitialDesign:
                                    incumbent=self.configs[0])
 
         # removing duplicates
+        # (Reference: https://stackoverflow.com/questions/7961363/removing-duplicates-in-lists)
         self.configs = list(OrderedDict.fromkeys(self.configs))
         return self.configs
 

--- a/smac/initial_design/initial_design.py
+++ b/smac/initial_design/initial_design.py
@@ -180,6 +180,7 @@ class InitialDesign:
             # therefore, at least two different configurations have to be in <configs>
             inc, _ = self.intensifier.intensify(
                 challengers=configs,
+                optimizer=None,
                 incumbent=inc,
                 run_history=self.runhistory,
                 aggregate_func=self.aggregate_func,

--- a/smac/initial_design/latin_hypercube_design.py
+++ b/smac/initial_design/latin_hypercube_design.py
@@ -23,9 +23,6 @@ class LHDesign(InitialDesign):
         List of configurations to be evaluated
         Don't pass configs to the constructor;
         otherwise factorial design is overwritten
-    intensifier
-    runhistory
-    aggregate_func
     """
 
     def _select_configurations(self) -> typing.List[Configuration]:
@@ -37,11 +34,10 @@ class LHDesign(InitialDesign):
             initial incumbent configuration
         """
 
-        cs = self.scenario.cs
-        params = cs.get_hyperparameters()
+        params = self.cs.get_hyperparameters()
 
         # seeding of lhd design
-        np.random.seed(self.rng.randint(1,2*20))
+        np.random.seed(self.rng.randint(1, 2 * 20))
 
         constants = 0
         for p in params:
@@ -52,4 +48,4 @@ class LHDesign(InitialDesign):
 
         return self._transform_continuous_designs(design=lhd,
                                                   origin='LHD',
-                                                  cs=cs)
+                                                  cs=self.cs)

--- a/smac/initial_design/random_configuration_design.py
+++ b/smac/initial_design/random_configuration_design.py
@@ -22,7 +22,7 @@ class RandomConfigurations(InitialDesign):
             Initial incumbent configuration
         """
 
-        configs = self.scenario.cs.sample_configuration(size=self.init_budget)
+        configs = self.cs.sample_configuration(size=self.init_budget)
         if self.init_budget == 1:
             configs = [configs]
         for config in configs:

--- a/smac/initial_design/sobol_design.py
+++ b/smac/initial_design/sobol_design.py
@@ -21,9 +21,6 @@ class SobolDesign(InitialDesign):
         List of configurations to be evaluated
         Don't pass configs to the constructor;
         otherwise factorial design is overwritten
-    intensifier
-    runhistory
-    aggregate_func
     """
 
     def _select_configurations(self) -> typing.List[Configuration]:
@@ -35,8 +32,7 @@ class SobolDesign(InitialDesign):
             initial incumbent configuration
         """
 
-        cs = self.scenario.cs
-        params = cs.get_hyperparameters()
+        params = self.cs.get_hyperparameters()
 
         constants = 0
         for p in params:
@@ -47,4 +43,4 @@ class SobolDesign(InitialDesign):
 
         return self._transform_continuous_designs(design=sobol,
                                                   origin='Sobol',
-                                                  cs=cs)
+                                                  cs=self.cs)

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -25,7 +25,7 @@ class AbstractRacer(object):
     """
     Base class for all racing methods
 
-    The "intensification" is designed to be spread across multiple ``eval_config()`` runs.
+    The "intensification" is designed to be spread across multiple ``eval_challenger()`` runs.
     This is to facilitate on-demand configuration sampling if multiple configurations are required,
     like Successive Halving or Hyperband.
 
@@ -60,7 +60,8 @@ class AbstractRacer(object):
         slack factor of adpative capping (factor * adpative cutoff)
     """
 
-    def __init__(self, tae_runner: ExecuteTARun,
+    def __init__(self,
+                 tae_runner: ExecuteTARun,
                  stats: Stats,
                  traj_logger: TrajLogger,
                  rng: np.random.RandomState,
@@ -113,16 +114,42 @@ class AbstractRacer(object):
         # to sample fresh configs from EPM / mark the end of an iteration
         self.iteration_done = False
 
-    def eval_challenger(self, challenger: Configuration,
+    def eval_challenger(self,
+                        challenger: Configuration,
                         incumbent: Configuration,
                         run_history: RunHistory,
                         aggregate_func: typing.Callable,
                         time_bound: float = float(MAXINT),
                         log_traj: bool = True) -> typing.Tuple[Configuration, float]:
+        """
+        Runs intensification by evaluating one configuration-instance at a time
+        *Side effect:* adds runs to run_history
+
+        Parameters
+        ----------
+        challenger : Configuration
+            promising configuration
+        incumbent : Configuration
+            best configuration so far
+        run_history : smac.runhistory.runhistory.RunHistory
+            stores all runs we ran so far
+        aggregate_func: typing.Callable
+            aggregate error across instances
+        time_bound : float, optional (default=2 ** 31 - 1)
+            time in [sec] available to perform intensify
+        log_traj : bool
+            whether to log changes of incumbents in trajectory
+
+        Returns
+        -------
+        typing.Tuple[Configuration, float]
+            incumbent and incumbent cost
+        """
 
         raise NotImplementedError()
 
-    def get_next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
+    def get_next_challenger(self,
+                            challengers: typing.Optional[typing.List[Configuration]],
                             chooser: typing.Optional[EPMChooser],
                             run_history: RunHistory,
                             repeat_configs: bool = True) -> typing.Optional[Configuration]:
@@ -152,7 +179,8 @@ class AbstractRacer(object):
                                            repeat_configs=repeat_configs)
         return challenger
 
-    def _next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
+    def _next_challenger(self,
+                         challengers: typing.Optional[typing.List[Configuration]],
                          chooser: typing.Optional[EPMChooser],
                          run_history: RunHistory,
                          repeat_configs: bool = True) -> typing.Optional[Configuration]:
@@ -206,7 +234,8 @@ class AbstractRacer(object):
         self.logger.debug("No valid challenger was generated!")
         return None
 
-    def _adapt_cutoff(self, challenger: Configuration,
+    def _adapt_cutoff(self,
+                      challenger: Configuration,
                       run_history: RunHistory,
                       inc_sum_cost: float) -> float:
         """Adaptive capping:
@@ -251,7 +280,8 @@ class AbstractRacer(object):
                      )
         return cutoff
 
-    def _compare_configs(self, incumbent: Configuration,
+    def _compare_configs(self,
+                         incumbent: Configuration,
                          challenger: Configuration,
                          run_history: RunHistory,
                          aggregate_func: typing.Callable,

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -128,10 +128,26 @@ class AbstractRacer(object):
     def get_next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
                             chooser: typing.Optional['smac.optimizer.smbo.SMBO'],
                             run_history: RunHistory,
-                            repeat_configs: bool = True) -> Configuration:
+                            repeat_configs: bool = True) -> typing.Optional[Configuration]:
         """
         Abstract method for choosing the next challenger, to allow for different selections across intensifiers
         uses ``_next_challenger()`` by default
+
+        Parameters
+        ----------
+        challengers : typing.List[Configuration]
+            promising configurations
+        chooser : 'smac.optimizer.smbo.SMBO'
+            optimizer that generates next configurations to use for racing
+        run_history : RunHistory
+            stores all runs we ran so far
+        repeat_configs : bool
+            if False, an evaluated configuration will not be generated again
+
+        Returns
+        -------
+        typing.Optional[Configuration]
+            next configuration to evaluate
         """
         challenger = self._next_challenger(challengers=challengers,
                                            chooser=chooser,

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -125,10 +125,10 @@ class AbstractRacer(object):
 
         raise NotImplementedError()
 
-    def next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
-                        chooser: typing.Optional['smac.optimizer.smbo.SMBO'],
-                        run_history: RunHistory,
-                        repeat_configs: bool = True) -> Configuration:
+    def get_next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
+                            chooser: typing.Optional['smac.optimizer.smbo.SMBO'],
+                            run_history: RunHistory,
+                            repeat_configs: bool = True) -> Configuration:
         """
         Abstract method for choosing the next challenger, to allow for different selections across intensifiers
         uses ``_next_challenger()`` by default
@@ -165,7 +165,6 @@ class AbstractRacer(object):
         start_time = time.time()
 
         used_configs = set(run_history.get_all_configs())
-        challenger = None
 
         if challengers:
             # iterate over challengers provided
@@ -177,19 +176,20 @@ class AbstractRacer(object):
             chall_gen = chooser.choose_next()
         else:
             self.logger.debug("No configurations/chooser provided. Cannot generate challenger!")
-            return challenger
+            return None
+
+        self.logger.debug('Time to select next challenger: %.4f' % (time.time() - start_time))
 
         # select challenger from the generators
         for challenger in chall_gen:
             if repeat_configs:  # repetitions allowed
-                break
+                return challenger
             else:               # select only a unique challenger
                 if challenger not in used_configs:
-                    break
+                    return challenger
 
-        self.logger.debug('Time to select next challenger: %.4f' % (time.time() - start_time))
-
-        return challenger
+        self.logger.debug("No valid challenger was generated!")
+        return None
 
     def get_num_iterations(self) -> int:
         """

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -111,7 +111,7 @@ class AbstractRacer(object):
 
         # attributes for sampling next configuration
         self.repeat_configs = True
-        # to sample fresh configs from EPM / mark the end of an iteration
+        # to mark the end of an iteration
         self.iteration_done = False
 
     def eval_challenger(self,

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -37,7 +37,7 @@ class AbstractRacer(object):
         target algorithm run executor
     stats: Stats
         stats object
-    traj_logger: TrajLogger
+    traj_logger: smac.utils.io.traj_logging.TrajLogger
         TrajLogger object to log all new incumbents
     rng : np.random.RandomState
     instances : typing.List[str]
@@ -134,9 +134,9 @@ class AbstractRacer(object):
         ----------
         challengers : typing.List[Configuration]
             promising configurations
-        chooser : EPMChooser
+        chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
             optimizer that generates next configurations to use for racing
-        run_history : RunHistory
+        run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         repeat_configs : bool
             if False, an evaluated configuration will not be generated again
@@ -162,10 +162,10 @@ class AbstractRacer(object):
         Parameters
         ----------
         challengers : typing.List[Configuration]
-            promising configurations
-        chooser : EPMChooser
+            promising configurations to evaluate next
+        chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
             a sampler that generates next configurations to use for racing
-        run_history : RunHistory
+        run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         repeat_configs : bool
             if False, an evaluated configuration will not be generated again
@@ -220,7 +220,7 @@ class AbstractRacer(object):
         ----------
         challenger : Configuration
             Configuration which challenges incumbent
-        run_history : RunHistory
+        run_history : smac.runhistory.runhistory.RunHistory
             Stores all runs we ran so far
         inc_sum_cost: float
             Sum of runtimes of all incumbent runs
@@ -272,7 +272,7 @@ class AbstractRacer(object):
             Current incumbent
         challenger: Configuration
             Challenger configuration
-        run_history: RunHistory
+        run_history: smac.runhistory.runhistory.RunHistory
             Stores all runs we ran so far
         aggregate_func: typing.Callable
             Aggregate performance across instances

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -152,7 +152,8 @@ class AbstractRacer(object):
                             challengers: typing.Optional[typing.List[Configuration]],
                             chooser: typing.Optional[EPMChooser],
                             run_history: RunHistory,
-                            repeat_configs: bool = True) -> typing.Optional[Configuration]:
+                            repeat_configs: bool = True) -> \
+            typing.Tuple[typing.Optional[Configuration], bool]:
         """
         Abstract method for choosing the next challenger, to allow for different selections across intensifiers
         uses ``_next_challenger()`` by default
@@ -172,12 +173,14 @@ class AbstractRacer(object):
         -------
         typing.Optional[Configuration]
             next configuration to evaluate
+        bool
+            flag telling if the configuration is newly sampled or one currently being tracked
         """
         challenger = self._next_challenger(challengers=challengers,
                                            chooser=chooser,
                                            run_history=run_history,
                                            repeat_configs=repeat_configs)
-        return challenger
+        return challenger, True
 
     def _next_challenger(self,
                          challengers: typing.Optional[typing.List[Configuration]],

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -195,11 +195,13 @@ class AbstractRacer(object):
 
         # select challenger from the generators
         for challenger in chall_gen:
-            if repeat_configs:  # repetitions allowed
+            # repetitions allowed
+            if repeat_configs:
                 return challenger
-            else:               # select only a unique challenger
-                if challenger not in used_configs:
-                    return challenger
+
+            # otherwise, select only a unique challenger
+            if challenger not in used_configs:
+                return challenger
 
         self.logger.debug("No valid challenger was generated!")
         return None

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 import numpy as np
 
 from smac.optimizer.objective import sum_cost
+from smac.optimizer.epm_configuration_chooser import EPMChooser
 
 from smac.stats.stats import Stats
 from smac.utils.constants import MAXINT
@@ -14,10 +15,6 @@ from smac.runhistory.runhistory import RunHistory
 from smac.tae.execute_ta_run import ExecuteTARun
 from smac.utils.io.traj_logging import TrajLogger
 
-# (for now) to avoid cyclic imports
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    import smac.optimizer.smbo.SMBO
 
 __author__ = "Ashwin Raaghav Narayanan"
 __copyright__ = "Copyright 2019, ML4AAD"
@@ -126,7 +123,7 @@ class AbstractRacer(object):
         raise NotImplementedError()
 
     def get_next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
-                            chooser: typing.Optional['smac.optimizer.smbo.SMBO'],
+                            chooser: typing.Optional[EPMChooser],
                             run_history: RunHistory,
                             repeat_configs: bool = True) -> typing.Optional[Configuration]:
         """
@@ -137,7 +134,7 @@ class AbstractRacer(object):
         ----------
         challengers : typing.List[Configuration]
             promising configurations
-        chooser : 'smac.optimizer.smbo.SMBO'
+        chooser : EPMChooser
             optimizer that generates next configurations to use for racing
         run_history : RunHistory
             stores all runs we ran so far
@@ -156,7 +153,7 @@ class AbstractRacer(object):
         return challenger
 
     def _next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
-                         chooser: typing.Optional['smac.optimizer.smbo.SMBO'],
+                         chooser: typing.Optional[EPMChooser],
                          run_history: RunHistory,
                          repeat_configs: bool = True) -> typing.Optional[Configuration]:
         """ Retuns the next challenger to use in intensification
@@ -166,7 +163,7 @@ class AbstractRacer(object):
         ----------
         challengers : typing.List[Configuration]
             promising configurations
-        chooser : smac.optimizer.smbo.SMBO
+        chooser : EPMChooser
             a sampler that generates next configurations to use for racing
         run_history : RunHistory
             stores all runs we ran so far
@@ -214,7 +211,6 @@ class AbstractRacer(object):
         raise NotImplementedError()
 
     def _adapt_cutoff(self, challenger: Configuration,
-                      incumbent: Configuration,
                       run_history: RunHistory,
                       inc_sum_cost: float) -> float:
         """Adaptive capping:
@@ -230,8 +226,6 @@ class AbstractRacer(object):
         ----------
         challenger : Configuration
             Configuration which challenges incumbent
-        incumbent : Configuration
-            Best configuration so far
         run_history : RunHistory
             Stores all runs we ran so far
         inc_sum_cost: float

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -204,12 +204,6 @@ class AbstractRacer(object):
         self.logger.debug("No valid challenger was generated!")
         return None
 
-    def get_num_iterations(self) -> int:
-        """
-        helper method to get number of completed racing iterations
-        """
-        raise NotImplementedError()
-
     def _adapt_cutoff(self, challenger: Configuration,
                       run_history: RunHistory,
                       inc_sum_cost: float) -> float:

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -116,7 +116,7 @@ class AbstractRacer(object):
 
     def eval_challenger(self,
                         challenger: Configuration,
-                        incumbent: Configuration,
+                        incumbent: typing.Optional[Configuration],
                         run_history: RunHistory,
                         aggregate_func: typing.Callable,
                         time_bound: float = float(MAXINT),
@@ -129,8 +129,8 @@ class AbstractRacer(object):
         ----------
         challenger : Configuration
             promising configuration
-        incumbent : Configuration
-            best configuration so far
+        incumbent : typing.Optional[Configuration]
+            best configuration so far, None in 1st run
         run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         aggregate_func: typing.Callable
@@ -216,8 +216,7 @@ class AbstractRacer(object):
             self.logger.debug("Generating new challenger from optimizer")
             chall_gen = chooser.choose_next()
         else:
-            self.logger.debug("No configurations/chooser provided. Cannot generate challenger!")
-            return None
+            raise ValueError('No configurations/chooser provided. Cannot generate challenger!')
 
         self.logger.debug('Time to select next challenger: %.4f' % (time.time() - start_time))
 

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -157,7 +157,8 @@ class Hyperband(SuccessiveHalving):
                             challengers: typing.Optional[typing.List[Configuration]],
                             chooser: typing.Optional[EPMChooser],
                             run_history: RunHistory,
-                            repeat_configs: bool = True) -> typing.Optional[Configuration]:
+                            repeat_configs: bool = True) -> \
+            typing.Tuple[typing.Optional[Configuration], bool]:
         """
         Selects which challenger to use based on the iteration stage and set the iteration parameters.
         First iteration will choose configurations from the ``chooser`` or input challengers,
@@ -178,6 +179,8 @@ class Hyperband(SuccessiveHalving):
         -------
         typing.Optional[Configuration]
             next configuration to evaluate
+        bool
+            flag telling if the configuration is newly sampled or one currently being tracked
         """
 
         if not hasattr(self, 's'):
@@ -187,13 +190,13 @@ class Hyperband(SuccessiveHalving):
         # sampling from next challenger marks the beginning of a new iteration
         self.iteration_done = False
 
-        challenger = self.sh_intensifier.get_next_challenger(
-                         challengers=challengers,
-                         chooser=chooser,
-                         run_history=run_history,
-                         repeat_configs=self.sh_intensifier.repeat_configs
-                     )
-        return challenger
+        challenger, new_challenger = self.sh_intensifier.get_next_challenger(
+            challengers=challengers,
+            chooser=chooser,
+            run_history=run_history,
+            repeat_configs=self.sh_intensifier.repeat_configs
+        )
+        return challenger, new_challenger
 
     def _update_stage(self, run_history: RunHistory = None) -> None:
         """

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -217,7 +217,7 @@ class Hyperband(SuccessiveHalving):
     def get_next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
                             chooser: typing.Optional['smac.optimizer.smbo.SMBO'],
                             run_history: RunHistory,
-                            repeat_configs: bool = True):
+                            repeat_configs: bool = True) -> typing.Optional[Configuration]:
         """
         Selects which challenger to use based on the iteration stage and set the iteration parameters.
         First iteration will choose configurations from the ``chooser`` or input challengers,
@@ -233,6 +233,11 @@ class Hyperband(SuccessiveHalving):
             stores all runs we ran so far
         repeat_configs : bool
             if False, an evaluated configuration will not be generated again
+
+        Returns
+        -------
+        typing.Optional[Configuration]
+            next configuration to evaluate
         """
         challenger = self.sh_intensifier.get_next_challenger(
                          challengers=challengers,

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -148,7 +148,7 @@ class Hyperband(SuccessiveHalving):
                                                                   log_traj=log_traj)
 
         # reset if SH iteration is over, else update for next iteration
-        if self.sh_intensifier.sh_iters >= 1:
+        if self.sh_intensifier.iteration_done:
             self._update_stage()
 
         return incumbent, inc_perf
@@ -184,6 +184,9 @@ class Hyperband(SuccessiveHalving):
             # initialize tracking variables
             self._update_stage()
 
+        # sampling from next challenger marks the beginning of a new iteration
+        self.iteration_done = False
+
         challenger = self.sh_intensifier.get_next_challenger(
                          challengers=challengers,
                          chooser=chooser,
@@ -211,6 +214,7 @@ class Hyperband(SuccessiveHalving):
             # reset if HB iteration is over
             self.s = self.s_max
             self.hb_iters += 1
+            self.iteration_done = True
         else:
             # update for next iteration
             self.s -= 1

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -11,6 +11,11 @@ from smac.runhistory.runhistory import RunHistory
 from smac.tae.execute_ta_run import ExecuteTARun
 from smac.utils.io.traj_logging import TrajLogger
 
+# (for now) to avoid cyclic imports
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from smac.optimizer.smbo import SMBO
+
 __author__ = "Ashwin Raaghav Narayanan"
 __copyright__ = "Copyright 2019, ML4AAD"
 __license__ = "3-clause BSD"
@@ -113,6 +118,7 @@ class Hyperband(SuccessiveHalving):
         self.s = np.floor(np.log(self.max_budget / self.initial_budget) / np.log(self.eta))
 
     def intensify(self, challengers: typing.List[Configuration],
+                  optimizer: typing.Optional['SMBO'],
                   incumbent: typing.Optional[Configuration],
                   run_history: RunHistory,
                   aggregate_func: typing.Callable,
@@ -128,6 +134,8 @@ class Hyperband(SuccessiveHalving):
         ----------
         challengers : typing.List[Configuration]
             promising configurations
+        optimizer : SMBO
+            optimizer that generates next configurations to use for racing
         incumbent : Configuration
             best configuration so far
         run_history : RunHistory
@@ -179,6 +187,7 @@ class Hyperband(SuccessiveHalving):
 
         # run 1 iteration of successive halving
         incumbent, inc_perf = sh_intensifier.intensify(challengers=challengers,
+                                                       optimizer=optimizer,
                                                        incumbent=incumbent,
                                                        run_history=run_history,
                                                        aggregate_func=aggregate_func,

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -29,9 +29,9 @@ class Hyperband(SuccessiveHalving):
     ----------
     tae_runner : tae.executre_ta_run_*.ExecuteTARun* Object
         target algorithm run executor
-    stats: Stats
+    stats: smac.stats.stats.Stats
         stats object
-    traj_logger: TrajLogger
+    traj_logger: smac.utils.io.traj_logging.TrajLogger
         TrajLogger object to log all new incumbents
     rng : np.random.RandomState
     instances : typing.List[str]
@@ -121,7 +121,7 @@ class Hyperband(SuccessiveHalving):
             promising configuration
         incumbent : Configuration
             best configuration so far
-        run_history : RunHistory
+        run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         aggregate_func: typing.Callable
             aggregate error across instances
@@ -164,9 +164,9 @@ class Hyperband(SuccessiveHalving):
         ----------
         challengers : typing.List[Configuration]
             promising configurations
-        chooser : EPMChooser
+        chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
             optimizer that generates next configurations to use for racing
-        run_history : RunHistory
+        run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         repeat_configs : bool
             if False, an evaluated configuration will not be generated again
@@ -197,12 +197,12 @@ class Hyperband(SuccessiveHalving):
 
         Parameters
         ----------
-         run_history : RunHistory
+         run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         """
         if not hasattr(self, 's'):
             # setting initial running budget for future iterations (s & s_max from Algorithm 1)
-            self.s_max = np.floor(np.log(self.max_budget / self.initial_budget) / np.log(self.eta))
+            self.s_max = int(np.floor(np.log(self.max_budget / self.initial_budget) / np.log(self.eta)))
             self.s = self.s_max
         elif self.s == 0:
             # reset if HB iteration is over

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -121,8 +121,8 @@ class Hyperband(SuccessiveHalving):
         ----------
         challenger : Configuration
             promising configuration
-        incumbent : Configuration
-            best configuration so far
+        incumbent : typing.Optional[Configuration]
+            best configuration so far, None in 1st run
         run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         aggregate_func: typing.Callable

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -4,6 +4,7 @@ import typing
 import numpy as np
 
 from smac.intensification.successive_halving import SuccessiveHalving
+from smac.optimizer.epm_configuration_chooser import EPMChooser
 from smac.stats.stats import Stats
 from smac.utils.constants import MAXINT
 from smac.configspace import Configuration
@@ -215,7 +216,7 @@ class Hyperband(SuccessiveHalving):
         return incumbent, inc_perf
 
     def get_next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
-                            chooser: typing.Optional['smac.optimizer.smbo.SMBO'],
+                            chooser: typing.Optional[EPMChooser],
                             run_history: RunHistory,
                             repeat_configs: bool = True) -> typing.Optional[Configuration]:
         """
@@ -227,7 +228,7 @@ class Hyperband(SuccessiveHalving):
         ----------
         challengers : typing.List[Configuration]
             promising configurations
-        chooser : 'smac.optimizer.smbo.SMBO'
+        chooser : EPMChooser
             optimizer that generates next configurations to use for racing
         run_history : RunHistory
             stores all runs we ran so far

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -61,7 +61,8 @@ class Hyperband(SuccessiveHalving):
         slack factor of adpative capping (factor * adpative cutoff)
     """
 
-    def __init__(self, tae_runner: ExecuteTARun,
+    def __init__(self,
+                 tae_runner: ExecuteTARun,
                  stats: Stats,
                  traj_logger: TrajLogger,
                  rng: np.random.RandomState,
@@ -103,7 +104,8 @@ class Hyperband(SuccessiveHalving):
         self.hb_iters = 0
         self.sh_intensifier = None
 
-    def eval_challenger(self, challenger: Configuration,
+    def eval_challenger(self,
+                        challenger: Configuration,
                         incumbent: typing.Optional[Configuration],
                         run_history: RunHistory,
                         aggregate_func: typing.Callable,
@@ -151,7 +153,8 @@ class Hyperband(SuccessiveHalving):
 
         return incumbent, inc_perf
 
-    def get_next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
+    def get_next_challenger(self,
+                            challengers: typing.Optional[typing.List[Configuration]],
                             chooser: typing.Optional[EPMChooser],
                             run_history: RunHistory,
                             repeat_configs: bool = True) -> typing.Optional[Configuration]:

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -167,10 +167,10 @@ class Intensifier(AbstractRacer):
         while True:
 
             # get challenger
-            challenger = self.next_challenger(challengers=challengers,
-                                              optimizer=optimizer,
-                                              n_chall=n_chall,
-                                              run_history=run_history)
+            challenger = self.get_next_challenger(challengers=challengers,
+                                                  optimizer=optimizer,
+                                                  n_chall=n_chall,
+                                                  run_history=run_history)
             n_chall += 1
             if not challenger:
                 self.logger.debug('All configurations have been evaluated.')

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -370,7 +370,6 @@ class Intensifier(AbstractRacer):
             for instance, seed, _ in to_run:
 
                 cutoff = self._adapt_cutoff(challenger=challenger,
-                                            incumbent=incumbent,
                                             run_history=run_history,
                                             inc_sum_cost=inc_sum_cost)
                 if cutoff is not None and cutoff <= 0:

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -175,8 +175,6 @@ class Intensifier(AbstractRacer):
         inc_perf: float
             empirical performance of incumbent configuration
         """
-        self.start_time = time.time()
-        self._ta_time = 0
 
         if time_bound < self._min_time:
             raise ValueError("time_bound must be >= %f" % self._min_time)
@@ -550,6 +548,10 @@ class Intensifier(AbstractRacer):
                 self.N = max(1, self.minR)
                 self.to_run = None
 
+                # reset time bound related params since this is a new configuration
+                self.start_time = time.time()
+                self._ta_time = 0
+
             return challenger, True
 
         # return currently running challenger
@@ -596,9 +598,14 @@ class Intensifier(AbstractRacer):
         """
         Updates tracking variables at the end of an intensification run
         """
+        # track iterations
         self.n_iters += 1
         self.iteration_done = True
         self.configs_to_run = None
+
+        # reset for a new iteration
+        self._num_run = 0
+        self._chall_indx = 0
 
         self.stats.update_average_configs_per_intensify(
             n_configs=self._chall_indx)

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -187,6 +187,7 @@ class Intensifier(AbstractRacer):
         if self.first_run and not incumbent:
             self.logger.info("First run, no incumbent provided; challenger is assumed to be the incumbent")
             incumbent = challenger
+            self.running_challenger = None
             self.first_run = False
 
         self.logger.debug("Intensify on %s", challenger)
@@ -533,13 +534,10 @@ class Intensifier(AbstractRacer):
             # pick next configuration from the generator
             try:
                 challenger = next(self.configs_to_run)
-
             except StopIteration:
                 # out of challengers for the current iteration, start next incumbent iteration
                 self._update_trackers()
-                self.configs_to_run = self._generate_challengers(challengers=challengers,
-                                                                 chooser=chooser)
-                challenger = next(self.configs_to_run)
+                return None
 
             if challenger:
                 # reset instance index for the new challenger

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -250,7 +250,7 @@ class SuccessiveHalving(AbstractRacer):
             promising configuration
         incumbent : Configuration
             best configuration so far
-        run_history : RunHistory
+        run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         aggregate_func: typing.Callable
             aggregate error across instances
@@ -369,9 +369,9 @@ class SuccessiveHalving(AbstractRacer):
         ----------
         challengers : typing.List[Configuration]
             promising configurations
-        chooser : EPMChooser
+        chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
             optimizer that generates next configurations to use for racing
-        run_history : RunHistory
+        run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         repeat_configs : bool
             if False, an evaluated configuration will not be generated again
@@ -424,7 +424,7 @@ class SuccessiveHalving(AbstractRacer):
 
         Parameters
         ----------
-         run_history : RunHistory
+         run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         """
 
@@ -489,7 +489,7 @@ class SuccessiveHalving(AbstractRacer):
             promising configuration
         incumbent : Configuration
             best configuration so far
-        run_history : RunHistory
+        run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         aggregate_func: typing.Callable
             aggregate error across instances
@@ -532,7 +532,7 @@ class SuccessiveHalving(AbstractRacer):
         ----------
         configs: typing.List[Configuration]
             list of configurations to filter from
-        run_history: RunHistory
+        run_history: smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         k: int
             number of configurations to select

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -388,7 +388,10 @@ class SuccessiveHalving(AbstractRacer):
         # if this is the first run, then initialize tracking variables
         if not hasattr(self, 'stage'):
             self._update_stage(run_history=run_history)
-        
+
+        # sampling from next challenger marks the beginning of a new iteration
+        self.iteration_done = False
+
         curr_budget = int(self.all_budgets[self.stage])
         prev_budget = int(self.all_budgets[self.stage - 1]) if self.stage > 0 else 0
 
@@ -466,6 +469,7 @@ class SuccessiveHalving(AbstractRacer):
                 self._chall_indx = 0
                 self._num_run = 0
 
+                self.iteration_done = True
                 self.sh_iters += 1
                 self.stage = 0
                 self.configs_to_run = None

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -1,4 +1,3 @@
-import time
 import logging
 import typing
 
@@ -6,6 +5,7 @@ import numpy as np
 
 from smac.intensification.abstract_racer import AbstractRacer
 from smac.optimizer.objective import sum_cost
+from smac.optimizer.epm_configuration_chooser import EPMChooser
 from smac.stats.stats import Stats
 from smac.utils.constants import MAXINT
 from smac.configspace import Configuration
@@ -13,10 +13,6 @@ from smac.runhistory.runhistory import RunHistory
 from smac.tae.execute_ta_run import BudgetExhaustedException, CappedRunException, ExecuteTARun
 from smac.utils.io.traj_logging import TrajLogger
 
-# (for now) to avoid cyclic imports
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    import smac.optimizer.smbo.SMBO
 
 __author__ = "Ashwin Raaghav Narayanan"
 __copyright__ = "Copyright 2019, ML4AAD"
@@ -295,7 +291,6 @@ class SuccessiveHalving(AbstractRacer):
 
         # selecting cutoff if running adaptive capping
         cutoff = self._adapt_cutoff(challenger=challenger,
-                                    incumbent=incumbent,
                                     run_history=run_history,
                                     inc_sum_cost=inc_sum_cost)
         if cutoff is not None and cutoff <= 0:
@@ -306,9 +301,9 @@ class SuccessiveHalving(AbstractRacer):
         self.logger.debug('Cutoff for challenger: %s' % str(cutoff))
 
         try:
-
             # run target algorithm for each instance-seed pair
             self.logger.debug("Execute target algorithm")
+
             try:
                 status, cost, dur, res = self.tae_runner.start(
                     config=challenger,
@@ -356,7 +351,7 @@ class SuccessiveHalving(AbstractRacer):
         return incumbent, inc_perf
 
     def get_next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
-                            chooser: typing.Optional['smac.optimizer.smbo.SMBO'],
+                            chooser: typing.Optional[EPMChooser],
                             run_history: RunHistory,
                             repeat_configs: bool = True) -> typing.Optional[Configuration]:
         """
@@ -368,7 +363,7 @@ class SuccessiveHalving(AbstractRacer):
         ----------
         challengers : typing.List[Configuration]
             promising configurations
-        chooser : 'smac.optimizer.smbo.SMBO'
+        chooser : EPMChooser
             optimizer that generates next configurations to use for racing
         run_history : RunHistory
             stores all runs we ran so far

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -86,7 +86,8 @@ class SuccessiveHalving(AbstractRacer):
         slack factor of adpative capping (factor * adaptive cutoff)
     """
 
-    def __init__(self, tae_runner: ExecuteTARun,
+    def __init__(self,
+                 tae_runner: ExecuteTARun,
                  stats: Stats,
                  traj_logger: TrajLogger,
                  rng: np.random.RandomState,
@@ -162,7 +163,8 @@ class SuccessiveHalving(AbstractRacer):
         else:
             self.repeat_configs = True
 
-    def _init_sh_params(self, initial_budget: typing.Optional[float],
+    def _init_sh_params(self,
+                        initial_budget: typing.Optional[float],
                         max_budget: typing.Optional[float],
                         eta: float,
                         num_initial_challengers: typing.Optional[int]) -> None:
@@ -234,7 +236,8 @@ class SuccessiveHalving(AbstractRacer):
         self.n_configs_in_stage = num_initial_challengers * np.power(self.eta, 
                                                                      -np.linspace(0, max_sh_iter, max_sh_iter + 1))
 
-    def eval_challenger(self, challenger: Configuration,
+    def eval_challenger(self,
+                        challenger: Configuration,
                         incumbent: typing.Optional[Configuration],
                         run_history: RunHistory,
                         aggregate_func: typing.Callable,
@@ -356,7 +359,8 @@ class SuccessiveHalving(AbstractRacer):
 
         return incumbent, inc_perf
 
-    def get_next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
+    def get_next_challenger(self,
+                            challengers: typing.Optional[typing.List[Configuration]],
                             chooser: typing.Optional[EPMChooser],
                             run_history: RunHistory,
                             repeat_configs: bool = True) -> typing.Optional[Configuration]:
@@ -475,7 +479,8 @@ class SuccessiveHalving(AbstractRacer):
         self.curr_inst_idx = 0
         self.running_challenger = None
 
-    def _get_incumbent(self, challenger: Configuration,
+    def _get_incumbent(self,
+                       challenger: Configuration,
                        incumbent: typing.Optional[Configuration],
                        run_history: RunHistory,
                        aggregate_func: typing.Callable,
@@ -522,7 +527,8 @@ class SuccessiveHalving(AbstractRacer):
 
         return new_incumbent
 
-    def _top_k(self, configs: typing.List[Configuration],
+    def _top_k(self,
+               configs: typing.List[Configuration],
                run_history: RunHistory,
                k: int) -> typing.List[Configuration]:
         """

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -274,12 +274,12 @@ class SuccessiveHalving(AbstractRacer):
             inc_sum_cost = np.inf
 
         # select which instance to run current config on
-        curr_budget = int(self.all_budgets[self.stage])
-        prev_budget = int(self.all_budgets[self.stage - 1]) if self.stage > 0 else 0
+        curr_budget = self.all_budgets[self.stage]
+        prev_budget = self.all_budgets[self.stage - 1] if self.stage > 0 else 0.0
 
         # selecting instance-seed subset for this budget, depending on the kind of budget
         if self.instance_as_budget:
-            curr_insts = self.inst_seed_pairs[prev_budget:curr_budget]
+            curr_insts = self.inst_seed_pairs[int(prev_budget):int(curr_budget)]
         else:
             curr_insts = self.inst_seed_pairs
         n_insts_remaining = len(curr_insts) - self.curr_inst_idx - 1
@@ -343,6 +343,12 @@ class SuccessiveHalving(AbstractRacer):
 
         # if all configurations for the current stage have been evaluated, reset stage
         if len(self.curr_challengers) == self.n_configs_in_stage[self.stage] and n_insts_remaining <= 0:
+
+            self.logger.info('Successive Halving iteration-step: %d-%d with '
+                             'budget [%.2f / %d] - evaluated %d challenger(s)' %
+                             (self.sh_iters + 1, self.stage + 1,
+                              self.all_budgets[self.stage], self.max_budget, self.n_configs_in_stage[self.stage]))
+
             self._update_stage(run_history=run_history)
 
         # get incumbent cost
@@ -469,10 +475,6 @@ class SuccessiveHalving(AbstractRacer):
         self.curr_inst_idx = 0
         self.running_challenger = None
 
-        self.logger.info('Successive Halving iteration-step: %d-%d with budget [%.2f / %d] and %d challengers' %
-                         (self.sh_iters+1, self.stage+1,
-                          self.all_budgets[self.stage], self.max_budget, self.n_configs_in_stage[self.stage]))
-
     def _get_incumbent(self, challenger: Configuration,
                        incumbent: typing.Optional[Configuration],
                        run_history: RunHistory,
@@ -519,16 +521,6 @@ class SuccessiveHalving(AbstractRacer):
             new_incumbent = incumbent if new_incumbent is None else new_incumbent
 
         return new_incumbent
-
-    def get_num_iterations(self) -> int:
-        """
-        Returns the number of completed iterations of the intensifier
-
-        Returns
-        -------
-        int
-        """
-        return self.sh_iters
 
     def _top_k(self, configs: typing.List[Configuration],
                run_history: RunHistory,

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -160,6 +160,7 @@ class SuccessiveHalving(AbstractRacer):
             self.adaptive_capping = False
 
         # challengers can be repeated only if optimizing across multiple seeds or changing instance orders every run
+        # (this does not include having multiple instances)
         if not (self.n_seeds > 1 or self.instance_order == 'shuffle'):
             self.repeat_configs = False
         else:
@@ -357,7 +358,7 @@ class SuccessiveHalving(AbstractRacer):
     def get_next_challenger(self, challengers: typing.Optional[typing.List[Configuration]],
                             chooser: typing.Optional['smac.optimizer.smbo.SMBO'],
                             run_history: RunHistory,
-                            repeat_configs: bool = True) -> Configuration:
+                            repeat_configs: bool = True) -> typing.Optional[Configuration]:
         """
         Selects which challenger to use based on the iteration stage and set the iteration parameters.
         First iteration will choose configurations from the ``chooser`` or input challengers,
@@ -373,6 +374,11 @@ class SuccessiveHalving(AbstractRacer):
             stores all runs we ran so far
         repeat_configs : bool
             if False, an evaluated configuration will not be generated again
+
+        Returns
+        -------
+        typing.Optional[Configuration]
+            next configuration to evaluate
         """
         # if this is the first run, then initialize tracking variables
         if not hasattr(self, 'stage'):

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -233,7 +233,7 @@ class SuccessiveHalving(AbstractRacer):
         # budgets to consider in each stage
         self.all_budgets = self.max_budget * np.power(self.eta, -np.linspace(max_sh_iter, 0, max_sh_iter + 1))
         # number of challengers to consider in each stage
-        self.n_configs_in_stage = num_initial_challengers * np.power(self.eta, 
+        self.n_configs_in_stage = num_initial_challengers * np.power(self.eta,
                                                                      -np.linspace(0, max_sh_iter, max_sh_iter + 1))
 
     def eval_challenger(self,

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -251,8 +251,8 @@ class SuccessiveHalving(AbstractRacer):
         ----------
         challenger : Configuration
             promising configuration
-        incumbent : Configuration
-            best configuration so far
+        incumbent : typing.Optional[Configuration]
+            best configuration so far, None in 1st run
         run_history : smac.runhistory.runhistory.RunHistory
             stores all runs we ran so far
         aggregate_func: typing.Callable

--- a/smac/optimizer/epils.py
+++ b/smac/optimizer/epils.py
@@ -158,6 +158,9 @@ class EPILS_Solver(object):
                                                                   run_history=self.runhistory)
                 initial_design_configs = [c for c in initial_design_configs if c != challenger]
 
+                if not challenger:
+                    break
+
                 # evaluate challenger
                 self.incumbent, inc_perf = self.intensifier.eval_challenger(
                         challenger=challenger,
@@ -217,6 +220,10 @@ class EPILS_Solver(object):
                 challenger = self.intensifier.get_next_challenger(challengers=[local_inc],
                                                                   chooser=None,
                                                                   run_history=self.runhistory)
+
+                if not challenger:
+                    break
+
                 # evaluate challenger
                 self.incumbent, inc_perf = self.intensifier.eval_challenger(
                         challenger=challenger,
@@ -302,6 +309,10 @@ class EPILS_Solver(object):
                     challenger = self.intensifier.get_next_challenger(challengers=[neighbor],
                                                                       chooser=None,
                                                                       run_history=self.runhistory)
+
+                    if not challenger:
+                        break
+
                     # evaluate challenger
                     incumbent, inc_perf = self.intensifier.eval_challenger(
                         challenger=challenger,

--- a/smac/optimizer/epils.py
+++ b/smac/optimizer/epils.py
@@ -193,14 +193,20 @@ class EPILS_Solver(object):
             # don't be too aggressive here
             self.intensifier.minR = self.slow_race_minR
             self.intensifier.Adaptive_Capping_Slackfactor = self.slow_race_adaptive_capping_factor
-            # log traj 
-            self.incumbent, inc_perf = self.intensifier.intensify(
-                    challengers=[local_inc],
-                    incumbent=self.incumbent,
-                    run_history=self.runhistory,
-                    aggregate_func=self.aggregate_func,
-                    time_bound=0.01,
-                    log_traj=True)
+            # log traj
+
+            # run intensification
+            while not self.intensifier.iteration_done:
+                # sample next challenger
+                challenger = self.intensifier.get_next_challenger(challengers=[local_inc], chooser=None)
+                # evaluate challenger
+                self.incumbent, inc_perf = self.intensifier.eval_challenger(
+                        challenger=challenger,
+                        incumbent=self.incumbent,
+                        run_history=self.runhistory,
+                        aggregate_func=self.aggregate_func,
+                        time_bound=0.01,
+                        log_traj=True)
             if self.incumbent == local_inc:
                 self.logger.info("Changed global incumbent!")
 
@@ -271,15 +277,22 @@ class EPILS_Solver(object):
                 neighbors_looked_at += 1
 
                 neighbor.origin = "SLS"
-                self.logger.debug("Intensify")                
-                incumbent, inc_perf = self.intensifier.intensify(
-                    challengers=[neighbor],
-                    incumbent=incumbent,
-                    run_history=self.runhistory,
-                    aggregate_func=self.aggregate_func,
-                    time_bound=0.01,
-                    log_traj=False)
-                
+                self.logger.debug("Intensify")
+                # run intensification
+                while not self.intensifier.iteration_done:
+                    # sample next challenger
+                    challenger = self.intensifier.get_next_challenger(challengers=[neighbor],
+                                                                      chooser=None,
+                                                                      run_history=self.runhistory)
+                    # evaluate challenger
+                    incumbent, inc_perf = self.intensifier.eval_challenger(
+                        challenger=challenger,
+                        incumbent=self.incumbent,
+                        run_history=self.runhistory,
+                        aggregate_func=self.aggregate_func,
+                        time_bound=0.01,
+                        log_traj=False)
+
                 # first improvement SLS
                 if incumbent != prev_incumbent:
                     changed_inc = True

--- a/smac/optimizer/epm_configuration_chooser.py
+++ b/smac/optimizer/epm_configuration_chooser.py
@@ -3,7 +3,6 @@ import typing
 
 import numpy as np
 
-import smac
 from smac.configspace import Configuration
 from smac.configspace.util import convert_configurations_to_array
 from smac.epm.rf_with_instances import RandomForestWithInstances
@@ -30,7 +29,7 @@ class EPMChooser(object):
                  rng: np.random.RandomState,
                  restore_incumbent: Configuration = None,
                  random_configuration_chooser: typing.Union[
-                     ChooserNoCoolDown, ChooserLinearCoolDown]=ChooserNoCoolDown(2.0),
+                     ChooserNoCoolDown, ChooserLinearCoolDown] = ChooserNoCoolDown(2.0),
                  predict_incumbent: bool = True):
         """
         Interface to train the EPM and generate next configurations

--- a/smac/optimizer/epm_configuration_chooser.py
+++ b/smac/optimizer/epm_configuration_chooser.py
@@ -1,0 +1,183 @@
+import logging
+import typing
+
+import numpy as np
+
+import smac
+from smac.configspace import Configuration
+from smac.configspace.util import convert_configurations_to_array
+from smac.epm.rf_with_instances import RandomForestWithInstances
+from smac.optimizer.acquisition import AbstractAcquisitionFunction
+from smac.optimizer.ei_optimization import AcquisitionFunctionMaximizer, \
+    RandomSearch
+from smac.optimizer.random_configuration_chooser import ChooserNoCoolDown, \
+    ChooserLinearCoolDown
+from smac.runhistory.runhistory import RunHistory
+from smac.runhistory.runhistory2epm import AbstractRunHistory2EPM
+from smac.scenario.scenario import Scenario
+from smac.stats.stats import Stats
+
+
+class EPMChooser(object):
+    def __init__(self,
+                 scenario: Scenario,
+                 stats: Stats,
+                 runhistory: RunHistory,
+                 runhistory2epm: AbstractRunHistory2EPM,
+                 model: RandomForestWithInstances,
+                 acq_optimizer: AcquisitionFunctionMaximizer,
+                 acquisition_func: AbstractAcquisitionFunction,
+                 rng: np.random.RandomState,
+                 restore_incumbent: Configuration = None,
+                 random_configuration_chooser: typing.Union[
+                     ChooserNoCoolDown, ChooserLinearCoolDown]=ChooserNoCoolDown(2.0),
+                 predict_incumbent: bool = True):
+        """
+        Interface to train the EPM and generate next configurations
+
+        Parameters
+        ----------
+        scenario: smac.scenario.scenario.Scenario
+            Scenario object
+        stats: Stats
+            statistics object with configuration budgets
+        runhistory: RunHistory
+            runhistory with all runs so far
+        model: RandomForestWithInstances
+            empirical performance model (right now, we support only
+            RandomForestWithInstances)
+        acq_optimizer: AcquisitionFunctionMaximizer
+            Optimizer of acquisition function.
+        restore_incumbent: Configuration
+            incumbent to be used from the start. ONLY used to restore states.
+        rng: np.random.RandomState
+            Random number generator
+        random_configuration_chooser
+            Chooser for random configuration -- one of
+            * ChooserNoCoolDown(modulus)
+            * ChooserLinearCoolDown(start_modulus, modulus_increment, end_modulus)
+        predict_incumbent: bool
+            Use predicted performance of incumbent instead of observed performance
+        """
+
+        self.logger = logging.getLogger(
+            self.__module__ + "." + self.__class__.__name__)
+        self.incumbent = restore_incumbent
+
+        self.scenario = scenario
+        self.stats = stats
+        self.runhistory = runhistory
+        self.rh2EPM = runhistory2epm
+        self.model = model
+        self.acq_optimizer = acq_optimizer
+        self.acquisition_func = acquisition_func
+        self.rng = rng
+        self.random_configuration_chooser = random_configuration_chooser
+
+        self._random_search = RandomSearch(
+            acquisition_func, self.scenario.cs, rng
+        )
+
+        self.initial_design_configs = []
+
+        self.predict_incumbent = predict_incumbent
+
+    def choose_next(self, incumbent_value: float = None):
+        """Choose next candidate solution with Bayesian optimization. The
+        suggested configurations depend on the argument ``acq_optimizer`` to
+        the ``SMBO`` class.
+
+        Parameters
+        ----------
+        incumbent_value: float
+            Cost value of incumbent configuration
+            (required for acquisition function);
+            if not given, it will be inferred from runhistory;
+            if not given and runhistory is empty,
+            it will raise a ValueError
+
+        Returns
+        -------
+        Iterable
+        """
+
+        self.logger.debug("Search for next configuration")
+
+        X, Y = self.rh2EPM.transform(self.runhistory)
+
+        if X.shape[0] == 0:
+            # Only return a single point to avoid an overly high number of
+            # random search iterations
+            return self._random_search.maximize(
+                runhistory=self.runhistory, stats=self.stats, num_points=1
+            )
+
+        self.model.train(X, Y)
+
+        if incumbent_value is None:
+            if self.runhistory.empty():
+                raise ValueError("Runhistory is empty and the cost value of "
+                                 "the incumbent is unknown.")
+            incumbent, incumbent_array, incumbent_value = self._get_incumbent()
+        else:
+            incumbent = None
+            incumbent_array = None
+
+        self.acquisition_func.update(
+            model=self.model,
+            eta=incumbent_value,
+            incumbent=incumbent,
+            incumbent_array=incumbent_array,
+            num_data=len(self.runhistory.data),
+            X=X,
+        )
+
+        challengers = self.acq_optimizer.maximize(
+            runhistory=self.runhistory,
+            stats=self.stats,
+            num_points=self.scenario.acq_opt_challengers,
+            random_configuration_chooser=self.random_configuration_chooser
+        )
+        return challengers
+
+    def _get_incumbent(self) -> typing.Tuple[float, np.ndarray, Configuration]:
+        """Get incumbent value, configuration, and array representation.
+
+        This is retrieved either from the runhistory or from best predicted
+        performance on configs in runhistory (depends on self.predict_incumbent)
+
+        Return
+        ------
+        float
+        np.ndarry
+        Configuration
+        """
+        all_configs = self.runhistory.get_all_configs()
+        if self.predict_incumbent:
+            configs_array = convert_configurations_to_array(all_configs)
+            costs = list(map(
+                lambda input_: (
+                    self.model.predict_marginalized_over_instances(input_[0].reshape((1, -1)))[0][0][0],
+                    input_[0], input_[1],
+                ),
+                zip(configs_array, all_configs),
+            ))
+            costs = sorted(costs, key=lambda t: t[0])
+            incumbent = costs[0][2]
+            incumbent_array = costs[0][1]
+            incumbent_value = costs[0][0]
+            # won't need log(y) if EPM was already trained on log(y)
+        else:
+            if self.runhistory.empty():
+                raise ValueError("Runhistory is empty and the cost value of "
+                                 "the incumbent is unknown.")
+            incumbent = self.incumbent
+            incumbent_array = convert_configurations_to_array([all_configs])
+            incumbent_value = self.runhistory.get_cost(incumbent)
+            incumbent_value_as_array = np.array(incumbent_value).reshape((1, 1))
+            # It's unclear how to do this for inv scaling and potential future scaling.
+            # This line should be changed if necessary
+            incumbent_value = self.rh2EPM.transform_response_values(incumbent_value_as_array)
+            incumbent_value = incumbent_value[0][0]
+
+        return incumbent, incumbent_array, incumbent_value

--- a/smac/optimizer/epm_configuration_chooser.py
+++ b/smac/optimizer/epm_configuration_chooser.py
@@ -39,14 +39,14 @@ class EPMChooser(object):
         ----------
         scenario: smac.scenario.scenario.Scenario
             Scenario object
-        stats: Stats
+        stats: smac.stats.stats.Stats
             statistics object with configuration budgets
-        runhistory: RunHistory
+        runhistory: smac.runhistory.runhistory.RunHistory
             runhistory with all runs so far
-        model: RandomForestWithInstances
+        model: smac.epm.rf_with_instances.RandomForestWithInstances
             empirical performance model (right now, we support only
             RandomForestWithInstances)
-        acq_optimizer: AcquisitionFunctionMaximizer
+        acq_optimizer: smac.optimizer.ei_optimization.AcquisitionFunctionMaximizer
             Optimizer of acquisition function.
         restore_incumbent: Configuration
             incumbent to be used from the start. ONLY used to restore states.

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -240,8 +240,13 @@ class SMBO(object):
 
         return self.incumbent
 
-    def validate(self, config_mode='inc', instance_mode='train+test',
-                 repetitions=1, use_epm=False, n_jobs=-1, backend='threading'):
+    def validate(self,
+                 config_mode='inc',
+                 instance_mode='train+test',
+                 repetitions=1,
+                 use_epm=False,
+                 n_jobs=-1,
+                 backend='threading'):
         """Create validator-object and run validation, using
         scenario-information, runhistory from smbo and tae_runner from intensify
 
@@ -320,7 +325,7 @@ class SMBO(object):
         return time_left
 
     def _component_builder(self, conf:typing.Union[Configuration, dict]) \
-        -> typing.Tuple[AbstractAcquisitionFunction, AbstractEPM]:
+            -> typing.Tuple[AbstractAcquisitionFunction, AbstractEPM]:
         """
             builds new Acquisition function object
             and EPM object and returns these

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -200,7 +200,7 @@ class SMBO(object):
 
             # sample next configuration for intensification
             # Initial design runs are also included in the BO loop now.
-            challenger = self.intensifier.get_next_challenger(
+            challenger, new_challenger = self.intensifier.get_next_challenger(
                 challengers=self.initial_design_configs,
                 chooser=self.epm_chooser,
                 run_history=self.runhistory,
@@ -210,8 +210,10 @@ class SMBO(object):
             # remove config from initial design challengers to not repeat it again
             self.initial_design_configs = [c for c in self.initial_design_configs if c != challenger]
 
-            time_spent = time.time() - start_time
-            time_left = self._get_timebound_for_intensification(time_spent)
+            # update timebound only if a 'new' configuration is sampled as the challenger
+            if new_challenger:
+                time_spent = time.time() - start_time
+                time_left = self._get_timebound_for_intensification(time_spent)
 
             if challenger:
                 # evaluate selected challenger

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -161,21 +161,6 @@ class SMBO(object):
             # Intensifier initialization
             self.initial_design_configs = self.initial_design.select_configurations()
 
-        # elif self.stats.ta_runs > 0 and self.incumbent is None:
-        #     raise ValueError("According to stats there have been runs performed, "
-        #                      "but the optimizer cannot detect an incumbent. Did "
-        #                      "you set the incumbent (e.g. after restoring state)?")
-        # elif self.stats.ta_runs == 0 and self.incumbent is not None:
-        #     raise ValueError("An incumbent is specified, but there are no runs "
-        #                      "recorded in the Stats-object. If you're restoring "
-        #                      "a state, please provide the Stats-object.")
-        # else:
-        #     # Restoring state!
-        #     self.logger.info("State Restored! Starting optimization with "
-        #                      "incumbent %s", self.incumbent)
-        #     self.logger.info("State restored with following budget:")
-        #     self.stats.print_stats()
-
     def run(self):
         """Runs the Bayesian optimization loop
 
@@ -245,11 +230,6 @@ class SMBO(object):
 
         Parameters
         ----------
-        X : (N, D) numpy array
-            Each row contains a configuration and one set of
-            instance features.
-        Y : (N, O) numpy array
-            The function values for each configuration instance pair.
         incumbent_value: float
             Cost value of incumbent configuration
             (required for acquisition function);

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -161,6 +161,21 @@ class SMBO(object):
             # Intensifier initialization
             self.initial_design_configs = self.initial_design.select_configurations()
 
+        elif self.stats.ta_runs > 0 and self.incumbent is None:
+            raise ValueError("According to stats there have been runs performed, "
+                             "but the optimizer cannot detect an incumbent. Did "
+                             "you set the incumbent (e.g. after restoring state)?")
+        elif self.stats.ta_runs == 0 and self.incumbent is not None:
+            raise ValueError("An incumbent is specified, but there are no runs "
+                             "recorded in the Stats-object. If you're restoring "
+                             "a state, please provide the Stats-object.")
+        else:
+            # Restoring state!
+            self.logger.info("State Restored! Starting optimization with "
+                             "incumbent %s", self.incumbent)
+            self.logger.info("State restored with following budget:")
+            self.stats.print_stats()
+
     def run(self):
         """Runs the Bayesian optimization loop
 

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -213,20 +213,21 @@ class SMBO(object):
             time_spent = time.time() - start_time
             time_left = self._get_timebound_for_intensification(time_spent)
 
-            # evaluate selected challenger
-            self.logger.debug("Intensify - evaluate challenger")
+            if challenger:
+                # evaluate selected challenger
+                self.logger.debug("Intensify - evaluate challenger")
 
-            self.incumbent, inc_perf = self.intensifier.eval_challenger(
-                challenger=challenger,
-                incumbent=self.incumbent,
-                run_history=self.runhistory,
-                aggregate_func=self.aggregate_func,
-                time_bound=max(self.intensifier._min_time, time_left))
+                self.incumbent, inc_perf = self.intensifier.eval_challenger(
+                    challenger=challenger,
+                    incumbent=self.incumbent,
+                    run_history=self.runhistory,
+                    aggregate_func=self.aggregate_func,
+                    time_bound=max(self.intensifier._min_time, time_left))
 
-            if self.scenario.shared_model:
-                pSMAC.write(run_history=self.runhistory,
-                            output_directory=self.scenario.output_dir_for_this_run,
-                            logger=self.logger)
+                if self.scenario.shared_model:
+                    pSMAC.write(run_history=self.runhistory,
+                                output_directory=self.scenario.output_dir_for_this_run,
+                                logger=self.logger)
 
             self.logger.debug("Remaining budget: %f (wallclock), %f (ta costs), %f (target runs)" % (
                 self.stats.get_remaing_time_budget(),
@@ -324,7 +325,7 @@ class SMBO(object):
                           (total_time, time_spent, (1 - frac_intensify), time_left, frac_intensify))
         return time_left
 
-    def _component_builder(self, conf:typing.Union[Configuration, dict]) \
+    def _component_builder(self, conf: typing.Union[Configuration, dict]) \
             -> typing.Tuple[AbstractAcquisitionFunction, AbstractEPM]:
         """
             builds new Acquisition function object

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -196,13 +196,23 @@ class SMBO(object):
                            configuration_space=self.config_space,
                            logger=self.logger)
 
-            time_left = self._get_timebound_for_intensification()
+            start_time = time.time()
 
-            self.logger.debug("Intensify")
-
-            self.incumbent, inc_perf = self.intensifier.intensify(
+            # sample next configuration for intensification
+            challenger = self.intensifier.next_challenger(
                 challengers=None,
-                optimizer=self,
+                chooser=self,
+                run_history=self.runhistory,
+                repeat_configs=self.intensifier.repeat_configs
+            )
+
+            time_spent = time.time() - start_time
+            time_left = self._get_timebound_for_intensification(time_spent)
+
+            self.logger.debug("Intensify - evaluate challenger")
+
+            self.incumbent, inc_perf = self.intensifier.eval_challenger(
+                challenger=challenger,
                 incumbent=self.incumbent,
                 run_history=self.runhistory,
                 aggregate_func=self.aggregate_func,

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -293,7 +293,7 @@ class RunHistory(object):
         cost: float
             Computed cost for configuration
         """
-        config_id = self.config_ids[config]
+        config_id = self.config_ids.get(config)
         return self.cost_per_config.get(config_id, np.nan)
 
     def get_runs_for_config(self, config: Configuration, max_budget: bool = True):

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -101,23 +101,23 @@ class TestSMACFacade(unittest.TestCase):
     def test_construct_random_configuration_chooser(self):
         rng = np.random.RandomState(42)
         smbo = SMAC4AC(self.scenario)
-        self.assertIsInstance(smbo.solver.random_configuration_chooser, ChooserProb)
-        self.assertIsNot(smbo.solver.random_configuration_chooser, rng)
+        self.assertIsInstance(smbo.solver.epm_chooser.random_configuration_chooser, ChooserProb)
+        self.assertIsNot(smbo.solver.epm_chooser.random_configuration_chooser, rng)
         smbo = SMAC4AC(self.scenario, rng=rng)
-        self.assertIsInstance(smbo.solver.random_configuration_chooser, ChooserProb)
-        self.assertIs(smbo.solver.random_configuration_chooser.rng, rng)
+        self.assertIsInstance(smbo.solver.epm_chooser.random_configuration_chooser, ChooserProb)
+        self.assertIs(smbo.solver.epm_chooser.random_configuration_chooser.rng, rng)
         smbo = SMAC4AC(self.scenario, random_configuration_chooser_kwargs={'rng': rng})
-        self.assertIsInstance(smbo.solver.random_configuration_chooser, ChooserProb)
-        self.assertIs(smbo.solver.random_configuration_chooser.rng, rng)
+        self.assertIsInstance(smbo.solver.epm_chooser.random_configuration_chooser, ChooserProb)
+        self.assertIs(smbo.solver.epm_chooser.random_configuration_chooser.rng, rng)
         smbo = SMAC4AC(self.scenario, random_configuration_chooser_kwargs={'prob': 0.1})
-        self.assertIsInstance(smbo.solver.random_configuration_chooser, ChooserProb)
-        self.assertEqual(smbo.solver.random_configuration_chooser.prob, 0.1)
+        self.assertIsInstance(smbo.solver.epm_chooser.random_configuration_chooser, ChooserProb)
+        self.assertEqual(smbo.solver.epm_chooser.random_configuration_chooser.prob, 0.1)
         smbo = SMAC4AC(
             self.scenario,
             random_configuration_chooser=ChooserCosineAnnealing,
             random_configuration_chooser_kwargs={'prob_max': 1, 'prob_min': 0.1, 'restart_iteration': 10},
         )
-        self.assertIsInstance(smbo.solver.random_configuration_chooser, ChooserCosineAnnealing)
+        self.assertIsInstance(smbo.solver.epm_chooser.random_configuration_chooser, ChooserCosineAnnealing)
         # Check for construction failure on wrong argument
         with self.assertRaisesRegex(Exception, 'got an unexpected keyword argument'):
             SMAC4AC(self.scenario, random_configuration_chooser_kwargs={'dummy': 0.1})
@@ -125,19 +125,19 @@ class TestSMACFacade(unittest.TestCase):
     def test_construct_epm(self):
         rng = np.random.RandomState(42)
         smbo = SMAC4AC(self.scenario)
-        self.assertIsInstance(smbo.solver.model, RandomForestWithInstances)
+        self.assertIsInstance(smbo.solver.epm_chooser.model, RandomForestWithInstances)
         smbo = SMAC4AC(self.scenario, rng=rng)
-        self.assertIsInstance(smbo.solver.model, RandomForestWithInstances)
-        self.assertEqual(smbo.solver.model.seed, 1935803228)
+        self.assertIsInstance(smbo.solver.epm_chooser.model, RandomForestWithInstances)
+        self.assertEqual(smbo.solver.epm_chooser.model.seed, 1935803228)
         smbo = SMAC4AC(self.scenario, model_kwargs={'seed': 2})
-        self.assertIsInstance(smbo.solver.model, RandomForestWithInstances)
-        self.assertEqual(smbo.solver.model.seed, 2)
+        self.assertIsInstance(smbo.solver.epm_chooser.model, RandomForestWithInstances)
+        self.assertEqual(smbo.solver.epm_chooser.model.seed, 2)
         smbo = SMAC4AC(self.scenario, model_kwargs={'num_trees': 20})
-        self.assertIsInstance(smbo.solver.model, RandomForestWithInstances)
-        self.assertEqual(smbo.solver.model.rf_opts.num_trees, 20)
+        self.assertIsInstance(smbo.solver.epm_chooser.model, RandomForestWithInstances)
+        self.assertEqual(smbo.solver.epm_chooser.model.rf_opts.num_trees, 20)
         smbo = SMAC4AC(self.scenario, model=RandomEPM, model_kwargs={'seed': 2})
-        self.assertIsInstance(smbo.solver.model, RandomEPM)
-        self.assertEqual(smbo.solver.model.seed, 2)
+        self.assertIsInstance(smbo.solver.epm_chooser.model, RandomEPM)
+        self.assertEqual(smbo.solver.epm_chooser.model.seed, 2)
         # Check for construction failure on wrong argument
         with self.assertRaisesRegex(Exception, 'got an unexpected keyword argument'):
             SMAC4AC(self.scenario, model_kwargs={'dummy': 0.1})
@@ -145,16 +145,16 @@ class TestSMACFacade(unittest.TestCase):
     def test_construct_acquisition_function(self):
         rng = np.random.RandomState(42)
         smbo = SMAC4AC(self.scenario)
-        self.assertIsInstance(smbo.solver.acquisition_func, EI)
+        self.assertIsInstance(smbo.solver.epm_chooser.acquisition_func, EI)
         smbo = SMAC4AC(self.scenario, rng=rng)
-        self.assertIsInstance(smbo.solver.acquisition_func.model, RandomForestWithInstances)
-        self.assertEqual(smbo.solver.acquisition_func.model.seed, 1935803228)
+        self.assertIsInstance(smbo.solver.epm_chooser.acquisition_func.model, RandomForestWithInstances)
+        self.assertEqual(smbo.solver.epm_chooser.acquisition_func.model.seed, 1935803228)
         smbo = SMAC4AC(self.scenario, acquisition_function_kwargs={'par': 17})
-        self.assertIsInstance(smbo.solver.acquisition_func, EI)
-        self.assertEqual(smbo.solver.acquisition_func.par, 17)
+        self.assertIsInstance(smbo.solver.epm_chooser.acquisition_func, EI)
+        self.assertEqual(smbo.solver.epm_chooser.acquisition_func.par, 17)
         smbo = SMAC4AC(self.scenario, acquisition_function=LCB, acquisition_function_kwargs={'par': 19})
-        self.assertIsInstance(smbo.solver.acquisition_func, LCB)
-        self.assertEqual(smbo.solver.acquisition_func.par, 19)
+        self.assertIsInstance(smbo.solver.epm_chooser.acquisition_func, LCB)
+        self.assertEqual(smbo.solver.epm_chooser.acquisition_func.par, 19)
         # Check for construction failure on wrong argument
         with self.assertRaisesRegex(Exception, 'got an unexpected keyword argument'):
             SMAC4AC(self.scenario, acquisition_function_kwargs={'dummy': 0.1})
@@ -178,9 +178,6 @@ class TestSMACFacade(unittest.TestCase):
         )
         self.assertIsInstance(smbo.solver.intensifier, DummyIntensifier)
         self.assertEqual(smbo.solver.intensifier.maxR, 987)
-        # Check for construction failure on wrong argument
-        with self.assertRaisesRegex(Exception, 'got an unexpected keyword argument'):
-            SMAC4AC(self.scenario, intensifier_kwargs={'dummy': 0.1})
 
     def test_construct_initial_design(self):
 
@@ -200,9 +197,6 @@ class TestSMACFacade(unittest.TestCase):
         )
         self.assertIsInstance(smbo.solver.initial_design, InitialDesign)
         self.assertEqual(smbo.solver.initial_design.configs, 'dummy')
-        # Check for construction failure on wrong argument
-        with self.assertRaisesRegex(Exception, 'got an unexpected keyword argument'):
-            SMAC4AC(self.scenario, intensifier_kwargs={'dummy': 0.1})
 
         for initial_incumbent_string, expected_instance in (
             ("DEFAULT", DefaultConfiguration),
@@ -225,10 +219,10 @@ class TestSMACFacade(unittest.TestCase):
                 acquisition_function=EIPS,
                 runhistory2epm=RunHistory2EPM4EIPS,
             ).solver
-            self.assertIsInstance(smbo.model, UncorrelatedMultiObjectiveRandomForestWithInstances)
-            self.assertIsInstance(smbo.acquisition_func, EIPS)
-            self.assertIsInstance(smbo.acquisition_func.model, UncorrelatedMultiObjectiveRandomForestWithInstances)
-            self.assertIsInstance(smbo.rh2EPM, RunHistory2EPM4EIPS)
+            self.assertIsInstance(smbo.epm_chooser.model, UncorrelatedMultiObjectiveRandomForestWithInstances)
+            self.assertIsInstance(smbo.epm_chooser.acquisition_func, EIPS)
+            self.assertIsInstance(smbo.epm_chooser.acquisition_func.model, UncorrelatedMultiObjectiveRandomForestWithInstances)
+            self.assertIsInstance(smbo.epm_chooser.rh2EPM, RunHistory2EPM4EIPS)
 
     ####################################################################################################################
     # Other tests...

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -221,7 +221,8 @@ class TestSMACFacade(unittest.TestCase):
             ).solver
             self.assertIsInstance(smbo.epm_chooser.model, UncorrelatedMultiObjectiveRandomForestWithInstances)
             self.assertIsInstance(smbo.epm_chooser.acquisition_func, EIPS)
-            self.assertIsInstance(smbo.epm_chooser.acquisition_func.model, UncorrelatedMultiObjectiveRandomForestWithInstances)
+            self.assertIsInstance(smbo.epm_chooser.acquisition_func.model,
+                                  UncorrelatedMultiObjectiveRandomForestWithInstances)
             self.assertIsInstance(smbo.epm_chooser.rh2EPM, RunHistory2EPM4EIPS)
 
     ####################################################################################################################

--- a/test/test_intensify/test_abstract_intensifier.py
+++ b/test/test_intensify/test_abstract_intensifier.py
@@ -58,14 +58,18 @@ class TestAbstractIntensifier(unittest.TestCase):
             rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
             cutoff=1, instances=[1], initial_budget=1, max_budget=3, eta=2)
 
-        # None when nothing to choose from
+        # Error when nothing to choose from
         with self.assertRaisesRegex(ValueError, "No configurations/chooser provided"):
             intensifier.get_next_challenger(challengers=None, chooser=None, run_history=self.rh)
 
         # next challenger from a list
-        config = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
+        config, _ = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
                                                  chooser=None, run_history=self.rh)
         self.assertEqual(config, self.config1)
+
+        config, _ = intensifier.get_next_challenger(challengers=[self.config2, self.config3],
+                                                 chooser=None, run_history=self.rh)
+        self.assertEqual(config, self.config2)
 
         # next challenger from a chooser
         intensifier = AbstractRacer(
@@ -74,10 +78,13 @@ class TestAbstractIntensifier(unittest.TestCase):
             cutoff=1, instances=[1], initial_budget=1, max_budget=3, eta=2)
         chooser = SMAC4AC(self.scen, rng=1).solver.epm_chooser
 
-        config = intensifier.get_next_challenger(challengers=None, chooser=chooser, run_history=self.rh)
+        config, _ = intensifier.get_next_challenger(challengers=None, chooser=chooser, run_history=self.rh)
         self.assertEqual(list(config.get_dictionary().values()), [24, 68])
 
-    def test_get_next_challenger_2(self):
+        config, _ = intensifier.get_next_challenger(challengers=None, chooser=chooser, run_history=self.rh)
+        self.assertEqual(list(config.get_dictionary().values()), [95, 38])
+
+    def test_get_next_challenger_repeat(self):
         """
             test get_next_challenger - repeat configurations
         """
@@ -88,13 +95,13 @@ class TestAbstractIntensifier(unittest.TestCase):
 
         # should not repeat configurations
         self.rh.add(self.config1, 1, 1, StatusType.SUCCESS)
-        config = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
+        config, _ = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
                                                  chooser=None, run_history=self.rh, repeat_configs=False)
 
         self.assertEqual(config, self.config2)
 
         # should repeat configurations
-        config = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
+        config, _ = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
                                                  chooser=None, run_history=self.rh, repeat_configs=True)
 
         self.assertEqual(config, self.config1)

--- a/test/test_intensify/test_abstract_intensifier.py
+++ b/test/test_intensify/test_abstract_intensifier.py
@@ -10,6 +10,7 @@ from smac.runhistory.runhistory import RunHistory
 from smac.scenario.scenario import Scenario
 from smac.intensification.abstract_racer import AbstractRacer
 from smac.optimizer.objective import average_cost, sum_cost
+from smac.facade.smac_ac_facade import SMAC4AC
 from smac.tae.execute_ta_run import StatusType
 from smac.stats.stats import Stats
 from smac.utils.io.traj_logging import TrajLogger
@@ -47,6 +48,33 @@ class TestAbstractIntensifier(unittest.TestCase):
         self.stats.start_timing()
 
         self.logger = logging.getLogger(self.__module__ + "." + self.__class__.__name__)
+
+    def test_get_next_challenger(self):
+        """
+            test get_next_challenger - pick from list/chooser
+        """
+        intensifier = AbstractRacer(
+            tae_runner=None, stats=self.stats, traj_logger=None,
+            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
+            cutoff=1, instances=[1], initial_budget=1, max_budget=3, eta=2)
+
+        # None when nothing to choose from
+        config = intensifier.get_next_challenger(challengers=None, chooser=None, run_history=self.rh)
+        self.assertEqual(config, None)
+
+        # next challenger from a list
+        config = intensifier.get_next_challenger(challengers=[self.config1], chooser=None, run_history=self.rh)
+        self.assertEqual(config, self.config1)
+
+        # next challenger from a chooser
+        intensifier = AbstractRacer(
+            tae_runner=None, stats=self.stats, traj_logger=None,
+            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
+            cutoff=1, instances=[1], initial_budget=1, max_budget=3, eta=2)
+        chooser = SMAC4AC(self.scen, rng=1).solver.epm_chooser
+
+        config = intensifier.get_next_challenger(challengers=None, chooser=chooser, run_history=self.rh)
+        self.assertEqual(list(config.get_dictionary().values()), [24, 68])
 
     def test_compare_configs_no_joint_set(self):
         intensifier = AbstractRacer(

--- a/test/test_intensify/test_abstract_intensifier.py
+++ b/test/test_intensify/test_abstract_intensifier.py
@@ -64,11 +64,11 @@ class TestAbstractIntensifier(unittest.TestCase):
 
         # next challenger from a list
         config, _ = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
-                                                 chooser=None, run_history=self.rh)
+                                                    chooser=None, run_history=self.rh)
         self.assertEqual(config, self.config1)
 
         config, _ = intensifier.get_next_challenger(challengers=[self.config2, self.config3],
-                                                 chooser=None, run_history=self.rh)
+                                                    chooser=None, run_history=self.rh)
         self.assertEqual(config, self.config2)
 
         # next challenger from a chooser
@@ -96,13 +96,13 @@ class TestAbstractIntensifier(unittest.TestCase):
         # should not repeat configurations
         self.rh.add(self.config1, 1, 1, StatusType.SUCCESS)
         config, _ = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
-                                                 chooser=None, run_history=self.rh, repeat_configs=False)
+                                                    chooser=None, run_history=self.rh, repeat_configs=False)
 
         self.assertEqual(config, self.config2)
 
         # should repeat configurations
         config, _ = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
-                                                 chooser=None, run_history=self.rh, repeat_configs=True)
+                                                    chooser=None, run_history=self.rh, repeat_configs=True)
 
         self.assertEqual(config, self.config1)
 

--- a/test/test_intensify/test_abstract_intensifier.py
+++ b/test/test_intensify/test_abstract_intensifier.py
@@ -63,7 +63,8 @@ class TestAbstractIntensifier(unittest.TestCase):
         self.assertEqual(config, None)
 
         # next challenger from a list
-        config = intensifier.get_next_challenger(challengers=[self.config1], chooser=None, run_history=self.rh)
+        config = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
+                                                 chooser=None, run_history=self.rh)
         self.assertEqual(config, self.config1)
 
         # next challenger from a chooser
@@ -75,6 +76,28 @@ class TestAbstractIntensifier(unittest.TestCase):
 
         config = intensifier.get_next_challenger(challengers=None, chooser=chooser, run_history=self.rh)
         self.assertEqual(list(config.get_dictionary().values()), [24, 68])
+
+    def test_get_next_challenger_2(self):
+        """
+            test get_next_challenger - repeat configurations
+        """
+        intensifier = AbstractRacer(
+            tae_runner=None, stats=self.stats, traj_logger=None,
+            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
+            cutoff=1, instances=[1], initial_budget=1, max_budget=3, eta=2)
+
+        # should not repeat configurations
+        self.rh.add(self.config1, 1, 1, StatusType.SUCCESS)
+        config = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
+                                                 chooser=None, run_history=self.rh, repeat_configs=False)
+
+        self.assertEqual(config, self.config2)
+
+        # should repeat configurations
+        config = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
+                                                 chooser=None, run_history=self.rh, repeat_configs=True)
+
+        self.assertEqual(config, self.config1)
 
     def test_compare_configs_no_joint_set(self):
         intensifier = AbstractRacer(

--- a/test/test_intensify/test_abstract_intensifier.py
+++ b/test/test_intensify/test_abstract_intensifier.py
@@ -199,18 +199,12 @@ class TestAbstractIntensifier(unittest.TestCase):
         inc_sum_cost = sum_cost(config=self.config1, instance_seed_budget_keys=inst_seed_pairs,
                                 run_history=self.rh)
 
-        cutoff = intensifier._adapt_cutoff(challenger=self.config2,
-                                           incumbent=self.config1,
-                                           run_history=self.rh,
-                                           inc_sum_cost=inc_sum_cost)
+        cutoff = intensifier._adapt_cutoff(challenger=self.config2, run_history=self.rh, inc_sum_cost=inc_sum_cost)
         # 15*1.2 - 6
         self.assertEqual(cutoff, 12)
 
         intensifier.cutoff = 5
 
-        cutoff = intensifier._adapt_cutoff(challenger=self.config2,
-                                           incumbent=self.config1,
-                                           run_history=self.rh,
-                                           inc_sum_cost=inc_sum_cost)
+        cutoff = intensifier._adapt_cutoff(challenger=self.config2, run_history=self.rh, inc_sum_cost=inc_sum_cost)
         # scenario cutoff
         self.assertEqual(cutoff, 5)

--- a/test/test_intensify/test_abstract_intensifier.py
+++ b/test/test_intensify/test_abstract_intensifier.py
@@ -59,8 +59,8 @@ class TestAbstractIntensifier(unittest.TestCase):
             cutoff=1, instances=[1], initial_budget=1, max_budget=3, eta=2)
 
         # None when nothing to choose from
-        config = intensifier.get_next_challenger(challengers=None, chooser=None, run_history=self.rh)
-        self.assertEqual(config, None)
+        with self.assertRaisesRegex(ValueError, "No configurations/chooser provided"):
+            intensifier.get_next_challenger(challengers=None, chooser=None, run_history=self.rh)
 
         # next challenger from a list
         config = intensifier.get_next_challenger(challengers=[self.config1, self.config2],

--- a/test/test_intensify/test_hyperband.py
+++ b/test/test_intensify/test_hyperband.py
@@ -61,8 +61,8 @@ class TestHyperband(unittest.TestCase):
             instances=[1], initial_budget=0.1, max_budget=1, eta=2)
         intensifier._update_stage()
 
-        self.assertEqual(intensifier.s, 3.0)
-        self.assertEqual(intensifier.s_max, 3.0)
+        self.assertEqual(intensifier.s, 3)
+        self.assertEqual(intensifier.s_max, 3)
         self.assertEqual(intensifier.hb_iters, 0)
         self.assertIsInstance(intensifier.sh_intensifier, SuccessiveHalving)
         self.assertEqual(intensifier.sh_intensifier.initial_budget, 0.125)
@@ -71,13 +71,14 @@ class TestHyperband(unittest.TestCase):
         # next HB stage
         intensifier._update_stage()
 
-        self.assertEqual(intensifier.s, 2.0)
+        self.assertEqual(intensifier.s, 2)
         self.assertEqual(intensifier.hb_iters, 0)
         self.assertEqual(intensifier.sh_intensifier.initial_budget, 0.25)
         self.assertEqual(intensifier.sh_intensifier.n_configs_in_stage.tolist(), [4.0, 2.0, 1.0])
 
+        intensifier._update_stage()  # s = 1
+        intensifier._update_stage()  # s = 0
         # HB iteration completed
-        intensifier.s = 0.0
         intensifier._update_stage()
 
         self.assertEqual(intensifier.s, intensifier.s_max)
@@ -107,9 +108,10 @@ class TestHyperband(unittest.TestCase):
         self.assertFalse(hasattr(intensifier, 's'))
 
         # Testing get_next_challenger - get next configuration
-        config = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
+        config = intensifier.get_next_challenger(challengers=[self.config2, self.config3],
+                                                 chooser=None, run_history=self.rh)
         self.assertEqual(intensifier.s, intensifier.s_max)
-        self.assertIsInstance(config, Configuration)
+        self.assertEqual(config, self.config2)
 
         # update to the last SH iteration of the given HB stage
         self.assertEqual(intensifier.s, 1)

--- a/test/test_intensify/test_hyperband.py
+++ b/test/test_intensify/test_hyperband.py
@@ -66,7 +66,7 @@ class TestHyperband(unittest.TestCase):
         self.assertEqual(intensifier.hb_iters, 0)
         self.assertIsInstance(intensifier.sh_intensifier, SuccessiveHalving)
         self.assertEqual(intensifier.sh_intensifier.initial_budget, 0.125)
-        self.assertEqual(intensifier.sh_intensifier.n_configs_in_stage.tolist(), [8.0, 4.0, 2.0, 1.0])
+        self.assertEqual(intensifier.sh_intensifier.n_configs_in_stage, [8.0, 4.0, 2.0, 1.0])
 
         # next HB stage
         intensifier._update_stage()
@@ -74,7 +74,7 @@ class TestHyperband(unittest.TestCase):
         self.assertEqual(intensifier.s, 2)
         self.assertEqual(intensifier.hb_iters, 0)
         self.assertEqual(intensifier.sh_intensifier.initial_budget, 0.25)
-        self.assertEqual(intensifier.sh_intensifier.n_configs_in_stage.tolist(), [4.0, 2.0, 1.0])
+        self.assertEqual(intensifier.sh_intensifier.n_configs_in_stage, [4.0, 2.0, 1.0])
 
         intensifier._update_stage()  # s = 1
         intensifier._update_stage()  # s = 0
@@ -84,7 +84,7 @@ class TestHyperband(unittest.TestCase):
         self.assertEqual(intensifier.s, intensifier.s_max)
         self.assertEqual(intensifier.hb_iters, 1)
         self.assertEqual(intensifier.sh_intensifier.initial_budget, 0.125)
-        self.assertEqual(intensifier.sh_intensifier.n_configs_in_stage.tolist(), [8.0, 4.0, 2.0, 1.0])
+        self.assertEqual(intensifier.sh_intensifier.n_configs_in_stage, [8.0, 4.0, 2.0, 1.0])
 
     @attr('slow')
     def test_eval_challenger(self):

--- a/test/test_intensify/test_hyperband.py
+++ b/test/test_intensify/test_hyperband.py
@@ -138,4 +138,3 @@ class TestHyperband(unittest.TestCase):
         self.assertEqual(self.stats.ta_runs, 1)
         self.assertEqual(list(self.rh.data.keys())[-1][0], self.rh.config_ids[self.config2])
         self.assertEqual(self.stats.inc_changed, 1)
-

--- a/test/test_intensify/test_hyperband.py
+++ b/test/test_intensify/test_hyperband.py
@@ -108,8 +108,8 @@ class TestHyperband(unittest.TestCase):
         self.assertFalse(hasattr(intensifier, 's'))
 
         # Testing get_next_challenger - get next configuration
-        config = intensifier.get_next_challenger(challengers=[self.config2, self.config3],
-                                                 chooser=None, run_history=self.rh)
+        config, _ = intensifier.get_next_challenger(challengers=[self.config2, self.config3],
+                                                    chooser=None, run_history=self.rh)
         self.assertEqual(intensifier.s, intensifier.s_max)
         self.assertEqual(config, self.config2)
 

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -410,7 +410,8 @@ class TestIntensify(unittest.TestCase):
             deterministic=False, always_race_against=self.config3, run_limit=1)
 
         # run incumbent first if it was not run before
-        config = intensifier.get_next_challenger(challengers=[self.config2], chooser=None)
+        config = intensifier.get_next_challenger(challengers=[self.config2, self.config1, self.config3],
+                                                 chooser=None)
         inc, _ = intensifier.eval_challenger(challenger=config, incumbent=None,
                                              run_history=self.rh, aggregate_func=average_cost)
 
@@ -419,7 +420,8 @@ class TestIntensify(unittest.TestCase):
         self.assertTrue(intensifier.run_challenger)
 
         # run challenger now that the incumbent has been executed
-        config = intensifier.get_next_challenger(challengers=[self.config1, self.config3], chooser=None)
+        config = intensifier.get_next_challenger(challengers=[self.config2, self.config1, self.config3],
+                                                 chooser=None)
         inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc,
                                              run_history=self.rh, aggregate_func=average_cost)
 
@@ -428,17 +430,15 @@ class TestIntensify(unittest.TestCase):
         self.assertEqual(self.stats.inc_changed, 1)
         self.assertFalse(intensifier.run_challenger)
         self.assertFalse(intensifier.continue_challenger)
-        # ran out of configurations, so get_next_challenger selects the next list of challengers to evaluate
-        # and starts the next intensification iteration
-        self.assertEqual(intensifier.n_iters, 1)
 
         # run `always_race_against` now since the incumbent has changed
-        config = intensifier.get_next_challenger(challengers=[self.config3], chooser=None)
+        config = intensifier.get_next_challenger(challengers=[self.config2, self.config1, self.config3],
+                                                 chooser=None)
         inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc,
                                              run_history=self.rh, aggregate_func=average_cost)
 
         self.assertEqual(inc, self.config1)
         self.assertTrue(intensifier.run_incumbent)
         self.assertEqual(len(self.rh.get_runs_for_config(self.config3)), 1)
-        self.assertEqual(intensifier.n_iters, 2)
+        self.assertEqual(intensifier.n_iters, 1)
         self.assertEqual(intensifier.configs_to_run, None)

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -407,7 +407,7 @@ class TestIntensify(unittest.TestCase):
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=np.random.RandomState(12345),
             instances=[1], run_obj_time=False,
-            deterministic=False, always_race_against=self.config3)
+            deterministic=False, always_race_against=self.config3, run_limit=1)
 
         # run incumbent first if it was not run before
         config = intensifier.get_next_challenger(challengers=[self.config2], chooser=None)
@@ -428,6 +428,9 @@ class TestIntensify(unittest.TestCase):
         self.assertEqual(self.stats.inc_changed, 1)
         self.assertFalse(intensifier.run_challenger)
         self.assertFalse(intensifier.continue_challenger)
+        # ran out of configurations, so get_next_challenger selects the next list of challengers to evaluate
+        # and starts the next intensification iteration
+        self.assertEqual(intensifier.n_iters, 1)
 
         # run `always_race_against` now since the incumbent has changed
         config = intensifier.get_next_challenger(challengers=[self.config3], chooser=None)
@@ -437,3 +440,5 @@ class TestIntensify(unittest.TestCase):
         self.assertEqual(inc, self.config1)
         self.assertTrue(intensifier.run_incumbent)
         self.assertEqual(len(self.rh.get_runs_for_config(self.config3)), 1)
+        self.assertEqual(intensifier.n_iters, 2)
+        self.assertEqual(intensifier.configs_to_run, None)

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -389,7 +389,7 @@ class TestIntensify(unittest.TestCase):
 
         gen = intensifier._generate_challengers(challengers=None, chooser=chooser)
 
-        self.assertEqual(list(next(gen).get_dictionary().values()), [24, 68])
+        self.assertEqual(next(gen).get_dictionary(), {'a': 24, 'b': 68})
         self.assertRaises(StopIteration, next, gen)
 
         # when both are none, raise error

--- a/test/test_intensify/test_successive_halving.py
+++ b/test/test_intensify/test_successive_halving.py
@@ -65,7 +65,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(len(intensifier.instances), 3)
         self.assertEqual(intensifier.initial_budget, 1)
         self.assertEqual(intensifier.max_budget, 6)
-        self.assertListEqual(intensifier.n_configs_in_stage.tolist(), [4.0, 2.0, 1.0])
+        self.assertListEqual(intensifier.n_configs_in_stage, [4.0, 2.0, 1.0])
         self.assertTrue(intensifier.instance_as_budget)
         self.assertTrue(intensifier.repeat_configs)
 
@@ -82,7 +82,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(len(intensifier.inst_seed_pairs), 1)  # since instance-seed pairs
         self.assertEqual(intensifier.initial_budget, 1)
         self.assertEqual(intensifier.max_budget, 10)
-        self.assertListEqual(intensifier.n_configs_in_stage.tolist(), [8.0, 4.0, 2.0, 1.0])
+        self.assertListEqual(intensifier.n_configs_in_stage, [8.0, 4.0, 2.0, 1.0])
         self.assertFalse(intensifier.instance_as_budget)
         self.assertFalse(intensifier.repeat_configs)
 
@@ -161,7 +161,7 @@ class TestSuccessiveHalving(unittest.TestCase):
             intensifier._top_k(configs=[self.config2, self.config1, self.config3],
                                k=1, run_history=self.rh)
 
-    def test_get_next_challenger_2(self):
+    def test_get_next_challenger_1(self):
         """
             test get_next_challenger for a presently running configuration
         """
@@ -177,22 +177,25 @@ class TestSuccessiveHalving(unittest.TestCase):
             cutoff=1, instances=[1, 2], initial_budget=1, max_budget=2, eta=2)
 
         # next challenger from a list
-        config = intensifier.get_next_challenger(challengers=[self.config1], chooser=None, run_history=self.rh)
+        config, new = intensifier.get_next_challenger(challengers=[self.config1], chooser=None, run_history=self.rh)
         self.assertEqual(config, self.config1)
+        self.assertTrue(new)
 
         # until evaluated, does not pick new challenger
-        config = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
+        config, new = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
         self.assertEqual(config, self.config1)
         self.assertEqual(intensifier.running_challenger, config)
+        self.assertFalse(new)
 
         # evaluating configuration
         _ = intensifier.eval_challenger(challenger=config, incumbent=None, run_history=self.rh,
                                         aggregate_func=average_cost)
-        config = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
+        config, new = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
         self.assertEqual(config, self.config2)
         self.assertEqual(len(intensifier.curr_challengers), 1)
+        self.assertTrue(new)
 
-    def test_get_next_challenger_3(self):
+    def test_get_next_challenger_2(self):
         """
             test get_next_challenger for higher stages of SH iteration
         """
@@ -206,9 +209,10 @@ class TestSuccessiveHalving(unittest.TestCase):
         intensifier.configs_to_run = [self.config1]
 
         # next challenger should come from configs to run
-        config = intensifier.get_next_challenger(challengers=None, chooser=None, run_history=self.rh)
+        config, new = intensifier.get_next_challenger(challengers=None, chooser=None, run_history=self.rh)
         self.assertEqual(config, self.config1)
         self.assertEqual(len(intensifier.configs_to_run), 0)
+        self.assertFalse(new)
 
     def test_update_stage(self):
         """
@@ -344,7 +348,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         self.assertEqual(intensifier.inst_seed_pairs, [(0, 0), (1, 0)])
 
-        config = intensifier.get_next_challenger(challengers=[self.config1], chooser=None, run_history=self.rh)
+        config, _ = intensifier.get_next_challenger(challengers=[self.config1], chooser=None, run_history=self.rh)
         inc, _ = intensifier.eval_challenger(challenger=config,
                                              incumbent=None,
                                              run_history=self.rh,
@@ -353,7 +357,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(inc, None)   # since this is first run, doesn't return any incumbent
         self.assertEqual(len(self.rh.get_runs_for_config(self.config1)), 1)
 
-        config = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
+        config, _ = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
         inc, _ = intensifier.eval_challenger(challenger=config,
                                              incumbent=None,
                                              run_history=self.rh,
@@ -364,7 +368,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(intensifier.configs_to_run, [self.config1])
         self.assertEqual(intensifier.stage, 1)
 
-        config = intensifier.get_next_challenger(challengers=[self.config3], chooser=None, run_history=self.rh)
+        config, _ = intensifier.get_next_challenger(challengers=[self.config3], chooser=None, run_history=self.rh)
         inc, _ = intensifier.eval_challenger(challenger=config,
                                              incumbent=None,
                                              run_history=self.rh,
@@ -381,7 +385,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         self.assertEqual(intensifier.inst_seed_pairs, [(1, 0), (0, 0)])
 
-        config = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
+        config, _ = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
         inc, _ = intensifier.eval_challenger(challenger=config,
                                              incumbent=None,
                                              run_history=self.rh,

--- a/test/test_intensify/test_successive_halving.py
+++ b/test/test_intensify/test_successive_halving.py
@@ -62,14 +62,16 @@ class TestSuccessiveHalving(unittest.TestCase):
             instances=[1, 2, 3], n_seeds=2, initial_budget=None, max_budget=None, eta=2)
 
         self.assertEqual(len(intensifier.inst_seed_pairs), 6)  # since instance-seed pairs
+        self.assertEqual(len(intensifier.instances), 3)
         self.assertEqual(intensifier.initial_budget, 1)
         self.assertEqual(intensifier.max_budget, 6)
-        self.assertEqual(intensifier.num_initial_challengers, 4)  # 2 iterations
+        self.assertListEqual(intensifier.n_configs_in_stage.tolist(), [4.0, 2.0, 1.0])
         self.assertTrue(intensifier.instance_as_budget)
+        self.assertTrue(intensifier.repeat_configs)
 
     def test_init_2(self):
         """
-            test parameter initialiations for successive halving - runtime as budget
+            test parameter initialiations for successive halving - real-valued budget
         """
         intensifier = SuccessiveHalving(
             tae_runner=None, stats=self.stats,
@@ -80,12 +82,13 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(len(intensifier.inst_seed_pairs), 1)  # since instance-seed pairs
         self.assertEqual(intensifier.initial_budget, 1)
         self.assertEqual(intensifier.max_budget, 10)
-        self.assertEqual(intensifier.num_initial_challengers, 8)  # 4 iterations
+        self.assertListEqual(intensifier.n_configs_in_stage.tolist(), [8.0, 4.0, 2.0, 1.0])
         self.assertFalse(intensifier.instance_as_budget)
+        self.assertFalse(intensifier.repeat_configs)
 
     def test_init_3(self):
         """
-            test wrong parameter initialiations for successive halving
+            test wrong parameter initializations for successive halving
         """
 
         # runtime as budget (no param provided)
@@ -119,25 +122,20 @@ class TestSuccessiveHalving(unittest.TestCase):
             test _top_k() for configs with same instance-seed-budget keys
         """
         intensifier = SuccessiveHalving(
-            tae_runner=None, stats=self.stats,
-            traj_logger=TrajLogger(output_dir=None, stats=self.stats),
+            tae_runner=None, stats=self.stats, traj_logger=None,
             rng=np.random.RandomState(12345),
             instances=[1], initial_budget=1)
         self.rh.add(config=self.config1, cost=1, time=1,
-                    status=StatusType.SUCCESS, instance_id=1,
-                    seed=None,
+                    status=StatusType.SUCCESS, instance_id=1, seed=None,
                     additional_info=None)
         self.rh.add(config=self.config1, cost=1, time=1,
-                    status=StatusType.SUCCESS, instance_id=2,
-                    seed=None,
+                    status=StatusType.SUCCESS, instance_id=2, seed=None,
                     additional_info=None)
         self.rh.add(config=self.config2, cost=2, time=2,
-                    status=StatusType.SUCCESS, instance_id=1,
-                    seed=None,
+                    status=StatusType.SUCCESS, instance_id=1, seed=None,
                     additional_info=None)
         self.rh.add(config=self.config2, cost=2, time=2,
-                    status=StatusType.SUCCESS, instance_id=2,
-                    seed=None,
+                    status=StatusType.SUCCESS, instance_id=2, seed=None,
                     additional_info=None)
         conf = intensifier._top_k(configs=[self.config2, self.config1],
                                   k=1, run_history=self.rh)
@@ -149,33 +147,109 @@ class TestSuccessiveHalving(unittest.TestCase):
             test _top_k() for configs with different instance-seed-budget keys
         """
         intensifier = SuccessiveHalving(
-            tae_runner=None, stats=self.stats,
-            traj_logger=TrajLogger(output_dir=None, stats=self.stats),
+            tae_runner=None, stats=self.stats, traj_logger=None,
             rng=np.random.RandomState(12345),
             instances=[1, 2], initial_budget=1)
         self.rh.add(config=self.config1, cost=1, time=1,
-                    status=StatusType.SUCCESS, instance_id=1,
-                    seed=None,
+                    status=StatusType.SUCCESS, instance_id=1, seed=None,
                     additional_info=None)
         self.rh.add(config=self.config2, cost=10, time=10,
-                    status=StatusType.SUCCESS, instance_id=2,
-                    seed=None,
+                    status=StatusType.SUCCESS, instance_id=2, seed=None,
                     additional_info=None)
 
         with self.assertRaisesRegex(AssertionError, 'Cannot compare configs'):
             intensifier._top_k(configs=[self.config2, self.config1, self.config3],
                                k=1, run_history=self.rh)
 
-    @attr('slow')
-    def test_intensify_1(self):
+    def test_get_next_challenger_2(self):
         """
-           test intensify with quality objective & arbitrary budget
+            test get_next_challenger for a presently running configuration
+        """
+        intensifier = SuccessiveHalving(
+            tae_runner=None, stats=self.stats, traj_logger=None,
+            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
+            cutoff=1, instances=[1, 2], initial_budget=1, max_budget=2, eta=2)
+
+        # next challenger from a list
+        config = intensifier.get_next_challenger(challengers=[self.config1], chooser=None, run_history=self.rh)
+        self.assertEqual(config, self.config1)
+
+        # until evaluated, does not pick new challenger
+        config = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
+        self.assertEqual(config, self.config1)
+        self.assertEqual(intensifier.running_challenger, config)
+
+        # evaluating configuration
+        _ = intensifier.eval_challenger(challenger=config, incumbent=None, run_history=self.rh,
+                                        aggregate_func=average_cost)
+        config = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
+        self.assertEqual(config, self.config2)
+        self.assertEqual(len(intensifier.curr_challengers), 1)
+
+    def test_get_next_challenger_2(self):
+        """
+            test get_next_challenger for higher stages of SH iteration
+        """
+        def target(x):
+            return 5
+
+        intensifier = SuccessiveHalving(
+            tae_runner=None, stats=self.stats, traj_logger=None,
+            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
+            cutoff=1, instances=[1], initial_budget=1, max_budget=2, eta=2)
+
+        intensifier._update_stage()
+        intensifier.stage += 1
+        intensifier.configs_to_run = [self.config1]
+
+        # next challenger should come from configs to run
+        config = intensifier.get_next_challenger(challengers=None, chooser=None, run_history=self.rh)
+        self.assertEqual(config, self.config1)
+        self.assertEqual(len(intensifier.configs_to_run), 0)
+
+    def test_update_stage(self):
+        """
+            test update_stage - initializations for all tracking variables
+        """
+        intensifier = SuccessiveHalving(
+            tae_runner=None, stats=self.stats, traj_logger=None,
+            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
+            cutoff=1, instances=[1], initial_budget=1, max_budget=2, eta=2)
+
+        # first stage update
+        intensifier._update_stage()
+
+        self.assertEqual(intensifier.stage, 0)
+        self.assertEqual(intensifier.sh_iters, 0)
+        self.assertEqual(intensifier.running_challenger, None)
+        self.assertEqual(intensifier.curr_challengers, set())
+
+        # higher stages
+        self.rh.add(self.config1, 1, 1, StatusType.SUCCESS)
+        self.rh.add(self.config2, 2, 2, StatusType.SUCCESS)
+        intensifier.curr_challengers = {self.config1, self.config2}
+        intensifier._update_stage(run_history=self.rh)
+
+        self.assertEqual(intensifier.stage, 1)
+        self.assertEqual(intensifier.sh_iters, 0)
+        self.assertEqual(intensifier.configs_to_run, [self.config1])
+
+        # next iteration
+        intensifier.curr_challengers = {self.config1}
+        intensifier._update_stage(run_history=self.rh)
+
+        self.assertEqual(intensifier.stage, 0)
+        self.assertEqual(intensifier.sh_iters, 1)
+        self.assertEqual(intensifier.configs_to_run, None)
+
+    @attr('slow')
+    def test_eval_challenger_1(self):
+        """
+           test eval_challenger with quality objective & real-valued budget
         """
 
         def target(x: Configuration, instance: str, seed: int, budget: float):
-            if x['b'] == 100:
-                time.sleep(1)
-            return (x['a'] + x['b'] + budget) / 1000.
+            return 0.1 * budget
 
         taf = ExecuteTAFuncDict(ta=target, stats=self.stats, run_obj='quality')
         taf.runhistory = self.rh
@@ -184,29 +258,34 @@ class TestSuccessiveHalving(unittest.TestCase):
             tae_runner=taf, stats=self.stats,
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
-            cutoff=1, instances=[1], initial_budget=1, max_budget=3, eta=2)
+            cutoff=1, instances=[None], initial_budget=0.25, max_budget=0.5, eta=2)
+        intensifier._update_stage()
 
-        self.rh.add(config=self.config1, cost=1, time=1,
-                    status=StatusType.SUCCESS, instance_id=1,
-                    seed=0, budget=3,
-                    additional_info=None)
+        self.rh.add(config=self.config1, cost=1, time=1, status=StatusType.SUCCESS,
+                    seed=0, budget=0.5)
+        self.rh.add(config=self.config2, cost=1, time=1, status=StatusType.SUCCESS,
+                    seed=0, budget=0.25)
+        self.rh.add(config=self.config3, cost=2, time=1, status=StatusType.SUCCESS,
+                    seed=0, budget=0.25)
 
-        inc, _ = intensifier.intensify(challengers=[self.config2, self.config3],
-                                       incumbent=self.config1,
-                                       run_history=self.rh,
-                                       aggregate_func=average_cost)
+        intensifier.curr_challengers = {self.config2, self.config3}
+        intensifier._update_stage(run_history=self.rh)
+
+        inc, inc_value = intensifier.eval_challenger(challenger=self.config2,
+                                                     incumbent=self.config1,
+                                                     run_history=self.rh,
+                                                     aggregate_func=average_cost)
 
         self.assertEqual(inc, self.config2)
-        self.assertEqual(self.stats.ta_runs, 3)
-        self.assertEqual(len(self.rh.config_ids.keys()), 3)
-        self.assertEqual(list(self.rh.data.values())[2][2], StatusType.TIMEOUT)  # config3 is timed out
-        self.assertEqual(list(self.rh.data.keys())[2][0], self.rh.config_ids[self.config3])
+        self.assertEqual(inc_value, 0.05)
+        self.assertEqual(self.stats.ta_runs, 1)
+        self.assertEqual(list(self.rh.data.keys())[-1][0], self.rh.config_ids[self.config2])
         self.assertEqual(self.stats.inc_changed, 1)
 
     @attr('slow')
-    def test_intensify_3(self):
+    def test_eval_challenger_2(self):
         """
-           test intensify with runtime objective and adaptive capping
+           test eval_challenger with runtime objective and adaptive capping
         """
 
         def target(x):
@@ -215,7 +294,6 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         taf = ExecuteTAFuncDict(ta=target, stats=self.stats, run_obj="runtime")
         taf.runhistory = self.rh
-        taf.runhistory.overwrite_existing_runs = True
 
         intensifier = SuccessiveHalving(
             tae_runner=taf, stats=self.stats,
@@ -228,58 +306,26 @@ class TestSuccessiveHalving(unittest.TestCase):
                         status=StatusType.SUCCESS, instance_id=i+1, seed=0,
                         additional_info=None)
 
-        # config2 & config3 should be capped and config1 should still be the incumbent
-        inc, _ = intensifier.intensify(challengers=[self.config2, self.config3],
-                                       incumbent=self.config1,
-                                       run_history=self.rh,
-                                       aggregate_func=average_cost)
+        intensifier._update_stage()
+
+        # config2 should be capped and config1 should still be the incumbent
+        inc, _ = intensifier.eval_challenger(challenger=self.config2,
+                                             incumbent=self.config1,
+                                             run_history=self.rh,
+                                             aggregate_func=average_cost)
 
         self.assertEqual(inc, self.config1)
-        self.assertEqual(self.stats.ta_runs, 2)
+        self.assertEqual(self.stats.ta_runs, 1)
         self.assertEqual(self.stats.inc_changed, 0)
         self.assertEqual(list(self.rh.data.values())[2][2], StatusType.CAPPED)
-        self.assertEqual(list(self.rh.data.values())[3][2], StatusType.CAPPED)
 
-    @attr('slow')
-    def test_intensify_4(self):
+    def test_intensify_3(self):
         """
-            test intensify with multiple instance-seed pairs
+            test eval_challenger for updating to next stage
         """
 
-        def target(x: Configuration, seed: int, instance: str):
-            if instance == 0:
-                time.sleep(0.5)
-            if x['b'] == 0:
-                time.sleep(0.6)
-            return (x['a'] + 1) / 1000.
-
-        taf = ExecuteTAFuncDict(ta=target, stats=self.stats, run_obj="runtime")
-        taf.runhistory = self.rh
-
-        intensifier = SuccessiveHalving(
-            tae_runner=taf, stats=self.stats,
-            traj_logger=TrajLogger(output_dir=None, stats=self.stats),
-            rng=np.random.RandomState(12345), deterministic=False,
-            instances=[0, 1], n_seeds=2, cutoff=1, instance_order=None)
-
-        # config1 should still be the incumbent - over all instance seed pairs
-        inc, _ = intensifier.intensify(challengers=[self.config1, self.config2],
-                                       incumbent=None,
-                                       run_history=self.rh,
-                                       aggregate_func=average_cost)
-
-        self.assertEqual(inc, self.config1)
-        self.assertEqual(len(self.rh.get_runs_for_config(self.config1)), 4)
-        self.assertEqual(len(self.rh.get_runs_for_config(self.config2)), 1)
-
-    @attr('slow')
-    def test_intensify_5(self):
-        """
-            test intensify with shuffling instance order every run
-        """
-
-        def target(x: Configuration, instance: str, seed: int):
-            return 2*x['a'] + x['b'] + int(instance)
+        def target(x: Configuration, instance: str):
+            return (x['a'] + int(instance)) / 1000.
 
         taf = ExecuteTAFuncDict(ta=target, stats=self.stats, run_obj="quality")
         taf.runhistory = self.rh
@@ -289,22 +335,38 @@ class TestSuccessiveHalving(unittest.TestCase):
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=np.random.RandomState(12345), run_obj_time=False,
             instances=[0, 1], instance_order='shuffle', eta=2,
-            deterministic=True)
+            deterministic=True, cutoff=1)
 
-        # config1 should become the new incumbent
-        inc, _ = intensifier.intensify(challengers=[self.config1, self.config2],
-                                       incumbent=None,
-                                       run_history=self.rh,
-                                       aggregate_func=average_cost)
+        intensifier._update_stage()
 
-        self.assertEqual(inc, self.config1)
+        config = intensifier.get_next_challenger(challengers=[self.config1], chooser=None, run_history=self.rh)
+        inc, _ = intensifier.eval_challenger(challenger=config,
+                                             incumbent=None,
+                                             run_history=self.rh,
+                                             aggregate_func=average_cost)
+
+        self.assertEqual(inc, None)   # since this is first run, doesn't return any incumbent
+        self.assertEqual(len(self.rh.get_runs_for_config(self.config1)), 1)
+
+        config = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
+        inc, _ = intensifier.eval_challenger(challenger=config,
+                                             incumbent=None,
+                                             run_history=self.rh,
+                                             aggregate_func=average_cost)
+
+        self.assertEqual(inc, None)
         self.assertEqual(len(self.rh.get_runs_for_config(self.config2)), 1)
+        self.assertEqual(intensifier.configs_to_run, [self.config1])
+        self.assertEqual(intensifier.stage, 1)
 
-        # config1 stays the incumbent, but the previously rejected config2 is still executed
-        inc, _ = intensifier.intensify(challengers=[self.config3, self.config2],
-                                       incumbent=inc,
-                                       run_history=self.rh,
-                                       aggregate_func=average_cost)
+        config = intensifier.get_next_challenger(challengers=[self.config3], chooser=None, run_history=self.rh)
+        inc, _ = intensifier.eval_challenger(challenger=config,
+                                             incumbent=None,
+                                             run_history=self.rh,
+                                             aggregate_func=average_cost)
 
-        self.assertEqual(inc, self.config1)
-        self.assertEqual(len(self.rh.get_runs_for_config(self.config2)), 2)
+        self.assertEqual(inc, self.config1)  # run completed, incumbent generated
+
+        self.assertEqual(len(self.rh.get_runs_for_config(self.config1)), 2)
+        self.assertEqual(intensifier.sh_iters, 1)
+        self.assertEqual(self.stats.inc_changed, 1)

--- a/test/test_smbo/test_epils.py
+++ b/test/test_smbo/test_epils.py
@@ -17,7 +17,7 @@ from smac.epm.uncorrelated_mo_rf_with_instances import \
     UncorrelatedMultiObjectiveRandomForestWithInstances
 from smac.epm.util_funcs import get_types
 from smac.facade.experimental.epils_facade import EPILS
-from smac.initial_design.initial_design import InitialDesign
+from smac.intensification.intensification import Intensifier
 
 if sys.version_info[0] == 2:
     import mock
@@ -39,7 +39,7 @@ class TestSMBO(unittest.TestCase):
         self.scenario = Scenario({'cs': test_helpers.get_branin_config_space(),
                                   'run_obj': 'quality',
                                   'output_dir': '',
-                                  'runcount_limit':1,
+                                  'runcount_limit': 1,
                                   'deterministic': True})
 
     def tearDown(self):
@@ -61,7 +61,6 @@ class TestSMBO(unittest.TestCase):
         # not enough runs available to change the inc
         self.assertEqual(inc["x"], 2.5)
         self.assertEqual(inc["y"], 7.5)
-
 
     def test_init_only_scenario_runtime(self):
         self.scenario.run_obj = 'runtime'
@@ -108,7 +107,7 @@ class TestSMBO(unittest.TestCase):
                                 'np.random.RandomState',
                                 EPILS, self.scenario, rng='BLA')
 
-    @mock.patch.object(InitialDesign, 'run')
+    @mock.patch.object(Intensifier, 'eval_challenger')
     def test_abort_on_initial_design(self, patch):
         def target(x):
             return 5
@@ -118,6 +117,7 @@ class TestSMBO(unittest.TestCase):
                          'abort_on_first_run_crash': 1})
         epils = EPILS(scen, tae_runner=target, rng=1).solver
         self.assertRaises(FirstRunCrashedException, epils.run)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_smbo/test_epm_configuration_chooser.py
+++ b/test/test_smbo/test_epm_configuration_chooser.py
@@ -143,8 +143,8 @@ class TestEPMChooser(unittest.TestCase):
         epm_chooser.incumbent = self.scenario.cs.sample_configuration()
         previous_configs = [epm_chooser.incumbent] + [self.scenario.cs.sample_configuration() for _ in range(0, 20)]
         epm_chooser.runhistory = RunHistory(aggregate_func=average_cost)
-        for i in range(0, len(previous_configs)):
-            epm_chooser.runhistory.add(previous_configs[i], i, 10, StatusType.SUCCESS)
+        for i, config in enumerate(previous_configs):
+            epm_chooser.runhistory.add(config, i, 10, StatusType.SUCCESS)
         epm_chooser.model = mock.Mock(spec=RandomForestWithInstances)
         epm_chooser.model.predict_marginalized_over_instances.side_effect = side_effect_predict
         epm_chooser.acquisition_func._compute = mock.Mock(spec=RandomForestWithInstances)

--- a/test/test_smbo/test_epm_configuration_chooser.py
+++ b/test/test_smbo/test_epm_configuration_chooser.py
@@ -1,0 +1,182 @@
+import sys
+import unittest
+from unittest import mock
+
+import numpy as np
+from ConfigSpace import Configuration
+
+from smac.epm.rf_with_instances import RandomForestWithInstances
+from smac.facade.smac_ac_facade import SMAC4AC
+from smac.optimizer.objective import average_cost
+from smac.runhistory.runhistory import RunHistory
+from smac.scenario.scenario import Scenario
+from smac.utils import test_helpers
+from smac.tae.execute_ta_run import StatusType
+
+
+class ConfigurationMock(object):
+    def __init__(self, value=None):
+        self.value = value
+
+    def get_array(self):
+        return [self.value]
+
+
+class TestEPMChooser(unittest.TestCase):
+
+    def setUp(self):
+        self.scenario = Scenario({'cs': test_helpers.get_branin_config_space(),
+                                  'run_obj': 'quality',
+                                  'output_dir': 'data-test_epmchooser'})
+
+    def branin(self, x):
+        y = (x[:, 1] - (5.1 / (4 * np.pi ** 2)) * x[:, 0] ** 2 + 5 * x[:, 0] / np.pi - 6) ** 2
+        y += 10 * (1 - 1 / (8 * np.pi)) * np.cos(x[:, 0]) + 10
+
+        return y[:, np.newaxis]
+
+    def test_choose_next(self):
+        seed = 42
+        config = self.scenario.cs.sample_configuration()
+        rh = RunHistory(aggregate_func=average_cost)
+        rh.add(config, 10, 10, StatusType.SUCCESS)
+
+        smbo = SMAC4AC(self.scenario, rng=seed, runhistory=rh).solver
+
+        x = next(smbo.epm_chooser.choose_next()).get_array()
+        self.assertEqual(x.shape, (2,))
+
+    def test_choose_next_w_empty_rh(self):
+        seed = 42
+        smbo = SMAC4AC(self.scenario, rng=seed).solver
+        smbo.runhistory = RunHistory(aggregate_func=average_cost)
+
+        # should return random search configuration
+        x = smbo.epm_chooser.choose_next(incumbent_value=0.0)
+        self.assertEqual(x[0].get_array().shape, (2,))
+        self.assertEqual(len(x), 1)
+
+    def test_choose_next_empty_X(self):
+        epm_chooser = SMAC4AC(self.scenario, rng=1).solver.epm_chooser
+        epm_chooser.acquisition_func._compute = mock.Mock(
+            spec=RandomForestWithInstances
+        )
+        epm_chooser._random_search.maximize = mock.Mock(
+            spec=epm_chooser._random_search.maximize
+        )
+        epm_chooser._random_search.maximize.return_value = [0, 1, 2]
+
+        x = epm_chooser.choose_next()
+        self.assertEqual(x, [0, 1, 2])
+        self.assertEqual(epm_chooser._random_search.maximize.call_count, 1)
+        self.assertEqual(epm_chooser.acquisition_func._compute.call_count, 0)
+
+    def test_choose_next_empty_X_2(self):
+        epm_chooser = SMAC4AC(self.scenario, rng=1).solver.epm_chooser
+
+        challengers = epm_chooser.choose_next()
+        x = [c for c in challengers]
+        self.assertEqual(len(x), 1)
+        self.assertIsInstance(x[0], Configuration)
+
+    def test_choose_next_2(self):
+        # Test with a single configuration in the runhistory!
+        def side_effect(X):
+            return np.mean(X, axis=1).reshape((-1, 1))
+
+        def side_effect_predict(X):
+            m, v = np.ones((X.shape[0], 1)), None
+            return m, v
+
+        seed = 42
+        incumbent = self.scenario.cs.get_default_configuration()
+        rh = RunHistory(aggregate_func=average_cost)
+        rh.add(incumbent, 10, 10, StatusType.SUCCESS)
+        epm_chooser = SMAC4AC(self.scenario, rng=seed, runhistory=rh).solver.epm_chooser
+
+        epm_chooser.model = mock.Mock(spec=RandomForestWithInstances)
+        epm_chooser.model.predict_marginalized_over_instances.side_effect = side_effect_predict
+        epm_chooser.acquisition_func._compute = mock.Mock(spec=RandomForestWithInstances)
+        epm_chooser.acquisition_func._compute.side_effect = side_effect
+        epm_chooser.incumbent = incumbent
+
+        challengers = epm_chooser.choose_next()
+        # Convert challenger list (a generator) to a real list
+        challengers = [c for c in challengers]
+
+        self.assertEqual(epm_chooser.model.train.call_count, 1)
+
+        # For each configuration it is randomly sampled whether to take it from the list of challengers or to sample it
+        # completely at random. Therefore, it is not guaranteed to obtain twice the number of configurations selected
+        # by EI.
+        self.assertEqual(len(challengers), 9968)
+        num_random_search_sorted = 0
+        num_random_search = 0
+        num_local_search = 0
+        for c in challengers:
+            self.assertIsInstance(c, Configuration)
+            if 'Random Search (sorted)' == c.origin:
+                num_random_search_sorted += 1
+            elif 'Random Search' == c.origin:
+                num_random_search += 1
+            elif 'Local Search' == c.origin:
+                num_local_search += 1
+            else:
+                raise ValueError((c.origin, 'Local Search' == c.origin, type('Local Search'), type(c.origin)))
+
+        self.assertEqual(num_local_search, 11)
+        self.assertEqual(num_random_search_sorted, 5000)
+        self.assertEqual(num_random_search, 4957)
+
+    @unittest.skipIf(sys.version_info < (3, 6), 'Test not deterministic for Python 3.5 and earlier')
+    def test_choose_next_3(self):
+        # Test with ten configurations in the runhistory
+        def side_effect(X):
+            return np.mean(X, axis=1).reshape((-1, 1))
+
+        def side_effect_predict(X):
+            m, v = np.ones((X.shape[0], 1)), None
+            return m, v
+
+        epm_chooser = SMAC4AC(self.scenario, rng=1).solver.epm_chooser
+        epm_chooser.incumbent = self.scenario.cs.sample_configuration()
+        previous_configs = [epm_chooser.incumbent] + [self.scenario.cs.sample_configuration() for _ in range(0, 20)]
+        epm_chooser.runhistory = RunHistory(aggregate_func=average_cost)
+        for i in range(0, len(previous_configs)):
+            epm_chooser.runhistory.add(previous_configs[i], i, 10, StatusType.SUCCESS)
+        epm_chooser.model = mock.Mock(spec=RandomForestWithInstances)
+        epm_chooser.model.predict_marginalized_over_instances.side_effect = side_effect_predict
+        epm_chooser.acquisition_func._compute = mock.Mock(spec=RandomForestWithInstances)
+        epm_chooser.acquisition_func._compute.side_effect = side_effect
+
+        challengers = epm_chooser.choose_next()
+        # Convert challenger list (a generator) to a real list
+        challengers = [c for c in challengers]
+
+        self.assertEqual(epm_chooser.model.train.call_count, 1)
+
+        # For each configuration it is randomly sampled whether to take it from the list of challengers or to sample it
+        # completely at random. Therefore, it is not guaranteed to obtain twice the number of configurations selected
+        # by EI
+        self.assertEqual(len(challengers), 9983)
+        num_random_search_sorted = 0
+        num_random_search = 0
+        num_local_search = 0
+        for c in challengers:
+            self.assertIsInstance(c, Configuration)
+            if 'Random Search (sorted)' == c.origin:
+                num_random_search_sorted += 1
+            elif 'Random Search' == c.origin:
+                num_random_search += 1
+            elif 'Local Search' == c.origin:
+                num_local_search += 1
+            else:
+                raise ValueError(c.origin)
+
+        self.assertEqual(num_local_search, 25)
+        self.assertEqual(num_random_search_sorted, 5000)
+        self.assertEqual(num_random_search, 4958)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_smbo/test_epm_configuration_chooser.py
+++ b/test/test_smbo/test_epm_configuration_chooser.py
@@ -55,6 +55,7 @@ class TestEPMChooser(unittest.TestCase):
         x = smbo.epm_chooser.choose_next(incumbent_value=0.0)
         self.assertEqual(x[0].get_array().shape, (2,))
         self.assertEqual(len(x), 1)
+        self.assertEqual(x[0].origin, 'Random Search')
 
     def test_choose_next_empty_X(self):
         epm_chooser = SMAC4AC(self.scenario, rng=1).solver.epm_chooser

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -1,19 +1,15 @@
+import shutil
 import unittest
 from unittest import mock
-import sys
-import shutil
-from nose.plugins.attrib import attr
 
 import numpy as np
-from ConfigSpace import Configuration
+from nose.plugins.attrib import attr
 
-from smac.epm.rf_with_instances import RandomForestWithInstances
 from smac.epm.gaussian_process_mcmc import GaussianProcessMCMC
+from smac.epm.rf_with_instances import RandomForestWithInstances
 from smac.facade.smac_ac_facade import SMAC4AC
-from smac.initial_design.initial_design import InitialDesign
+from smac.intensification.abstract_racer import AbstractRacer
 from smac.optimizer.acquisition import EI, LogEI
-from smac.optimizer.objective import average_cost
-from smac.runhistory.runhistory import RunHistory
 from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost, RunHistory2EPM4LogCost
 from smac.scenario.scenario import Scenario
 from smac.tae.execute_ta_run import FirstRunCrashedException
@@ -56,15 +52,15 @@ class TestSMBO(unittest.TestCase):
         self.scenario.run_obj = 'runtime'
         self.scenario.cutoff = 300
         smbo = SMAC4AC(self.scenario).solver
-        self.assertIsInstance(smbo.model, RandomForestWithInstances)
-        self.assertIsInstance(smbo.rh2EPM, RunHistory2EPM4LogCost)
-        self.assertIsInstance(smbo.acquisition_func, LogEI)
+        self.assertIsInstance(smbo.epm_chooser.model, RandomForestWithInstances)
+        self.assertIsInstance(smbo.epm_chooser.rh2EPM, RunHistory2EPM4LogCost)
+        self.assertIsInstance(smbo.epm_chooser.acquisition_func, LogEI)
 
     def test_init_only_scenario_quality(self):
         smbo = SMAC4AC(self.scenario).solver
-        self.assertIsInstance(smbo.model, RandomForestWithInstances)
-        self.assertIsInstance(smbo.rh2EPM, RunHistory2EPM4Cost)
-        self.assertIsInstance(smbo.acquisition_func, EI)
+        self.assertIsInstance(smbo.epm_chooser.model, RandomForestWithInstances)
+        self.assertIsInstance(smbo.epm_chooser.rh2EPM, RunHistory2EPM4Cost)
+        self.assertIsInstance(smbo.epm_chooser.acquisition_func, EI)
 
     def test_rng(self):
         smbo = SMAC4AC(self.scenario, rng=None).solver
@@ -87,167 +83,7 @@ class TestSMBO(unittest.TestCase):
             rng='BLA',
         )
 
-    def test_choose_next(self):
-        seed = 42
-        smbo = SMAC4AC(self.scenario, rng=seed).solver
-        smbo.runhistory = RunHistory(aggregate_func=average_cost)
-        X = self.scenario.cs.sample_configuration().get_array()[None, :]
-        smbo.incumbent = self.scenario.cs.sample_configuration()
-        smbo.runhistory.add(smbo.incumbent, 10, 10, 1)
-
-        Y = self.branin(X)
-        x = next(smbo.choose_next(X, Y)).get_array()
-        assert x.shape == (2,)
-
-    def test_choose_next_w_empty_rh(self):
-        seed = 42
-        smbo = SMAC4AC(self.scenario, rng=seed).solver
-        smbo.runhistory = RunHistory(aggregate_func=average_cost)
-        X = self.scenario.cs.sample_configuration().get_array()[None, :]
-
-        Y = self.branin(X)
-        self.assertRaisesRegex(
-            ValueError,
-            'Runhistory is empty and the cost value of the incumbent is '
-            'unknown.',
-            smbo.choose_next,
-            **{"X": X, "Y": Y}
-        )
-
-        x = next(smbo.choose_next(X, Y, incumbent_value=0.0)).get_array()
-        assert x.shape == (2,)
-
-    def test_choose_next_empty_X(self):
-        smbo = SMAC4AC(self.scenario, rng=1).solver
-        smbo.acquisition_func._compute = mock.Mock(
-            spec=RandomForestWithInstances
-        )
-        smbo._random_search.maximize = mock.Mock(
-            spec=smbo._random_search.maximize
-        )
-        smbo._random_search.maximize.return_value = [0, 1, 2]
-
-        X = np.zeros((0, 2))
-        Y = np.zeros((0, 1))
-
-        x = smbo.choose_next(X, Y)
-        self.assertEqual(x, [0, 1, 2])
-        self.assertEqual(smbo._random_search.maximize.call_count, 1)
-        self.assertEqual(smbo.acquisition_func._compute.call_count, 0)
-
-    def test_choose_next_empty_X_2(self):
-        smbo = SMAC4AC(self.scenario, rng=1).solver
-
-        X = np.zeros((0, 2))
-        Y = np.zeros((0, 1))
-
-        challengers = smbo.choose_next(X, Y)
-        x = [c for c in challengers]
-        self.assertEqual(len(x), 1)
-        self.assertIsInstance(x[0], Configuration)
-
-    def test_choose_next_2(self):
-        # Test with a single configuration in the runhistory!
-        def side_effect(X):
-            return np.mean(X, axis=1).reshape((-1, 1))
-
-        def side_effect_predict(X):
-            m, v = np.ones((X.shape[0], 1)), None
-            return m, v
-
-        smbo = SMAC4AC(self.scenario, rng=1).solver
-        smbo.incumbent = self.scenario.cs.sample_configuration()
-        smbo.runhistory = RunHistory(aggregate_func=average_cost)
-        smbo.runhistory.add(smbo.incumbent, 10, 10, 1)
-        smbo.model = mock.Mock(spec=RandomForestWithInstances)
-        smbo.model.predict_marginalized_over_instances.side_effect = side_effect_predict
-        smbo.acquisition_func._compute = mock.Mock(spec=RandomForestWithInstances)
-        smbo.acquisition_func._compute.side_effect = side_effect
-
-        X = smbo.rng.rand(10, 2)
-        Y = smbo.rng.rand(10, 1)
-
-        challengers = smbo.choose_next(X, Y)
-        # Convert challenger list (a generator) to a real list
-        challengers = [c for c in challengers]
-
-        self.assertEqual(smbo.model.train.call_count, 1)
-
-        # For each configuration it is randomly sampled whether to take it from the list of challengers or to sample it
-        # completely at random. Therefore, it is not guaranteed to obtain twice the number of configurations selected
-        # by EI.
-        self.assertEqual(len(challengers), 9940)
-        num_random_search_sorted = 0
-        num_random_search = 0
-        num_local_search = 0
-        for c in challengers:
-            self.assertIsInstance(c, Configuration)
-            if 'Random Search (sorted)' == c.origin:
-                num_random_search_sorted += 1
-            elif 'Random Search' == c.origin:
-                num_random_search += 1
-            elif 'Local Search' == c.origin:
-                num_local_search += 1
-            else:
-                raise ValueError((c.origin, 'Local Search' == c.origin, type('Local Search'), type(c.origin)))
-
-        self.assertEqual(num_local_search, 11)
-        self.assertEqual(num_random_search_sorted, 5000)
-        self.assertEqual(num_random_search, 4929)
-
-    @unittest.skipIf(sys.version_info < (3, 6), 'Test not deterministic for Python 3.5 and earlier')
-    def test_choose_next_3(self):
-        # Test with ten configurations in the runhistory
-        def side_effect(X):
-            return np.mean(X, axis=1).reshape((-1, 1))
-
-        def side_effect_predict(X):
-            m, v = np.ones((X.shape[0], 1)), None
-            return m, v
-
-        smbo = SMAC4AC(self.scenario, rng=1).solver
-        smbo.incumbent = self.scenario.cs.sample_configuration()
-        previous_configs = [smbo.incumbent] + [self.scenario.cs.sample_configuration() for i in range(0, 20)]
-        smbo.runhistory = RunHistory(aggregate_func=average_cost)
-        for i in range(0, len(previous_configs)):
-            smbo.runhistory.add(previous_configs[i], i, 10, 1)
-        smbo.model = mock.Mock(spec=RandomForestWithInstances)
-        smbo.model.predict_marginalized_over_instances.side_effect = side_effect_predict
-        smbo.acquisition_func._compute = mock.Mock(spec=RandomForestWithInstances)
-        smbo.acquisition_func._compute.side_effect = side_effect
-
-        X = smbo.rng.rand(10, 2)
-        Y = smbo.rng.rand(10, 1)
-
-        challengers = smbo.choose_next(X, Y)
-        # Convert challenger list (a generator) to a real list
-        challengers = [c for c in challengers]
-
-        self.assertEqual(smbo.model.train.call_count, 1)
-
-        # For each configuration it is randomly sampled whether to take it from the list of challengers or to sample it
-        # completely at random. Therefore, it is not guaranteed to obtain twice the number of configurations selected
-        # by EI
-        self.assertEqual(len(challengers), 9977)
-        num_random_search_sorted = 0
-        num_random_search = 0
-        num_local_search = 0
-        for c in challengers:
-            self.assertIsInstance(c, Configuration)
-            if 'Random Search (sorted)' == c.origin:
-                num_random_search_sorted += 1
-            elif 'Random Search' == c.origin:
-                num_random_search += 1
-            elif 'Local Search' == c.origin:
-                num_local_search += 1
-            else:
-                raise ValueError(c.origin)
-
-        self.assertEqual(num_local_search, 26)
-        self.assertEqual(num_random_search_sorted, 5000)
-        self.assertEqual(num_random_search, 4951)
-
-    @mock.patch.object(InitialDesign, 'run')
+    @mock.patch.object(AbstractRacer, 'eval_challenger')
     def test_abort_on_initial_design(self, patch):
         def target(x):
             return 5
@@ -257,7 +93,10 @@ class TestSMBO(unittest.TestCase):
                          'abort_on_first_run_crash': 1})
         self.output_dirs.append(scen.output_dir)
         smbo = SMAC4AC(scen, tae_runner=target, rng=1).solver
-        self.assertRaises(FirstRunCrashedException, smbo.run)
+
+        with self.assertRaises(FirstRunCrashedException):
+            smbo.start()
+            smbo.run()
 
     @attr('slow')
     def test_intensification_percentage(self):
@@ -310,9 +149,9 @@ class TestSMBO(unittest.TestCase):
         smac = SMAC4AC(self.scenario)
         self.output_dirs.append(smac.output_dir)
         smbo = smac.solver
-        with mock.patch.object(InitialDesign, "run", return_value=None) as initial_mock:
-            smbo.start()
-            self.assertEqual(smbo.incumbent, smbo.scenario.cs.get_default_configuration())
+        # SMBO should have the default configuration as the 1st config if no initial design is given
+        smbo.start()
+        self.assertEqual(smbo.initial_design_configs[0], smbo.scenario.cs.get_default_configuration())
 
     def test_rf_comp_builder(self):
         seed = 42

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -8,7 +8,7 @@ from nose.plugins.attrib import attr
 from smac.epm.gaussian_process_mcmc import GaussianProcessMCMC
 from smac.epm.rf_with_instances import RandomForestWithInstances
 from smac.facade.smac_ac_facade import SMAC4AC
-from smac.intensification.abstract_racer import AbstractRacer
+from smac.intensification.intensification import Intensifier
 from smac.optimizer.acquisition import EI, LogEI
 from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost, RunHistory2EPM4LogCost
 from smac.scenario.scenario import Scenario
@@ -83,7 +83,7 @@ class TestSMBO(unittest.TestCase):
             rng='BLA',
         )
 
-    @mock.patch.object(AbstractRacer, 'eval_challenger')
+    @mock.patch.object(Intensifier, 'eval_challenger')
     def test_abort_on_initial_design(self, patch):
         def target(x):
             return 5


### PR DESCRIPTION
The basic design of the pull architecture for sampling challengers on-the-fly.
* Implemented by passing the optimizer (SMBO) as an argument to `intensify()` method
* Currently supports sending both a list of challengers and optimizer as arguments to the intensifier, since `InitialDesign` sends its own configurations for intensification.

**UPDATE**
* `InitialDesign` only returns the configurations to run and all runs happen only through the main BO loop in SMBO. This is to avoid sampling additional configurations (and redundant code) during initial design. 

~**Note**: Testcases have not been modified yet.~