### PR TITLE
Pass more data to the acquisition function

### DIFF
--- a/smac/optimizer/acquisition.py
+++ b/smac/optimizer/acquisition.py
@@ -40,21 +40,21 @@ class AbstractAcquisitionFunction(object, metaclass=abc.ABCMeta):
         self.logger = PickableLoggerAdapter(self.__module__ + "." + self.__class__.__name__)
 
     def update(self, **kwargs):
-        """Update the acquisition functions values.
+        """Update the acquisition function attributes required for calculation.
 
-        This method will be called if the model is updated. E.g.
-        entropy search uses it to update its approximation of P(x=x_min),
-        EI uses it to update the current fmin.
+        This method will be called after fitting the model, but before maximizing the acquisition
+        function. As an examples, EI uses it to update the current fmin.
 
-        The default implementation takes all keyword arguments and sets the
-        respective attributes for the acquisition function object.
+        The default implementation only updates the attributes of the acqusition function which
+        are already present.
 
         Parameters
         ----------
         kwargs
         """
         for key in kwargs:
-            setattr(self, key, kwargs[key])
+            if hasattr(self, key):
+                setattr(self, key, kwargs[key])
 
     def __call__(self, configurations: List[Configuration]):
         """Computes the acquisition value for a given X
@@ -484,7 +484,6 @@ class LCB(AbstractAcquisitionFunction):
         super(LCB, self).__init__(model)
         self.long_name = 'Lower Confidence Bound'
         self.par = par
-        self.eta = None  # to be compatible with the existing update calls in SMBO
         self.num_data = None
 
     def _compute(self, X: np.ndarray):

--- a/smac/optimizer/acquisition.py
+++ b/smac/optimizer/acquisition.py
@@ -37,6 +37,7 @@ class AbstractAcquisitionFunction(object, metaclass=abc.ABCMeta):
             Models the objective function.
         """
         self.model = model
+        self._required_updates = ('model', )
         self.logger = PickableLoggerAdapter(self.__module__ + "." + self.__class__.__name__)
 
     def update(self, **kwargs):
@@ -52,8 +53,16 @@ class AbstractAcquisitionFunction(object, metaclass=abc.ABCMeta):
         ----------
         kwargs
         """
+        for key in self._required_updates:
+            print(key, key not in kwargs, kwargs.keys())
+            if key not in kwargs:
+                raise ValueError(
+                    'Acquisition function %s needs to be updated with key %s, but only got '
+                    'keys %s.'
+                    % (self.__class__.__name__, key, list(kwargs.keys()))
+                )
         for key in kwargs:
-            if hasattr(self, key):
+            if key in self._required_updates:
                 setattr(self, key, kwargs[key])
 
     def __call__(self, configurations: List[Configuration]):
@@ -199,6 +208,7 @@ class EI(AbstractAcquisitionFunction):
         self.long_name = 'Expected Improvement'
         self.par = par
         self.eta = None
+        self._required_updates = ('model', 'eta')
 
     def _compute(self, X: np.ndarray, **kwargs):
         """Computes the EI value and its derivatives.
@@ -355,6 +365,7 @@ class LogEI(AbstractAcquisitionFunction):
         self.long_name = 'Expected Improvement'
         self.par = par
         self.eta = None
+        self._required_updates = ('model', 'eta')
 
     def _compute(self, X: np.ndarray, **kwargs):
         """Computes the EI value and its derivatives.
@@ -434,6 +445,7 @@ class PI(AbstractAcquisitionFunction):
         self.long_name = 'Probability of Improvement'
         self.par = par
         self.eta = None
+        self._required_updates = ('model', 'eta')
 
     def _compute(self, X: np.ndarray):
         """Computes the PI value.
@@ -485,6 +497,7 @@ class LCB(AbstractAcquisitionFunction):
         self.long_name = 'Lower Confidence Bound'
         self.par = par
         self.num_data = None
+        self._required_updates = ('model', 'num_data')
 
     def _compute(self, X: np.ndarray):
         """Computes the LCB value.

--- a/smac/optimizer/acquisition.py
+++ b/smac/optimizer/acquisition.py
@@ -54,7 +54,6 @@ class AbstractAcquisitionFunction(object, metaclass=abc.ABCMeta):
         kwargs
         """
         for key in self._required_updates:
-            print(key, key not in kwargs, kwargs.keys())
             if key not in kwargs:
                 raise ValueError(
                     'Acquisition function %s needs to be updated with key %s, but only got '

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -269,7 +269,7 @@ class SMBO(object):
             if self.runhistory.empty():
                 raise ValueError("Runhistory is empty and the cost value of "
                                  "the incumbent is unknown.")
-            incumbent, incumbent_array, incumbent_value = self._get_incumbent_value()
+            incumbent, incumbent_array, incumbent_value = self._get_incumbent()
         else:
             incumbent = None
             incumbent_array = None
@@ -291,7 +291,7 @@ class SMBO(object):
         )
         return challengers
 
-    def _get_incumbent_value(self) -> typing.Tuple[float, np.ndarray, Configuration]:
+    def _get_incumbent(self) -> typing.Tuple[float, np.ndarray, Configuration]:
         '''Get incumbent value, configuration, and array representation.
 
         This is retreived either from the runhistory or from best predicted

--- a/test/test_smbo/test_acquisition.py
+++ b/test/test_smbo/test_acquisition.py
@@ -3,7 +3,15 @@ import unittest.mock
 
 import numpy as np
 
-from smac.optimizer.acquisition import EI, LogEI, EIPS, PI, LCB, IntegratedAcquisitionFunction
+from smac.optimizer.acquisition import (
+    EI,
+    LogEI,
+    EIPS,
+    PI,
+    LCB,
+    IntegratedAcquisitionFunction,
+    AbstractAcquisitionFunction,
+)
 
 
 class ConfigurationMock(object):
@@ -37,6 +45,22 @@ class MockModelDual(object):
                         self.num_targets).reshape((-1, 2)), \
                np.array([np.mean(X, axis=1).reshape((1, -1))] *
                         self.num_targets).reshape((-1, 2))
+
+
+class TestAcquisitionFunction(unittest.TestCase):
+    def setUp(self):
+        self.model = unittest.mock.Mock()
+        self.acq = AbstractAcquisitionFunction(model=self.model)
+
+    def update_model(self):
+        model = 'abc'
+        self.acq.update({'model': model})
+        self.assertEqual(self.acq.model, model)
+
+    def update_other(self):
+        self.acq.other = 'other'
+        self.acq.update({'other': None})
+        self.assertIsNone(self.acq.other)
 
 
 class TestIntegratedAcquisitionFunction(unittest.TestCase):

--- a/test/test_smbo/test_acquisition.py
+++ b/test/test_smbo/test_acquisition.py
@@ -10,7 +10,6 @@ from smac.optimizer.acquisition import (
     PI,
     LCB,
     IntegratedAcquisitionFunction,
-    AbstractAcquisitionFunction,
 )
 
 
@@ -64,8 +63,8 @@ class TestAcquisitionFunction(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "Acquisition function EI needs to be updated with key model, but only got keys "
-            "\['other'\].",
+            r"Acquisition function EI needs to be updated with key model, but only got keys "
+            r"\['other'\].",
         ):
             self.acq.update(other=None)
 
@@ -209,7 +208,8 @@ class TestEIPS(unittest.TestCase):
     def test_fail(self):
         with self.assertRaises(ValueError):
             configurations = [ConfigurationMock([1.0, 1.0])]
-            acq = self.ei(configurations)
+            self.ei(configurations)
+
 
 class TestLogEI(unittest.TestCase):
     def setUp(self):

--- a/test/test_smbo/test_acquisition.py
+++ b/test/test_smbo/test_acquisition.py
@@ -50,17 +50,28 @@ class MockModelDual(object):
 class TestAcquisitionFunction(unittest.TestCase):
     def setUp(self):
         self.model = unittest.mock.Mock()
-        self.acq = AbstractAcquisitionFunction(model=self.model)
+        self.acq = EI(model=self.model)
 
-    def update_model(self):
+    def test_update_model_and_eta(self):
         model = 'abc'
-        self.acq.update({'model': model})
+        self.assertIsNone(self.acq.eta)
+        self.acq.update(model=model, eta=0.1)
         self.assertEqual(self.acq.model, model)
+        self.assertEqual(self.acq.eta, 0.1)
 
-    def update_other(self):
+    def test_update_other(self):
         self.acq.other = 'other'
-        self.acq.update({'other': None})
-        self.assertIsNone(self.acq.other)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Acquisition function EI needs to be updated with key model, but only got keys "
+            "\['other'\].",
+        ):
+            self.acq.update(other=None)
+
+        model = 'abc'
+        self.acq.update(model=model, eta=0.1, other=None)
+        self.assertEqual(self.acq.other, 'other')
 
 
 class TestIntegratedAcquisitionFunction(unittest.TestCase):


### PR DESCRIPTION
Changes SMAC to:

* only update the acquisition function with attributes that are already present. This allows to update the acquisition function with costly arguments such as `X`, the whole training data, without the fear of it being stored in an ordinary acquisition function.
* Pass `X`, the incumbent configuration and the incumbent configuration in array format to the acquisition function.
* More unit tests for the acquisition function.

Reason:

This allows to implement acquisition functions which needs to know not only the incumbent value, but also the incumbent configuration, or even all data which was already evaluated.