### PR TITLE
Encoding Error, Removing cutoff ceiling #449, #439: 

### DIFF
--- a/examples/spear_qcp/run.sh
+++ b/examples/spear_qcp/run.sh
@@ -1,1 +1,1 @@
-python3 ../../scripts/smac --scenario scenario.txt --verbose DEBUG
+python ../../scripts/smac --scenario scenario.txt --verbose DEBUG

--- a/examples/spear_qcp/run.sh
+++ b/examples/spear_qcp/run.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 python ../../scripts/smac --scenario scenario.txt --verbose DEBUG

--- a/examples/spear_qcp/scenario.txt
+++ b/examples/spear_qcp/scenario.txt
@@ -1,4 +1,4 @@
-algo = python3 -u ./target_algorithm/scripts/SATCSSCWrapper.py --mem-limit 1024 --script ./target_algorithm/spear-python/spearCSSCWrapper.py
+algo = python -u ./target_algorithm/scripts/SATCSSCWrapper.py --mem-limit 1024 --script ./target_algorithm/spear-python/spearCSSCWrapper.py
 paramfile = ./target_algorithm/spear-python/spear-params-mixed.pcs
 execdir = .
 deterministic = 0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('extras_require.json') as fh:
 
 def get_version():
     version_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "smac", "__init__.py")
-    for line in open(version_file):
+    for line in open(version_file, encoding='utf-8'):
         if line.startswith("__version__"):
             version = line.split("=")[1].strip().replace("'", "").replace('"', '')
             return version
@@ -22,7 +22,7 @@ def get_version():
 
 def get_author():
     version_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "smac", "__init__.py")
-    for line in open(version_file):
+    for line in open(version_file, encoding='utf-8'):
         if line.startswith("__author__"):
             version = line.split("=")[1].strip().replace("'", "").replace('"', '')
             return version

--- a/smac/tae/execute_func.py
+++ b/smac/tae/execute_func.py
@@ -134,15 +134,14 @@ class AbstractTAFunc(ExecuteTARun):
             obj_kwargs['budget'] = budget
 
         if self.use_pynisher:
-            # walltime for pynisher has to be a rounded up integer
             if cutoff is not None:
-                cutoff = int(math.ceil(cutoff))
                 if cutoff > MAX_CUTOFF:
                     raise ValueError("%d is outside the legal range of [0, 65535] "
                                      "for cutoff (when using pynisher, due to OS limitations)" % cutoff)
 
             arguments = {'logger': logging.getLogger("pynisher"),
-                         'wall_time_in_s': cutoff,
+                         # walltime for pynisher has to be a rounded up integer
+                         'wall_time_in_s': int(math.ceil(cutoff)),
                          'mem_in_mb': self.memory_limit}
 
             # call ta

--- a/smac/tae/execute_ta_run.py
+++ b/smac/tae/execute_ta_run.py
@@ -163,8 +163,6 @@ class ExecuteTARun(object):
                 "Skip target algorithm run due to exhausted "
                 "configuration budget")
 
-        if cutoff is not None:
-            cutoff = int(math.ceil(cutoff))
         if cutoff is None and self.run_obj == "runtime":
             self.logger.error("For scenarios optimizing running time "
                               "(run objective), a cutoff time is required, "


### PR DESCRIPTION
- fixes encoding errors with the authors' names
- converts docs from python3 to python
- ceils the cutoff time only if it is passed to the pynisher