### PR TITLE
first run crashed exception in smbo, warning in successive halving

### DIFF
--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -1,6 +1,5 @@
 import logging
 import typing
-import warnings
 
 import numpy as np
 
@@ -141,9 +140,9 @@ class SuccessiveHalving(AbstractRacer):
             else:
                 seeds = self.rs.randint(low=0, high=MAXINT, size=self.n_seeds)
                 if self.n_seeds == 1:
-                    warnings.warn('The target algorithm is specified to be non deterministic, '
-                                  'but number of seeds to evaluate are set to 1. '
-                                  'Consider setting `n_seeds` > 1.')
+                    self.logger.warn('The target algorithm is specified to be non deterministic, '
+                                     'but number of seeds to evaluate are set to 1. '
+                                     'Consider setting `n_seeds` > 1.')
 
             # storing instances & seeds as tuples
             self.inst_seed_pairs = [(i, s) for s in seeds for i in self.instances]

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+import warnings
 
 import numpy as np
 
@@ -139,6 +140,11 @@ class SuccessiveHalving(AbstractRacer):
                 seeds = [0]
             else:
                 seeds = self.rs.randint(low=0, high=MAXINT, size=self.n_seeds)
+                if self.n_seeds == 1:
+                    warnings.warn('The target algorithm is specified to be non deterministic, '
+                                  'but number of seeds to evaluate are set to 1. '
+                                  'Consider setting `n_seeds` > 1.')
+
             # storing instances & seeds as tuples
             self.inst_seed_pairs = [(i, s) for s in seeds for i in self.instances]
 

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -26,6 +26,7 @@ from smac.runhistory.runhistory import RunHistory
 from smac.runhistory.runhistory2epm import AbstractRunHistory2EPM
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
+from smac.tae.execute_ta_run import FirstRunCrashedException
 from smac.utils.io.traj_logging import TrajLogger
 from smac.utils.validate import Validator
 from smac.utils.constants import MAXINT
@@ -217,13 +218,17 @@ class SMBO(object):
                 # evaluate selected challenger
                 self.logger.debug("Intensify - evaluate challenger")
 
-                self.incumbent, inc_perf = self.intensifier.eval_challenger(
-                    challenger=challenger,
-                    incumbent=self.incumbent,
-                    run_history=self.runhistory,
-                    aggregate_func=self.aggregate_func,
-                    time_bound=max(self.intensifier._min_time, time_left))
+                try:
+                    self.incumbent, inc_perf = self.intensifier.eval_challenger(
+                        challenger=challenger,
+                        incumbent=self.incumbent,
+                        run_history=self.runhistory,
+                        aggregate_func=self.aggregate_func,
+                        time_bound=max(self.intensifier._min_time, time_left))
 
+                except FirstRunCrashedException:
+                    if self.scenario.abort_on_first_run_crash:
+                        raise
                 if self.scenario.shared_model:
                     pSMAC.write(run_history=self.runhistory,
                                 output_directory=self.scenario.output_dir_for_this_run,

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -83,20 +83,33 @@ class TestSMBO(unittest.TestCase):
             rng='BLA',
         )
 
-    @mock.patch.object(Intensifier, 'eval_challenger')
+    @mock.patch.object(InitialDesign, 'run')
     def test_abort_on_initial_design(self, patch):
         def target(x):
             return 5
+
+        # should raise an error if abort_on_first_run_crash is True
         patch.side_effect = FirstRunCrashedException()
         scen = Scenario({'cs': test_helpers.get_branin_config_space(),
                          'run_obj': 'quality', 'output_dir': 'data-test_smbo-abort',
-                         'abort_on_first_run_crash': 1})
+                         'abort_on_first_run_crash': True})
+        self.output_dirs.append(scen.output_dir)
+        smbo = SMAC4AC(scen, tae_runner=target, rng=1).solver
+        self.assertRaises(FirstRunCrashedException, smbo.run)
+
+        # should not raise an error if abort_on_first_run_crash is False
+        patch.side_effect = FirstRunCrashedException()
+        scen = Scenario({'cs': test_helpers.get_branin_config_space(),
+                         'run_obj': 'quality', 'output_dir': 'data-test_smbo-abort',
+                         'abort_on_first_run_crash': False, 'wallclock-limit': 1})
         self.output_dirs.append(scen.output_dir)
         smbo = SMAC4AC(scen, tae_runner=target, rng=1).solver
 
-        with self.assertRaises(FirstRunCrashedException):
+        try:
             smbo.start()
             smbo.run()
+        except FirstRunCrashedException:
+            self.fail('Raises FirstRunCrashedException unexpectedly!')
 
     @attr('slow')
     def test_intensification_percentage(self):

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -83,7 +83,7 @@ class TestSMBO(unittest.TestCase):
             rng='BLA',
         )
 
-    @mock.patch.object(InitialDesign, 'run')
+    @mock.patch.object(Intensifier, 'eval_challenger')
     def test_abort_on_initial_design(self, patch):
         def target(x):
             return 5


### PR DESCRIPTION
* Fixed `FirstRunCrashedException` not raising an error when `abort_on_first_crash=True`
* Warning when successive halving/hyperband is used for a non-deterministic algorithm but `n_seeds=1`