### PR TITLE
Add acquisition function optimizer args to ROAR facade

### DIFF
--- a/smac/facade/roar_facade.py
+++ b/smac/facade/roar_facade.py
@@ -8,7 +8,7 @@ from smac.epm.random_epm import RandomEPM
 from smac.facade.smac_ac_facade import SMAC4AC
 from smac.initial_design.initial_design import InitialDesign
 from smac.intensification.abstract_racer import AbstractRacer
-from smac.optimizer.ei_optimization import RandomSearch
+from smac.optimizer.ei_optimization import RandomSearch, AcquisitionFunctionMaximizer
 from smac.runhistory.runhistory import RunHistory
 from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost
 from smac.stats.stats import Stats
@@ -41,6 +41,8 @@ class ROAR(SMAC4AC):
                  ] = None,
                  runhistory: RunHistory = None,
                  intensifier: AbstractRacer = None,
+                 acquisition_function_optimizer: typing.Optional[typing.Type[AcquisitionFunctionMaximizer]] = None,
+                 acquisition_function_optimizer_kwargs: typing.Optional[dict] = None,
                  initial_design: typing.Optional[typing.Type[InitialDesign]] = None,
                  initial_design_kwargs: typing.Optional[dict] = None,
                  initial_configurations: typing.List[Configuration] = None,
@@ -65,6 +67,12 @@ class ROAR(SMAC4AC):
             Runhistory to store all algorithm runs
         intensifier: AbstractRacer
             intensification object to issue a racing to decide the current incumbent
+        acquisition_function_optimizer : ~smac.optimizer.ei_optimization.AcquisitionFunctionMaximizer
+            Object that implements the :class:`~smac.optimizer.ei_optimization.AcquisitionFunctionMaximizer`.
+            Will use :class:`smac.optimizer.ei_optimization.RandomSearch` if not set. Can be used
+            to perform random search over a fixed set of configurations.
+        acquisition_function_optimizer_kwargs: Optional[dict]
+            Arguments passed to constructor of '~acquisition_function_optimizer'
         initial_design : InitialDesign
             initial sampling design
         initial_design_kwargs: Optional[dict]
@@ -84,6 +92,9 @@ class ROAR(SMAC4AC):
 
         scenario.acq_opt_challengers = 1
 
+        if acquisition_function_optimizer is None:
+            acquisition_function_optimizer = RandomSearch
+
         # use SMAC facade
         super().__init__(
             scenario=scenario,
@@ -95,7 +106,8 @@ class ROAR(SMAC4AC):
             initial_design_kwargs=initial_design_kwargs,
             initial_configurations=initial_configurations,
             run_id=run_id,
-            acquisition_function_optimizer=RandomSearch,
+            acquisition_function_optimizer=acquisition_function_optimizer,
+            acquisition_function_optimizer_kwargs=acquisition_function_optimizer_kwargs,
             model=RandomEPM,
             rng=rng,
             stats=stats


### PR DESCRIPTION
This allows me to pass the recent fixed set acquisition function optimizer (#558) to the ROAR facade.