### PR TITLE
Fix#513 - improve handling of sobol sequence for large search spaces

### DIFF
--- a/smac/facade/smac_bo_facade.py
+++ b/smac/facade/smac_bo_facade.py
@@ -53,20 +53,15 @@ class SMAC4BO(SMAC4AC):
         see ~smac.facade.smac_facade for documentation
         """
 
-        # The logger is only initialized on the call to super AFTER constructing all objects. In order to still log
-        # messages, we keep them in an array and fire them off later
-        log_messages = []
-
         scenario = kwargs['scenario']
 
         if len(scenario.cs.get_hyperparameters()) <= 40:
             kwargs['initial_design'] = kwargs.get('initial_design', SobolDesign)
         else:
-            kwargs['initial_design'] = kwargs.get('initial_design', LHDesign)
-            log_messages.append((
-                30,
-                'The Sobol initial design can only handle up to 40 dimensions. Changing to a Latin Hypercube design',
-            ))
+            raise ValueError(
+                'The default initial design "Sobol sequence" can only handle up to 40 dimensions. '
+                'Please use a different initial design, such as "the Latin Hypercube design".',
+            )
         kwargs['runhistory2epm'] = kwargs.get('runhistory2epm', RunHistory2EPM4Cost)
 
         init_kwargs = kwargs.get('initial_design_kwargs', dict()) or dict()
@@ -173,8 +168,6 @@ class SMAC4BO(SMAC4AC):
         scenario.intensification_percentage = 1e-10
 
         super().__init__(**kwargs)
-        for level, message in log_messages:
-            self.logger.log(level, message)
 
         if self.solver.scenario.n_features > 0:
             raise NotImplementedError("BOGP cannot handle instances")

--- a/smac/facade/smac_bo_facade.py
+++ b/smac/facade/smac_bo_facade.py
@@ -5,7 +5,6 @@ from smac.epm.gaussian_process_mcmc import GaussianProcessMCMC, GaussianProcess
 from smac.epm.gp_base_prior import HorseshoePrior, LognormalPrior
 from smac.epm.util_funcs import get_types, get_rng
 from smac.initial_design.sobol_design import SobolDesign
-from smac.initial_design.latin_hypercube_design import LHDesign
 from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost
 
 

--- a/smac/facade/smac_hpo_facade.py
+++ b/smac/facade/smac_hpo_facade.py
@@ -3,7 +3,6 @@ from smac.runhistory.runhistory2epm import RunHistory2EPM4LogScaledCost
 from smac.optimizer.acquisition import LogEI
 from smac.epm.rf_with_instances import RandomForestWithInstances
 from smac.initial_design.sobol_design import SobolDesign
-from smac.initial_design.latin_hypercube_design import LHDesign
 
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2018, ML4AAD"

--- a/smac/facade/smac_hpo_facade.py
+++ b/smac/facade/smac_hpo_facade.py
@@ -35,20 +35,15 @@ class SMAC4HPO(SMAC4AC):
         see ~smac.facade.smac_facade for docu
         """
 
-        # The logger is only initialized on the call to super AFTER constructing all objects. In order to still log
-        # messages, we keep them in an array and fire them off later
-        log_messages = []
-
         scenario = kwargs['scenario']
 
         if len(scenario.cs.get_hyperparameters()) <= 40:
            kwargs['initial_design'] = kwargs.get('initial_design', SobolDesign)
         else:
-           kwargs['initial_design'] = kwargs.get('initial_design', LHDesign)
-           log_messages.append((
-               30,
-               'The Sobol initial design can only handle up to 40 dimensions. Changing to a Latin Hypercube design',
-           ))
+           raise ValueError(
+               'The default initial design "Sobol sequence" can only handle up to 40 dimensions. '
+               'Please use a different initial design, such as "the Latin Hypercube design".',
+           )
         kwargs['runhistory2epm'] = kwargs.get('runhistory2epm', RunHistory2EPM4LogScaledCost)
 
         init_kwargs = kwargs.get('initial_design_kwargs', dict())
@@ -93,8 +88,6 @@ class SMAC4HPO(SMAC4AC):
 
         super().__init__(**kwargs)
         self.logger.info(self.__class__)
-        for level, message in log_messages:
-            self.logger.log(level, message)
 
         # better improve acquisition function optimization
         # 2. more randomly sampled configurations

--- a/smac/initial_design/initial_design.py
+++ b/smac/initial_design/initial_design.py
@@ -29,7 +29,7 @@ class InitialDesign:
                  cs: ConfigurationSpace,
                  rng: np.random.RandomState,
                  traj_logger: TrajLogger,
-                 ta_run_limit: float,
+                 ta_run_limit: int,
                  configs: typing.Optional[typing.List[Configuration]] = None,
                  n_configs_x_params: typing.Optional[int] = 10,
                  max_config_fracs: float = 0.25,

--- a/test/test_facade/test_smac4bo_facade.py
+++ b/test/test_facade/test_smac4bo_facade.py
@@ -21,5 +21,10 @@ class TestSMACFacade(unittest.TestCase):
         facade = SMAC4BO(scenario=scenario)
         self.assertIsInstance(facade.solver.initial_design, SobolDesign)
         cs.add_hyperparameter(UniformFloatHyperparameter('x41', 0, 1))
-        facade = SMAC4BO(scenario=scenario)
-        self.assertIsInstance(facade.solver.initial_design, LHDesign)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            'Sobol sequence" can only handle up to 40 dimensions. Please use a different initial design, such as '
+            '"the Latin Hypercube design"',
+        ):
+            SMAC4BO(scenario=scenario)

--- a/test/test_facade/test_smac4bo_facade.py
+++ b/test/test_facade/test_smac4bo_facade.py
@@ -6,7 +6,6 @@ from ConfigSpace.hyperparameters import UniformFloatHyperparameter
 from smac.configspace import ConfigurationSpace
 
 from smac.facade.smac_bo_facade import SMAC4BO
-from smac.initial_design.latin_hypercube_design import LHDesign
 from smac.initial_design.sobol_design import SobolDesign
 from smac.scenario.scenario import Scenario
 

--- a/test/test_facade/test_smac4bo_facade.py
+++ b/test/test_facade/test_smac4bo_facade.py
@@ -1,0 +1,25 @@
+import unittest
+import unittest.mock
+
+from ConfigSpace.hyperparameters import UniformFloatHyperparameter
+
+from smac.configspace import ConfigurationSpace
+
+from smac.facade.smac_bo_facade import SMAC4BO
+from smac.initial_design.latin_hypercube_design import LHDesign
+from smac.initial_design.sobol_design import SobolDesign
+from smac.scenario.scenario import Scenario
+
+
+class TestSMACFacade(unittest.TestCase):
+
+    def test_exchange_sobol_for_lhd(self):
+        cs = ConfigurationSpace()
+        for i in range(40):
+            cs.add_hyperparameter(UniformFloatHyperparameter('x%d' % (i + 1), 0, 1))
+        scenario = Scenario({'cs': cs, 'run_obj': 'quality'})
+        facade = SMAC4BO(scenario=scenario)
+        self.assertIsInstance(facade.solver.initial_design, SobolDesign)
+        cs.add_hyperparameter(UniformFloatHyperparameter('x41', 0, 1))
+        facade = SMAC4BO(scenario=scenario)
+        self.assertIsInstance(facade.solver.initial_design, LHDesign)

--- a/test/test_facade/test_smac4hpo_facade.py
+++ b/test/test_facade/test_smac4hpo_facade.py
@@ -21,5 +21,9 @@ class TestSMACFacade(unittest.TestCase):
         facade = SMAC4HPO(scenario=scenario)
         self.assertIsInstance(facade.solver.initial_design, SobolDesign)
         cs.add_hyperparameter(UniformFloatHyperparameter('x41', 0, 1))
-        facade = SMAC4HPO(scenario=scenario)
-        self.assertIsInstance(facade.solver.initial_design, LHDesign)
+        with self.assertRaisesRegex(
+                ValueError,
+                'Sobol sequence" can only handle up to 40 dimensions. Please use a different initial design, such as '
+                '"the Latin Hypercube design"',
+        ):
+            SMAC4HPO(scenario=scenario)

--- a/test/test_facade/test_smac4hpo_facade.py
+++ b/test/test_facade/test_smac4hpo_facade.py
@@ -6,7 +6,6 @@ from ConfigSpace.hyperparameters import UniformFloatHyperparameter
 from smac.configspace import ConfigurationSpace
 
 from smac.facade.smac_hpo_facade import SMAC4HPO
-from smac.initial_design.latin_hypercube_design import LHDesign
 from smac.initial_design.sobol_design import SobolDesign
 from smac.scenario.scenario import Scenario
 

--- a/test/test_facade/test_smac4hpo_facade.py
+++ b/test/test_facade/test_smac4hpo_facade.py
@@ -1,0 +1,25 @@
+import unittest
+import unittest.mock
+
+from ConfigSpace.hyperparameters import UniformFloatHyperparameter
+
+from smac.configspace import ConfigurationSpace
+
+from smac.facade.smac_hpo_facade import SMAC4HPO
+from smac.initial_design.latin_hypercube_design import LHDesign
+from smac.initial_design.sobol_design import SobolDesign
+from smac.scenario.scenario import Scenario
+
+
+class TestSMACFacade(unittest.TestCase):
+
+    def test_exchange_sobol_for_lhd(self):
+        cs = ConfigurationSpace()
+        for i in range(40):
+            cs.add_hyperparameter(UniformFloatHyperparameter('x%d' % (i + 1), 0, 1))
+        scenario = Scenario({'cs': cs, 'run_obj': 'quality'})
+        facade = SMAC4HPO(scenario=scenario)
+        self.assertIsInstance(facade.solver.initial_design, SobolDesign)
+        cs.add_hyperparameter(UniformFloatHyperparameter('x41', 0, 1))
+        facade = SMAC4HPO(scenario=scenario)
+        self.assertIsInstance(facade.solver.initial_design, LHDesign)

--- a/test/test_initial_design/test_sobol_design.py
+++ b/test/test_initial_design/test_sobol_design.py
@@ -1,0 +1,36 @@
+import unittest
+import unittest.mock
+
+import numpy as np
+from ConfigSpace import ConfigurationSpace, Configuration, UniformFloatHyperparameter
+
+from smac.initial_design.sobol_design import SobolDesign
+
+
+class TestSobol(unittest.TestCase):
+
+    def test_sobol(self):
+        cs = ConfigurationSpace()
+        for i in range(40):
+            cs.add_hyperparameter(UniformFloatHyperparameter('x%d' % (i + 1), 0, 1))
+
+        sobol_kwargs = dict(
+            rng=np.random.RandomState(1),
+            traj_logger=unittest.mock.Mock(),
+            ta_run_limit=1000,
+            configs=None,
+            n_configs_x_params=None,
+            max_config_fracs=0.25,
+            init_budget=1,
+        )
+        SobolDesign(
+            cs=cs,
+            **sobol_kwargs
+        ).select_configurations()
+
+        cs.add_hyperparameter(UniformFloatHyperparameter('x41', 0, 1))
+        with self.assertRaisesRegex(Exception, "'NoneType' object is not iterable"):
+            SobolDesign(
+                cs=cs,
+                **sobol_kwargs
+            ).select_configurations()


### PR DESCRIPTION
The Sobol Sequence implementation we're using fails with more than 40 dimensions. This PR adds

* a unit test for this
* a change to the SMAC4HPO facade to replace the sobol grid if there are too many hyperparameters.