### PR TITLE
Add argument to directly control the size of the initial design

### DIFF
--- a/smac/initial_design/initial_design.py
+++ b/smac/initial_design/initial_design.py
@@ -74,9 +74,12 @@ class InitialDesign:
             Function to aggregate performance of a configuration across
             instances.
         configs: typing.Optional[typing.List[Configuration]]
-            List of initial configurations.
+            List of initial configurations. Disables the arguments ``n_configs_x_params`` if given.
+            Either this, or ``n_configs_x_params`` or ``init_budget`` must be provided.
         n_configs_x_params: int
-            how many configurations will be used at most in the initial design (X*D)
+            how many configurations will be used at most in the initial design (X*D). Either
+            this, or ``init_budget`` or ``configs`` must be provided. Disables the argument
+            ``n_configs_x_params`` if given.
         max_config_fracs: float
             use at most X*budget in the initial design. Not active if a time limit is given.
         run_first_config: bool
@@ -84,7 +87,9 @@ class InitialDesign:
         fill_random_configs: bool
             fill budget with random configurations if initial incumbent sampling returns only 1 configuration
         init_budget : int, optional
-            Maximal initial budget (disables the argument ``n_configs_x_params``)
+            Maximal initial budget (disables the arguments ``n_configs_x_params`` and ``configs``
+            if both are given). Either this, or ``n_configs_x_params`` or ``configs`` must be
+            provided.
         """
 
         self.tae_runner = tae_runner

--- a/smac/initial_design/initial_design.py
+++ b/smac/initial_design/initial_design.py
@@ -111,9 +111,12 @@ class InitialDesign:
                 )
         elif configs is not None:
             self.init_budget = len(configs)
-        else:
+        elif n_configs_x_params is not None:
             self.init_budget = int(max(1, min(n_configs_x_params * n_params,
                                               (max_config_fracs * scenario.ta_run_limit))))
+        else:
+            raise ValueError('Need to provide either argument `init_budget`, `configs` or '
+                             '`n_configs_x_params`, but provided none of them.')
         if self.init_budget > scenario.ta_run_limit:
             raise ValueError(
                 'Initial budget %d cannot be higher than the run limit %d.'

--- a/smac/initial_design/initial_design.py
+++ b/smac/initial_design/initial_design.py
@@ -84,7 +84,7 @@ class InitialDesign:
         fill_random_configs: bool
             fill budget with random configurations if initial incumbent sampling returns only 1 configuration
         init_budget : int, optional
-            Maximal initial budget (alternative to ``n_configs_x_params``)
+            Maximal initial budget (disables the argument ``n_configs_x_params``)
         """
 
         self.tae_runner = tae_runner

--- a/test/test_initial_design/test_initial_design.py
+++ b/test/test_initial_design/test_initial_design.py
@@ -22,8 +22,12 @@ class TestSingleInitialDesign(unittest.TestCase):
         self.cs.add_hyperparameter(UniformFloatHyperparameter(
             name="x1", lower=1, upper=10, default_value=1)
         )
-        self.scenario = Scenario({'cs': self.cs, 'run_obj': 'quality',
-                                  'output_dir': ''})
+        self.scenario = Scenario({
+            'cs': self.cs,
+            'run_obj': 'quality',
+            'output_dir': '',
+            'ta_run_limit': 100,
+        })
         self.ta = ExecuteTAFuncDict(lambda x: x["x1"]**2)
 
     def test_single_default_config_design(self):
@@ -85,6 +89,68 @@ class TestSingleInitialDesign(unittest.TestCase):
         self.assertEqual(len(rh.data), 4)  # two runs per config
         self.assertEqual(rh.get_cost(inc), 4)
         self.assertEqual(len(rh.get_all_configs()), 2)
+
+    def test_init_budget(self):
+        stats = Stats(scenario=self.scenario)
+        stats.start_timing()
+        self.ta.stats = stats
+        tj = TrajLogger(output_dir=None, stats=stats)
+        rh = RunHistory(aggregate_func=average_cost)
+        self.ta.runhistory = rh
+        rng = np.random.RandomState(seed=12345)
+
+        intensifier = Intensifier(
+            tae_runner=self.ta,
+            stats=stats,
+            traj_logger=tj,
+            rng=rng,
+            instances=[None],
+            run_obj_time=False,
+        )
+        kwargs = dict(
+            tae_runner=self.ta,
+            scenario=self.scenario,
+            stats=stats,
+            traj_logger=tj,
+            runhistory=rh,
+            rng=rng,
+            intensifier=intensifier,
+            aggregate_func=average_cost,
+        )
+
+        configs = [Configuration(configuration_space=self.cs, values={"x1": 4}),
+                   Configuration(configuration_space=self.cs, values={"x1": 2})]
+        dc = InitialDesign(
+            configs=configs,
+            init_budget=3,
+            **kwargs,
+        )
+        self.assertEqual(dc.init_budget, 3)
+
+        dc = InitialDesign(
+            init_budget=3,
+            **kwargs,
+        )
+        self.assertEqual(dc.init_budget, 3)
+
+        configs = [Configuration(configuration_space=self.cs, values={"x1": 4}),
+                   Configuration(configuration_space=self.cs, values={"x1": 2})]
+        dc = InitialDesign(
+            configs=configs,
+            **kwargs,
+        )
+        self.assertEqual(dc.init_budget, 2)
+
+        dc = InitialDesign(
+            **kwargs,
+        )
+        self.assertEqual(dc.init_budget, 10)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            'Initial budget 200 cannot be higher than the run limit 100.',
+        ):
+            InitialDesign(init_budget=200, **kwargs)
 
     def test_fill_config_design(self):
         stats = Stats(scenario=self.scenario)

--- a/test/test_initial_design/test_initial_design.py
+++ b/test/test_initial_design/test_initial_design.py
@@ -48,7 +48,7 @@ class TestSingleInitialDesign(unittest.TestCase):
             aggregate_func=average_cost,
         )
 
-        inc = dc.run()
+        dc.run()
         self.assertTrue(stats.ta_runs == 1)
         self.assertTrue(len(rh.data) == 0)
 
@@ -70,8 +70,8 @@ class TestSingleInitialDesign(unittest.TestCase):
             run_obj_time=False,
         )
 
-        configs = [Configuration(configuration_space=self.cs, values={"x1":4}),
-                   Configuration(configuration_space=self.cs, values={"x1":2})]
+        configs = [Configuration(configuration_space=self.cs, values={"x1": 4}),
+                   Configuration(configuration_space=self.cs, values={"x1": 2})]
         dc = InitialDesign(
             tae_runner=self.ta,
             scenario=self.scenario,

--- a/test/test_initial_design/test_initial_design.py
+++ b/test/test_initial_design/test_initial_design.py
@@ -152,6 +152,13 @@ class TestSingleInitialDesign(unittest.TestCase):
         ):
             InitialDesign(init_budget=200, **kwargs)
 
+        with self.assertRaisesRegex(
+            ValueError,
+            'Need to provide either argument `init_budget`, `configs` or `n_configs_x_params`, '
+            'but provided none of them.',
+        ):
+            InitialDesign(**kwargs, n_configs_x_params=None)
+
     def test_fill_config_design(self):
         stats = Stats(scenario=self.scenario)
         stats.start_timing()


### PR DESCRIPTION
This might be advantageous in cases where one does meta-learning and wants to ensure that exactly 2 or 3 configurations are used to start.