### PR TITLE
Fix capping issue in successive halving

### DIFF
--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -362,11 +362,13 @@ class SuccessiveHalving(AbstractRacer):
             # adding challengers to the list of evaluated challengers
             #  - should not capped
             #  - should be successful in at least 1 run
+            # curr_challengers is a set, so "at least 1" success can be counted by set addition
+            # for each successful instance run for a challenger (no duplicates created)
             if np.isfinite(self.curr_inst_idx) and \
                     status == StatusType.SUCCESS:
                 self.curr_challengers.add(challenger)  # successful configs
             else:
-                self.fail_challengers.add(challenger)   # capped configs
+                self.fail_challengers.add(challenger)   # capped/crashed configs
 
             # get incumbent in the last stage if all instances have been evaluated
             if n_insts_remaining <= 0:

--- a/smac/tae/execute_func.py
+++ b/smac/tae/execute_func.py
@@ -50,7 +50,8 @@ class AbstractTAFunc(ExecuteTARun):
 
         super().__init__(ta=ta, stats=stats, runhistory=runhistory,
                          run_obj=run_obj, par_factor=par_factor,
-                         cost_for_crash=cost_for_crash)
+                         cost_for_crash=cost_for_crash,
+                         abort_on_first_run_crash=abort_on_first_run_crash)
         """
         Abstract class for having a function as target algorithm
 

--- a/test/test_intensify/test_successive_halving.py
+++ b/test/test_intensify/test_successive_halving.py
@@ -324,8 +324,9 @@ class TestSuccessiveHalving(unittest.TestCase):
            test eval_challenger with runtime objective and adaptive capping
         """
 
-        def target(x):
-            time.sleep(1.5)
+        def target(x: Configuration, instance: str):
+            if x['a'] == 100 or instance == 2:
+                time.sleep(1.5)
             return (x['a'] + 1) / 1000.
 
         taf = ExecuteTAFuncDict(ta=target, stats=self.stats, run_obj="runtime")
@@ -337,22 +338,36 @@ class TestSuccessiveHalving(unittest.TestCase):
             rng=np.random.RandomState(12345), deterministic=True, cutoff=1,
             instances=[1, 2], initial_budget=1, max_budget=2, eta=2, instance_order=None)
 
-        for i in range(2):
-            self.rh.add(config=self.config1, cost=.001, time=0.001,
-                        status=StatusType.SUCCESS, instance_id=i + 1, seed=0,
-                        additional_info=None)
+        intensifier._update_stage(run_history=self.rh)
 
-        intensifier._update_stage(run_history=None)
+        # config1 should be executed successfully and selected as incumbent
+        config, _ = intensifier.get_next_challenger(challengers=[self.config1], chooser=None, run_history=self.rh)
+        inc, _ = intensifier.eval_challenger(challenger=config,
+                                             incumbent=None,
+                                             run_history=self.rh, )
+        self.assertEqual(config, self.config1)
+        self.assertEqual(self.stats.ta_runs, 1)
+        self.assertEqual(self.stats.inc_changed, 1)
 
         # config2 should be capped and config1 should still be the incumbent
-        inc, _ = intensifier.eval_challenger(challenger=self.config2,
-                                             incumbent=self.config1,
+        config, _ = intensifier.get_next_challenger(challengers=[self.config2], chooser=None, run_history=self.rh)
+        inc, _ = intensifier.eval_challenger(challenger=config,
+                                             incumbent=inc,
                                              run_history=self.rh,)
 
         self.assertEqual(inc, self.config1)
-        self.assertEqual(self.stats.ta_runs, 1)
-        self.assertEqual(self.stats.inc_changed, 0)
-        self.assertEqual(list(self.rh.data.values())[2][2], StatusType.CAPPED)
+        self.assertEqual(self.stats.ta_runs, 2)
+        self.assertEqual(self.stats.inc_changed, 1)
+        self.assertEqual(list(self.rh.data.values())[1][2], StatusType.CAPPED)
+
+        # config1 is selected for the next stage and allowed to timeout since this is the 1st run for this instance
+        config, _ = intensifier.get_next_challenger(challengers=[], chooser=None, run_history=self.rh)
+        inc, _ = intensifier.eval_challenger(challenger=config,
+                                             incumbent=inc,
+                                             run_history=self.rh, )
+        self.assertEqual(inc, self.config1)
+        self.assertEqual(self.stats.ta_runs, 3)
+        self.assertEqual(list(self.rh.data.values())[2][2], StatusType.TIMEOUT)
 
     def test_eval_challenger_3(self):
         """


### PR DESCRIPTION
There was an issue with running adaptive capping with successive halving because capped configurations were being considered when selecting for the next stage. Now they are ignored.