### PR TITLE
Remove default rng from gp prior objects

### DIFF
--- a/smac/epm/gp_base_prior.py
+++ b/smac/epm/gp_base_prior.py
@@ -9,7 +9,7 @@ from smac.utils.constants import VERY_SMALL_NUMBER
 
 class Prior(object):
 
-    def __init__(self, rng: np.random.RandomState = None):
+    def __init__(self, rng: np.random.RandomState):
         """
         Abstract base class to define the interface for priors
         of GP hyperparameter.
@@ -29,9 +29,8 @@ class Prior(object):
 
         """
         if rng is None:
-            self.rng = np.random.RandomState(np.random.randint(0, 10000))
-        else:
-            self.rng = rng
+            raise ValueError('Argument rng must not be `None`.')
+        self.rng = rng
 
     def lnprob(self, theta: float) -> float:
         """
@@ -152,7 +151,7 @@ class Prior(object):
 
 class TophatPrior(Prior):
 
-    def __init__(self, lower_bound: float, upper_bound: float, rng: np.random.RandomState = None):
+    def __init__(self, lower_bound: float, upper_bound: float, rng: np.random.RandomState):
         """
         Tophat prior as it used in the original spearmint code.
 
@@ -171,10 +170,8 @@ class TophatPrior(Prior):
         rng: np.random.RandomState
             Random number generator
         """
-        if rng is None:
-            self.rng = np.random.RandomState(np.random.randint(0, 10000))
-        else:
-            self.rng = rng
+
+        super().__init__(rng)
         self.min = lower_bound
         self._log_min = np.log(lower_bound)
         self.max = upper_bound
@@ -242,7 +239,7 @@ class TophatPrior(Prior):
 
 class HorseshoePrior(Prior):
 
-    def __init__(self, scale: float=0.1, rng: np.random.RandomState=None):
+    def __init__(self, scale: float, rng: np.random.RandomState):
         """
         Horseshoe Prior as it is used in spearmint
 
@@ -259,10 +256,7 @@ class HorseshoePrior(Prior):
         rng: np.random.RandomState
             Random number generator
         """
-        if rng is None:
-            self.rng = np.random.RandomState(np.random.randint(0, 10000))
-        else:
-            self.rng = rng
+        super().__init__(rng)
         self.scale = scale
         self.scale_square = scale ** 2
 
@@ -338,7 +332,7 @@ class HorseshoePrior(Prior):
 
 class LognormalPrior(Prior):
 
-    def __init__(self, sigma: float, mean: float=0, rng: np.random.RandomState = None):
+    def __init__(self, sigma: float, rng: np.random.RandomState, mean: float = 0, ):
         """
         Log normal prior
 
@@ -353,15 +347,12 @@ class LognormalPrior(Prior):
         sigma: float
             Specifies the standard deviation of the normal
             distribution.
-        mean: float
-            Specifies the mean of the normal distribution
         rng: np.random.RandomState
             Random number generator
+        mean: float
+            Specifies the mean of the normal distribution
         """
-        if rng is None:
-            self.rng = np.random.RandomState(np.random.randint(0, 10000))
-        else:
-            self.rng = rng
+        super().__init__(rng)
 
         if mean != 0:
             raise NotImplementedError(mean)
@@ -433,8 +424,8 @@ class LognormalPrior(Prior):
 
 
 class SoftTopHatPrior(Prior):
-    def __init__(self, lower_bound=-10, upper_bound=10, exponent=2, rng: np.random.RandomState = None):
-        super().__init__(rng=rng)
+    def __init__(self, lower_bound, upper_bound, exponent, rng: np.random.RandomState):
+        super().__init__(rng)
 
         with warnings.catch_warnings():
             warnings.simplefilter('error')
@@ -505,7 +496,7 @@ class SoftTopHatPrior(Prior):
 
 class GammaPrior(Prior):
 
-    def __init__(self, a: float, scale: float, loc: float=0, rng: np.random.RandomState = None):
+    def __init__(self, a: float, scale: float, loc: float, rng: np.random.RandomState):
         """
         Gamma prior
 
@@ -522,7 +513,7 @@ class GammaPrior(Prior):
         rng: np.random.RandomState
             Random number generator
         """
-        super().__init__(rng=rng)
+        super().__init__(rng)
 
         self.a = a
         self.loc = loc

--- a/test/test_epm/test_gp_priors.py
+++ b/test/test_epm/test_gp_priors.py
@@ -16,7 +16,11 @@ def wrap_ln(theta, prior):
 class TestTophatPrior(unittest.TestCase):
 
     def test_lnprob_and_grad_scalar(self):
-        prior = TophatPrior(lower_bound=np.exp(-10), upper_bound=np.exp(2))
+        prior = TophatPrior(
+            lower_bound=np.exp(-10),
+            upper_bound=np.exp(2),
+            rng=np.random.RandomState(1),
+        )
 
         # Legal scalar
         for val in (-1, 0, 1):
@@ -45,7 +49,11 @@ class TestTophatPrior(unittest.TestCase):
         rng = np.random.RandomState(1)
         lower_bound = 2 + rng.random_sample() * 50
         upper_bound = lower_bound + rng.random_sample() * 50
-        prior = TophatPrior(lower_bound=lower_bound, upper_bound=upper_bound)
+        prior = TophatPrior(
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+            rng=np.random.RandomState(1),
+        )
         sample = prior.sample_from_prior(1)
         self.assertEqual(sample.shape, (1,))
         sample = prior.sample_from_prior(2)
@@ -61,7 +69,7 @@ class TestTophatPrior(unittest.TestCase):
 class TestHorseshoePrior(unittest.TestCase):
 
     def test_lnprob_and_grad_scalar(self):
-        prior = HorseshoePrior(scale=1)
+        prior = HorseshoePrior(scale=1, rng=np.random.RandomState(1))
 
         # Legal scalar
         self.assertEqual(prior.lnprob(-1), 1.1450937952919953)
@@ -81,7 +89,11 @@ class TestHorseshoePrior(unittest.TestCase):
         rng = np.random.RandomState(1)
         lower_bound = 2 + rng.random_sample() * 50
         upper_bound = lower_bound + rng.random_sample() * 50
-        prior = TophatPrior(lower_bound=lower_bound, upper_bound=upper_bound)
+        prior = TophatPrior(
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+            rng=np.random.RandomState(1),
+        )
         sample = prior.sample_from_prior(1)
         self.assertEqual(sample.shape, (1,))
         sample = prior.sample_from_prior(2)
@@ -95,7 +107,7 @@ class TestHorseshoePrior(unittest.TestCase):
 
     def test_gradient(self):
         for scale in (0.1, 0.5, 1., 2.):
-            prior = HorseshoePrior(scale=scale)
+            prior = HorseshoePrior(scale=scale, rng=np.random.RandomState(1))
             # The function appears to be unstable above 15
             for theta in range(-20, 15):
                 if theta == 0:
@@ -112,7 +124,7 @@ class TestHorseshoePrior(unittest.TestCase):
 class TestGammaPrior(unittest.TestCase):
 
     def test_lnprob_and_grad_scalar(self):
-        prior = GammaPrior(a=0.5, scale=1/2, loc=0)
+        prior = GammaPrior(a=0.5, scale=1/2, loc=0, rng=np.random.RandomState(1))
 
         # Legal scalar
         x = -1
@@ -120,7 +132,7 @@ class TestGammaPrior(unittest.TestCase):
         self.assertEqual(prior.gradient(x), -1.2357588823428847)
 
     def test_lnprob_and_grad_array(self):
-        prior = GammaPrior(a=0.5, scale=1/2, loc=0)
+        prior = GammaPrior(a=0.5, scale=1/2, loc=0, rng=np.random.RandomState(1))
         val = np.array([-1, -1])
         with self.assertRaises(NotImplementedError):
             prior.lnprob(val)
@@ -129,7 +141,7 @@ class TestGammaPrior(unittest.TestCase):
 
     def test_gradient(self):
         for scale in (0.5, 1., 2.):
-            prior = GammaPrior(a=2, scale=scale, loc=0)
+            prior = GammaPrior(a=2, scale=scale, loc=0, rng=np.random.RandomState(1))
             # The function appears to be unstable above 10
             for theta in np.arange(1e-15, 10, 0.01):
                 if theta == 0:
@@ -147,7 +159,7 @@ class TestLogNormalPrior(unittest.TestCase):
 
     def test_gradient(self):
         for sigma in (0.5, 1., 2.):
-            prior = LognormalPrior(mean=0, sigma=sigma)
+            prior = LognormalPrior(mean=0, sigma=sigma, rng=np.random.RandomState(1))
             # The function appears to be unstable above 15
             for theta in range(0, 15):
                 # Gradient approximation becomes unstable when going closer to zero
@@ -164,7 +176,12 @@ class TestLogNormalPrior(unittest.TestCase):
 class TestSoftTopHatPrior(unittest.TestCase):
 
     def test_lnprob(self):
-        prior = SoftTopHatPrior(lower_bound=np.exp(-5), upper_bound=np.exp(5))
+        prior = SoftTopHatPrior(
+            lower_bound=np.exp(-5),
+            upper_bound=np.exp(5),
+            exponent=2,
+            rng=np.random.RandomState(1),
+        )
 
         # Legal values
         self.assertEqual(prior.lnprob(-5), 0)
@@ -180,7 +197,12 @@ class TestSoftTopHatPrior(unittest.TestCase):
         self.assertAlmostEqual(prior.lnprob(7), -4)
 
     def test_grad(self):
-        prior = SoftTopHatPrior(lower_bound=np.exp(-5), upper_bound=np.exp(5))
+        prior = SoftTopHatPrior(
+            lower_bound=np.exp(-5),
+            upper_bound=np.exp(5),
+            exponent=2,
+            rng=np.random.RandomState(1),
+        )
 
         # Legal values
         self.assertEqual(prior.gradient(-5), 0)


### PR DESCRIPTION
To avoid SMAC behaving in a random manner if forgetting to seed these objects.