### PR TITLE
Issue 488 save incumbent in traj as json

### DIFF
--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -308,8 +308,7 @@ class TrajLogger(object):
                 v = float(v)
             elif isinstance(hp, IntegerHyperparameter):
                 v = int(v)
-            elif (isinstance(hp, CategoricalHyperparameter)
-                  or isinstance(hp, Constant)):
+            elif isinstance(hp, (CategoricalHyperparameter, Constant)):
                 # Checking for the correct type requires jumping some hoops
                 # First, we gather possible interpretations of our string
                 interpretations = [v]
@@ -319,14 +318,16 @@ class TrajLogger(object):
                     interpretations.append(True if v == 'True' else False)
                 else:
                     for t in [int, float]:
-                        try: interpretations.append(t(v))
-                        except ValueError: continue
+                        try:
+                            interpretations.append(t(v))
+                        except ValueError:
+                            continue
 
                 # Second, check if it's in the choices / the correct type.
                 if isinstance(hp, CategoricalHyperparameter):
                     legal = set(interpretations) & set(hp.choices)
                 if isinstance(hp, Constant):
-                    legal = {l for l in legal if type(l) == type(hp.default_value)}
+                    legal = {l for l in legal if type(l) is type(hp.default_value)}
 
                 # Third, issue warnings if the interpretation is not unambigious
                 if len(legal) < 1:

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -159,7 +159,7 @@ class TrajLogger(object):
                 conf.append("%s='%s'" % (p, repr(incumbent[p])))
 
         traj_entry = {"cpu_time": ta_time_used,
-                      "total_cpu_time": None,  # TODO: fix this
+                      "total_cpu_time": None,
                       "wallclock_time": wallclock_time,
                       "evaluations": self.stats.ta_runs,
                       "cost": train_perf,
@@ -200,7 +200,7 @@ class TrajLogger(object):
             inc_dict = incumbent.get_dictionary()
 
         traj_entry = {"cpu_time": ta_time_used,
-                      "total_cpu_time": None,  # TODO: fix this
+                      "total_cpu_time": None,
                       "wallclock_time": wallclock_time,
                       "evaluations": self.stats.ta_runs,
                       "cost": train_perf,
@@ -234,7 +234,7 @@ class TrajLogger(object):
             Each entry in the list is a dictionary of the form
             {
             "cpu_time": float,
-            "total_cpu_time": None, # TODO
+            "total_cpu_time": None,
             "wallclock_time": float,
             "evaluations": int
             "cost": float,
@@ -268,7 +268,7 @@ class TrajLogger(object):
             Each entry in the list is a dictionary of the form
             {
             "cpu_time": float,
-            "total_cpu_time": None, # TODO
+            "total_cpu_time": None,
             "wallclock_time": float,
             "evaluations": int
             "cost": float,

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import logging
 import json
 import typing

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -324,21 +324,14 @@ class TrajLogger(object):
                             continue
 
                 # Second, check if it's in the choices / the correct type.
-                if isinstance(hp, CategoricalHyperparameter):
-                    legal = set(interpretations) & set(hp.choices)
-                if isinstance(hp, Constant):
-                    legal = {l for l in legal if type(l) is type(hp.default_value)}
+                legal = {l for l in legal if hp.is_legal(l)}
 
-                # Third, issue warnings if the interpretation is not unambigious
-                if len(legal) < 1:
+                # Third, issue warnings if the interpretation is ambigious
+                if len(legal) != 1:
                     logging.getLogger("smac.trajlogger").warning(
-                        "No legal interpretation of value {} for hp {} found. "
-                        "Trying to pass string, but this will likely result in an error".format(v, hp.name))
-                if len(legal) > 1:
-                    logging.getLogger("smac.trajlogger").warning(
-                        "Multiple interpretations of value {} for hp {} found"
-                        "Passing string, but this might lead to unintended behaviour".format(v, hp.name))
-                if len(legal) == 1:
+                        "Ambigous or no interpretation of value {} for hp {} found ({} possible interpretations)"
+                        "Passing string, but this will likely result in an error".format(v, hp.name, len(legal)))
+                else:
                     v = legal.pop()
 
             config_dict[k] = v

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -324,12 +324,12 @@ class TrajLogger(object):
                             continue
 
                 # Second, check if it's in the choices / the correct type.
-                legal = {l for l in legal if hp.is_legal(l)}
+                legal = {l for l in interpretations if hp.is_legal(l)}
 
                 # Third, issue warnings if the interpretation is ambigious
                 if len(legal) != 1:
                     logging.getLogger("smac.trajlogger").warning(
-                        "Ambigous or no interpretation of value {} for hp {} found ({} possible interpretations)"
+                        "Ambigous or no interpretation of value {} for hp {} found ({} possible interpretations). "
                         "Passing string, but this will likely result in an error".format(v, hp.name, len(legal)))
                 else:
                     v = legal.pop()

--- a/smac/utils/io/traj_logging.py
+++ b/smac/utils/io/traj_logging.py
@@ -69,7 +69,7 @@ class TrajLogger(object):
                         '"Configuration..."\n')
 
             self.aclib_traj_fn = os.path.join(output_dir, "traj_aclib2.json")
-            self.alljson_traj_fn = os.path.join(output_dir, "traj_alljson.json")
+            self.alljson_traj_fn = os.path.join(output_dir, "traj.json")
 
         self.trajectory = []
 
@@ -159,18 +159,12 @@ class TrajLogger(object):
                 conf.append("%s='%s'" % (p, repr(incumbent[p])))
 
         traj_entry = {"cpu_time": ta_time_used,
-                      "total_cpu_time": None,
                       "wallclock_time": wallclock_time,
                       "evaluations": self.stats.ta_runs,
                       "cost": train_perf,
-                      "incumbent": conf
+                      "incumbent": conf,
+                      "origin": incumbent.origin,
                       }
-        # Silent support for passing configuration-dict's directly (since actual Configuration's always have
-        #   origin-attribute since v0.4.11 and minimum required by SMAC is 0.4.6):
-        try:
-            traj_entry["origin"] = incumbent.origin
-        except AttributeError:
-            traj_entry["origin"] = "UNKNOWN"
 
         with open(self.aclib_traj_fn, "a") as fp:
             json.dump(traj_entry, fp)
@@ -194,24 +188,13 @@ class TrajLogger(object):
         wallclock_time: float
             Wallclock time used so far
         """
-        # Silent support for passing configuration-dict's directly:
-        inc_dict = incumbent
-        if isinstance(incumbent, Configuration):
-            inc_dict = incumbent.get_dictionary()
-
         traj_entry = {"cpu_time": ta_time_used,
-                      "total_cpu_time": None,
                       "wallclock_time": wallclock_time,
                       "evaluations": self.stats.ta_runs,
                       "cost": train_perf,
-                      "incumbent": inc_dict,
+                      "incumbent": incumbent.get_dictionary(),
+                      "origin": incumbent.origin,
                       }
-        # Silent support for passing configuration-dict's directly (since actual Configuration's always have
-        #   origin-attribute since v0.4.11 and minimum required by SMAC is 0.4.6):
-        try:
-            traj_entry["origin"] = incumbent.origin
-        except AttributeError:
-            traj_entry["origin"] = "UNKNOWN"
 
         with open(self.alljson_traj_fn, "a") as fp:
             json.dump(traj_entry, fp)
@@ -234,7 +217,6 @@ class TrajLogger(object):
             Each entry in the list is a dictionary of the form
             {
             "cpu_time": float,
-            "total_cpu_time": None,
             "wallclock_time": float,
             "evaluations": int
             "cost": float,
@@ -268,7 +250,6 @@ class TrajLogger(object):
             Each entry in the list is a dictionary of the form
             {
             "cpu_time": float,
-            "total_cpu_time": None,
             "wallclock_time": float,
             "evaluations": int
             "cost": float,

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -3,20 +3,20 @@ Created on Apr 25, 2015
 
 @author: Andre Biedenkapp
 '''
+import tempfile
 import unittest
 import logging
 import json
 import os
 
-try:
-    import unittest.mock
-    from unittest.mock import patch
-except:
-    from mock import patch
+import unittest.mock
+from unittest.mock import patch
+
 from smac.utils.io.traj_logging import TrajLogger
 from smac.utils.io.traj_logging import TrajEntry
 
-from smac.configspace import ConfigurationSpace, Configuration, CategoricalHyperparameter, Constant
+from smac.configspace import ConfigurationSpace, Configuration, CategoricalHyperparameter, Constant, \
+                             UniformFloatHyperparameter, UniformIntegerHyperparameter
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
 
@@ -32,110 +32,74 @@ class TrajLoggerTest(unittest.TestCase):
         self.logger.setLevel(logging.DEBUG)
         self.value = 0
         self.cs = ConfigurationSpace()
+        self.cs.add_hyperparameters([
+            UniformFloatHyperparameter('param_a', -0.2, 1.77, 1.1),
+            UniformIntegerHyperparameter('param_b', -3, 10, 1),
+            Constant('param_c', 'value'),
+            CategoricalHyperparameter('ambigous_categorical', choices=['True', True, 5]),  # True is ambigous here
+        ])
+        self.test_config = Configuration(self.cs, {'param_a': 0.5,
+                                                   'param_b': 1,
+                                                   'param_c': 'value',
+                                                   'ambigous_categorical': 5})
 
     def test_init(self):
-        scen = Scenario(scenario={'run_obj': 'quality', 'cs': self.cs,
-                                  'output_dir': ''})
+        scen = Scenario(scenario={'run_obj': 'quality', 'cs': self.cs, 'output_dir': ''})
         stats = Stats(scen)
-        TrajLogger(output_dir='./tmp_test_folder', stats=stats)
-        self.assertFalse(os.path.exists('smac3-output'))
-        self.assertTrue(os.path.exists('tmp_test_folder'))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'tmp_test_folder')
+            TrajLogger(output_dir=path, stats=stats)
+            self.assertTrue(os.path.exists(path))
 
     def test_oserror(self):
-        scen = Scenario(scenario={'run_obj': 'quality', 'cs': self.cs,
-                                  'output_dir': ''})
+        scen = Scenario(scenario={'run_obj': 'quality', 'cs': self.cs, 'output_dir': ''})
         stats = Stats(scen)
         # test OSError
         with patch('os.makedirs') as osMock:
             osMock.side_effect = OSError()
-            self.assertRaises(OSError, TrajLogger, output_dir='./tmp_test_folder', stats=stats)
+            self.assertRaises(OSError, TrajLogger, output_dir='random_directory', stats=stats)
 
     @patch('smac.stats.stats.Stats')
-    def test_add_entry(self, mock_stats):
-
-        tl = TrajLogger(output_dir='./tmp_test_folder', stats=mock_stats)
-        test_config = {'param_a': 0.5,
-                       'param_b': 1,
-                       'param_c': 'value'}
-
+    def test_add_entries(self, mock_stats):
+        # Mock stats
         mock_stats.ta_time_used = .5
         mock_stats.get_used_wallclock_time = self.mocked_get_used_wallclock_time
         mock_stats.ta_runs = 1
 
-        tl.add_entry(0.9, 1, test_config)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tl = TrajLogger(output_dir=tmpdir, stats=mock_stats)
 
-        self.assertTrue(os.path.exists('tmp_test_folder/traj_old.csv'))
-        self.assertTrue(os.path.exists('tmp_test_folder/traj_aclib2.json'))
-        self.assertTrue(os.path.exists('tmp_test_folder/traj_alljson.json'))
+            # Add some entries
+            tl.add_entry(0.9, 1, self.test_config)
+            mock_stats.ta_runs = 2
+            mock_stats.ta_time_used = 0
+            tl.add_entry(1.3, 1, self.test_config)
+            mock_stats.ta_time_used = 0
+            tl.add_entry(0.7, 2, Configuration(self.cs, dict(self.test_config.get_dictionary(), **{'param_a': 0.})))
 
-        with open('tmp_test_folder/traj_old.csv') as to:
-            data = to.read().split('\n')[:-1]
+            # Test the list that's added to the trajectory class
+            self.assertEqual(tl.trajectory[0], TrajEntry(0.9, 1, self.test_config, 1, 0.5, 1))
+            # Test named-tuple-access:
+            self.assertEqual(tl.trajectory[0].train_perf, 0.9)
+            self.assertEqual(tl.trajectory[0].incumbent_id, 1)
+            self.assertEqual(tl.trajectory[0].ta_runs, 1)
+            self.assertEqual(tl.trajectory[0].ta_time_used, 0.5)
+            self.assertEqual(tl.trajectory[0].wallclock_time, 1)
+            self.assertEqual(len(tl.trajectory), 3)
 
-        header = data[0].split(',')
-        self.assertEquals(header[0], '"CPU Time Used"')
-        self.assertEquals(header[-1], '"Configuration..."')
+            # Check if the trajectories are generated
+            for fn in ['traj_old.csv', 'traj_aclib2.json', 'traj.json']:
+                self.assertTrue(os.path.exists(os.path.join(tmpdir, fn)))
 
-        data = list(map(lambda x: x.split(', '), data[1:]))
-        frmt_str = '%1.6f'
-        self.assertEquals(frmt_str % .5, data[0][0])
-        self.assertEquals(frmt_str % .9, data[0][1])
-        self.assertEquals(frmt_str % 0.5, data[0][-4])
+            # Load trajectories
+            with open(os.path.join(tmpdir, 'traj_old.csv')) as to:
+                data = to.read().split('\n')
+            with open(os.path.join(tmpdir, 'traj_aclib2.json')) as js_aclib:
+                json_dicts_aclib2 = [json.loads(l) for l in js_aclib.read().splitlines()]
+            with open(os.path.join(tmpdir, 'traj.json')) as js:
+                json_dicts_alljson = [json.loads(l) for l in js.read().splitlines()]
 
-        with open('tmp_test_folder/traj_aclib2.json') as js:
-            json_dict = json.load(js)
-
-        self.assertEquals(json_dict['cpu_time'], .5)
-        self.assertEquals(json_dict['cost'], 0.9)
-        self.assertEquals(len(json_dict['incumbent']), 3)
-        self.assertTrue("param_a='0.5'" in json_dict['incumbent'])
-
-        with open('tmp_test_folder/traj_alljson.json') as js:
-            json_dict = json.load(js)
-
-        self.assertEquals(json_dict['cpu_time'], .5)
-        self.assertEquals(json_dict['cost'], 0.9)
-        self.assertEquals(len(json_dict['incumbent']), 3)
-        self.assertTrue(json_dict["incumbent"]["param_a"] == 0.5)
-
-        # And finally, test the list that's added to the trajectory class
-        self.assertEqual(tl.trajectory[0], TrajEntry(0.9, 1,
-                                            {'param_c': 'value', 'param_b': 1,
-                                             'param_a': 0.5}, 1, 0.5, 1))
-        # Test named-tuple-access:
-        self.assertEqual(tl.trajectory[0].train_perf, 0.9)
-        self.assertEqual(tl.trajectory[0].incumbent_id, 1)
-        self.assertEqual(tl.trajectory[0].ta_runs, 1)
-        self.assertEqual(tl.trajectory[0].ta_time_used, 0.5)
-        self.assertEqual(tl.trajectory[0].wallclock_time, 1)
-        self.assertEqual(len(tl.trajectory), 1)
-
-    @patch('smac.stats.stats.Stats')
-    def test_add_multiple_entries(self, mock_stats):
-        tl = TrajLogger(output_dir='./tmp_test_folder', stats=mock_stats)
-
-        test_config = {'param_a': 0.5,
-                       'param_b': 1,
-                       'param_c': 'value'}
-        mock_stats.ta_time_used = 0.5
-        mock_stats.get_used_wallclock_time = self.mocked_get_used_wallclock_time
-        mock_stats.ta_runs = 1
-        tl.add_entry(0.9, 1, test_config)
-
-        mock_stats.ta_runs = 2
-        mock_stats.ta_time_used = 0
-        tl.add_entry(1.3, 1, test_config)
-
-        test_config['param_a'] = 0.
-        mock_stats.ta_time_used = 0
-        tl.add_entry(0.7, 2, test_config)
-
-        self.assertTrue(os.path.exists('tmp_test_folder/traj_old.csv'))
-        self.assertTrue(os.path.exists('tmp_test_folder/traj_aclib2.json'))
-        self.assertTrue(os.path.exists('tmp_test_folder/traj_alljson.json'))
-
-        with open('tmp_test_folder/traj_old.csv') as to:
-            data = to.read().split('\n')[:-1]
-
+        # Check old format
         header = data[0].split(',')
         self.assertEquals(header[0], '"CPU Time Used"')
         self.assertEquals(header[-1], '"Configuration..."')
@@ -144,102 +108,50 @@ class TrajLoggerTest(unittest.TestCase):
         frmt_str = '%1.6f'
         self.assertEquals(frmt_str % 0.5, data[0][0])
         self.assertEquals(frmt_str % 0.9, data[0][1])
-        self.assertEquals(frmt_str % 0.5, data[0][-4])
+        self.assertEquals(frmt_str % 0.5, data[0][-5])
 
         self.assertEquals(frmt_str % 0, data[1][0])
         self.assertEquals(frmt_str % 1.3, data[1][1])
-        self.assertEquals(frmt_str % 2, data[1][-4])
+        self.assertEquals(frmt_str % 2, data[1][-5])
 
         self.assertEquals(frmt_str % 0, data[2][0])
         self.assertEquals(frmt_str % .7, data[2][1])
-        self.assertEquals(frmt_str % 3, data[2][-4])
+        self.assertEquals(frmt_str % 3, data[2][-5])
 
-        json_dicts = []
-        with open('tmp_test_folder/traj_aclib2.json') as js:
-            data = js.read().split('\n')[:-1]
+        # Check aclib2-format
+        self.assertEquals(json_dicts_aclib2[0]['cpu_time'], .5)
+        self.assertEquals(json_dicts_aclib2[0]['cost'], 0.9)
+        self.assertEquals(len(json_dicts_aclib2[0]['incumbent']), 4)
+        self.assertTrue("param_a='0.5'" in json_dicts_aclib2[0]['incumbent'])
+        self.assertTrue("param_a='0.0'" in json_dicts_aclib2[2]['incumbent'])
 
-        for d in data:
-            json_dicts.append(json.loads(d))
-
-        self.assertEquals(json_dicts[0]['cpu_time'], .5)
-        self.assertEquals(json_dicts[0]['cost'], 0.9)
-        self.assertEquals(len(json_dicts[0]['incumbent']), 3)
-        self.assertTrue("param_a='0.5'" in json_dicts[0]['incumbent'])
-
-        with open('tmp_test_folder/traj_alljson.json') as js:
-            data = js.read().split('\n')[:-1]
-        json_dicts = [json.loads(d) for d in data]
-
-        self.assertEquals(json_dicts[0]['cpu_time'], .5)
-        self.assertEquals(json_dicts[0]['cost'], 0.9)
-        self.assertEquals(len(json_dicts[0]['incumbent']), 3)
-        self.assertTrue(json_dicts[0]["incumbent"]["param_a"] == 0.5)
+        # Check alljson-format
+        self.assertEquals(json_dicts_alljson[0]['cpu_time'], .5)
+        self.assertEquals(json_dicts_alljson[0]['cost'], 0.9)
+        self.assertEquals(len(json_dicts_alljson[0]['incumbent']), 4)
+        self.assertTrue(json_dicts_alljson[0]["incumbent"]["param_a"] == 0.5)
+        self.assertTrue(json_dicts_alljson[2]["incumbent"]["param_a"] == 0.0)
 
     @patch('smac.stats.stats.Stats')
     def test_ambigious_categoricals(self, mock_stats):
-        tl = TrajLogger(output_dir='./tmp_test_folder', stats=mock_stats)
-
-        cs = ConfigurationSpace()
-        cs.add_hyperparameters([
-            # Adding another value to the choices with "True", for example, would break the interpretation with aclib2
-            CategoricalHyperparameter('ambigous_categorical', choices=[3, 7.2, True, 0, 'random_string']),
-            Constant('ambigous_constant', value='False')
-        ])
         mock_stats.ta_time_used = 0.5
         mock_stats.get_used_wallclock_time = self.mocked_get_used_wallclock_time
         mock_stats.ta_runs = 1
-        tl.add_entry(0.9, 1, Configuration(cs, {'ambigous_categorical': True,
-                                                'ambigous_constant': 'False'}))
 
-        mock_stats.ta_runs = 2
-        mock_stats.ta_time_used = 0
-        tl.add_entry(1.3, 1, Configuration(cs, {'ambigous_categorical': True,
-                                                'ambigous_constant': 'False'}))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tl = TrajLogger(output_dir=tmpdir, stats=mock_stats)
 
-        mock_stats.ta_time_used = 0
-        tl.add_entry(0.7, 2, Configuration(cs, {'ambigous_categorical': 7.2,
-                                                'ambigous_constant': 'False'}))
+            problem_config = Configuration(self.cs, {'param_a': 0.0, 'param_b': 2, 'param_c': 'value',
+                                                     'ambigous_categorical': True})  # not recoverable without json
+            tl.add_entry(0.9, 1, problem_config)
 
-        self.assertTrue(os.path.exists('tmp_test_folder/traj_aclib2.json'))
-        self.assertTrue(os.path.exists('tmp_test_folder/traj_alljson.json'))
-
-        from_aclib2 = tl.read_traj_aclib_format('tmp_test_folder/traj_aclib2.json', cs)
-        from_alljson = tl.read_traj_alljson_format('tmp_test_folder/traj_alljson.json', cs)
-
-        for reloaded in [from_aclib2, from_alljson]:
-            self.assertIsInstance(reloaded[0]['incumbent']['ambigous_categorical'], bool)
-            self.assertIsInstance(reloaded[-1]['incumbent']['ambigous_categorical'], float)
-            self.assertIsInstance(reloaded[0]['incumbent']['ambigous_constant'], str)
-            self.assertIsInstance(reloaded[-1]['incumbent']['ambigous_constant'], str)
-
-        # An example breaking for aclib2 (unfixable) but working with alljson
-        bad_cs = ConfigurationSpace()
-        bad_cs.add_hyperparameters([
-            CategoricalHyperparameter('ambigous_categorical', choices=[3, 7.2, True, "True", 0, 'random_string']),
-            Constant('ambigous_constant', value='False')
-        ])
-
-        from_aclib2 = tl.read_traj_aclib_format('tmp_test_folder/traj_aclib2.json', bad_cs)
-        from_alljson = tl.read_traj_alljson_format('tmp_test_folder/traj_alljson.json', bad_cs)
+            from_aclib2 = tl.read_traj_aclib_format(os.path.join(tmpdir, 'traj_aclib2.json'), self.cs)
+            from_alljson = tl.read_traj_alljson_format(os.path.join(tmpdir, 'traj.json'), self.cs)
 
         # Wrong! but passes:
         self.assertIsInstance(from_aclib2[0]['incumbent']['ambigous_categorical'], str)
-
-        # Works for alljson:
+        # Works good for alljson:
         self.assertIsInstance(from_alljson[0]['incumbent']['ambigous_categorical'], bool)
-        self.assertIsInstance(from_alljson[-1]['incumbent']['ambigous_categorical'], float)
-        self.assertIsInstance(from_alljson[0]['incumbent']['ambigous_constant'], str)
-        self.assertIsInstance(from_alljson[-1]['incumbent']['ambigous_constant'], str)
-
-    def tearDown(self):
-        if os.path.exists('tmp_test_folder/traj_old.csv'):
-            os.remove('tmp_test_folder/traj_old.csv')
-        if os.path.exists('tmp_test_folder/traj_aclib2.json'):
-            os.remove('tmp_test_folder/traj_aclib2.json')
-        if os.path.exists('tmp_test_folder/traj_alljson.json'):
-            os.remove('tmp_test_folder/traj_alljson.json')
-        if os.path.exists('tmp_test_folder'):
-            os.rmdir('tmp_test_folder')
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -66,6 +66,7 @@ class TrajLoggerTest(unittest.TestCase):
 
         self.assertTrue(os.path.exists('tmp_test_folder/traj_old.csv'))
         self.assertTrue(os.path.exists('tmp_test_folder/traj_aclib2.json'))
+        self.assertTrue(os.path.exists('tmp_test_folder/traj_alljson.json'))
 
         with open('tmp_test_folder/traj_old.csv') as to:
             data = to.read().split('\n')[:-1]
@@ -87,6 +88,14 @@ class TrajLoggerTest(unittest.TestCase):
         self.assertEquals(json_dict['cost'], 0.9)
         self.assertEquals(len(json_dict['incumbent']), 3)
         self.assertTrue("param_a='0.5'" in json_dict['incumbent'])
+
+        with open('tmp_test_folder/traj_alljson.json') as js:
+            json_dict = json.load(js)
+
+        self.assertEquals(json_dict['cpu_time'], .5)
+        self.assertEquals(json_dict['cost'], 0.9)
+        self.assertEquals(len(json_dict['incumbent']), 3)
+        self.assertTrue(json_dict["incumbent"]["param_a"] == 0.5)
 
         # And finally, test the list that's added to the trajectory class
         self.assertEqual(tl.trajectory[0], TrajEntry(0.9, 1,
@@ -122,6 +131,7 @@ class TrajLoggerTest(unittest.TestCase):
 
         self.assertTrue(os.path.exists('tmp_test_folder/traj_old.csv'))
         self.assertTrue(os.path.exists('tmp_test_folder/traj_aclib2.json'))
+        self.assertTrue(os.path.exists('tmp_test_folder/traj_alljson.json'))
 
         with open('tmp_test_folder/traj_old.csv') as to:
             data = to.read().split('\n')[:-1]
@@ -156,11 +166,23 @@ class TrajLoggerTest(unittest.TestCase):
         self.assertEquals(len(json_dicts[0]['incumbent']), 3)
         self.assertTrue("param_a='0.5'" in json_dicts[0]['incumbent'])
 
+        with open('tmp_test_folder/traj_alljson.json') as js:
+            data = js.read().split('\n')[:-1]
+
+        json_dicts = [json.loads(d) for d in data]
+
+        self.assertEquals(json_dicts[0]['cpu_time'], .5)
+        self.assertEquals(json_dicts[0]['cost'], 0.9)
+        self.assertEquals(len(json_dicts[0]['incumbent']), 3)
+        self.assertTrue(json_dicts[0]["incumbent"]["param_a"] == 0.5)
+
     def tearDown(self):
         if os.path.exists('tmp_test_folder/traj_old.csv'):
             os.remove('tmp_test_folder/traj_old.csv')
         if os.path.exists('tmp_test_folder/traj_aclib2.json'):
             os.remove('tmp_test_folder/traj_aclib2.json')
+        if os.path.exists('tmp_test_folder/traj_alljson.json'):
+            os.remove('tmp_test_folder/traj_alljson.json')
         if os.path.exists('tmp_test_folder'):
             os.rmdir('tmp_test_folder')
 

--- a/test/test_utils/io/test_traj_logging.py
+++ b/test/test_utils/io/test_traj_logging.py
@@ -188,17 +188,17 @@ class TrajLoggerTest(unittest.TestCase):
         mock_stats.ta_time_used = 0.5
         mock_stats.get_used_wallclock_time = self.mocked_get_used_wallclock_time
         mock_stats.ta_runs = 1
-        tl.add_entry(0.9, 1, Configuration(cs, {'ambigous_categorical' : True,
-                                                'ambigous_constant' : 'False'}))
+        tl.add_entry(0.9, 1, Configuration(cs, {'ambigous_categorical': True,
+                                                'ambigous_constant': 'False'}))
 
         mock_stats.ta_runs = 2
         mock_stats.ta_time_used = 0
-        tl.add_entry(1.3, 1, Configuration(cs, {'ambigous_categorical' : True,
-                                                'ambigous_constant' : 'False'}))
+        tl.add_entry(1.3, 1, Configuration(cs, {'ambigous_categorical': True,
+                                                'ambigous_constant': 'False'}))
 
         mock_stats.ta_time_used = 0
-        tl.add_entry(0.7, 2, Configuration(cs, {'ambigous_categorical' : 7.2,
-                                                'ambigous_constant' : 'False'}))
+        tl.add_entry(0.7, 2, Configuration(cs, {'ambigous_categorical': 7.2,
+                                                'ambigous_constant': 'False'}))
 
         self.assertTrue(os.path.exists('tmp_test_folder/traj_aclib2.json'))
         self.assertTrue(os.path.exists('tmp_test_folder/traj_alljson.json'))
@@ -225,6 +225,7 @@ class TrajLoggerTest(unittest.TestCase):
         # Wrong! but passes:
         self.assertIsInstance(from_aclib2[0]['incumbent']['ambigous_categorical'], str)
 
+        # Works for alljson:
         self.assertIsInstance(from_alljson[0]['incumbent']['ambigous_categorical'], bool)
         self.assertIsInstance(from_alljson[-1]['incumbent']['ambigous_categorical'], float)
         self.assertIsInstance(from_alljson[0]['incumbent']['ambigous_constant'], str)


### PR DESCRIPTION
Fix #488 by introducing `alljson` format for trajectory read and write.
Also, add interpretation of non-string categorical values in hyperparameters, such as `CategoricalHyperparameter` with `choices = [1, False, 'random_string]` to address issues such as https://github.com/automl/ParameterImportance/issues/107.