### PR TITLE
Stricter checks for things added to runhistory

### DIFF
--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -195,6 +195,13 @@ class RunHistory(object):
                 Defines how data will be used.
         """
 
+        if config is None:
+            raise TypeError('Configuration to add to the runhistory must not be None')
+        elif not isinstance(config, Configuration):
+            raise TypeError(
+                'Configuration to add to the runhistory is not of type Configuration, but %s' % type(config)
+            )
+
         # Get the config id
         config_id_tmp = self.config_ids.get(config)
         if config_id_tmp is None:

--- a/test/test_runhistory/test_runhistory.py
+++ b/test/test_runhistory/test_runhistory.py
@@ -54,6 +54,18 @@ class RunhistoryTest(unittest.TestCase):
             loaded_rh = pickle.load(fh)
         self.assertEqual(loaded_rh.data, rh.data)
 
+    def test_illegal_input(self):
+        rh = RunHistory()
+
+        with self.assertRaisesRegex(TypeError, 'Configuration to add to the runhistory must not be None'):
+            rh.add(config=None, cost=1.23, time=2.34, status=StatusType.SUCCESS)
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "Configuration to add to the runhistory is not of type Configuration, but <class 'str'>",
+        ):
+            rh.add(config='abc', cost=1.23, time=2.34, status=StatusType.SUCCESS)
+
     def test_add_multiple_times(self):
         rh = RunHistory()
         cs = get_config_space()

--- a/test/test_utils/test_validate.py
+++ b/test/test_utils/test_validate.py
@@ -5,6 +5,7 @@ import shutil
 
 import numpy as np
 
+from smac.configspace import Configuration
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
 from smac.tae.execute_ta_run import StatusType
@@ -159,20 +160,19 @@ class ValidationTest(unittest.TestCase):
         validator = Validator(scen, self.trajectory, self.rng)
 
         # Get runhistory
-        old_configs = ['config1', 'config2', 'config3',
-                       'config4', 'config5', 'config6']
+        old_configs = [Configuration(scen.cs, values={'x1': i, 'x2': i}) for i in range(1, 7)]
         old_rh = RunHistory()
-        old_rh.add('config1', 1, 1, StatusType.SUCCESS, instance_id='0', seed=0)
-        old_rh.add('config2', 1, 1, StatusType.TIMEOUT, instance_id='0', seed=0)
-        old_rh.add('config3', 1, 1, StatusType.CRASHED, instance_id='0', seed=0)
-        old_rh.add('config4', 1, 1, StatusType.ABORT, instance_id='0', seed=0)
-        old_rh.add('config5', 1, 1, StatusType.MEMOUT, instance_id='0', seed=0)
-        old_rh.add('config6', 1, 1, StatusType.CAPPED, instance_id='0', seed=0)
+        old_rh.add(old_configs[0], 1, 1, StatusType.SUCCESS, instance_id='0', seed=0)
+        old_rh.add(old_configs[1], 1, 1, StatusType.TIMEOUT, instance_id='0', seed=0)
+        old_rh.add(old_configs[2], 1, 1, StatusType.CRASHED, instance_id='0', seed=0)
+        old_rh.add(old_configs[3], 1, 1, StatusType.ABORT, instance_id='0', seed=0)
+        old_rh.add(old_configs[4], 1, 1, StatusType.MEMOUT, instance_id='0', seed=0)
+        old_rh.add(old_configs[5], 1, 1, StatusType.CAPPED, instance_id='0', seed=0)
 
         # Get multiple configs
-        expected = [_Run(inst_specs='0', seed=0, inst='0', config='config3'),
-                    _Run(inst_specs='0', seed=0, inst='0', config='config4'),
-                    _Run(inst_specs='0', seed=0, inst='0', config='config6')]
+        expected = [_Run(inst_specs='0', seed=0, inst='0', config=old_configs[2]),
+                    _Run(inst_specs='0', seed=0, inst='0', config=old_configs[3]),
+                    _Run(inst_specs='0', seed=0, inst='0', config=old_configs[5])]
 
         runs = validator._get_runs(old_configs, ['0'], repetitions=1, runhistory=old_rh)
         self.assertEqual(runs[0], expected)


### PR DESCRIPTION
I recently faced a weird bug where the configurations in the runhistory are `None`, but which I can't easily debug. This PR will prevent adding `None` to the runhistory and will help me debugging this issue if the bug pops up again.