### PR TITLE
revert intensification behaviour for first configuration

### DIFF
--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -183,9 +183,15 @@ class Intensifier(AbstractRacer):
             return incumbent, inc_perf
 
         # if first ever run, then assume current challenger to be the incumbent
-        if self.stage == IntensifierStage.RUN_FIRST_CONFIG and not incumbent:
-            self.logger.info("First run, no incumbent provided; challenger is assumed to be the incumbent")
-            incumbent = challenger
+        if self.stage == IntensifierStage.RUN_FIRST_CONFIG:
+            if incumbent is None:
+                self.logger.info("First run, no incumbent provided; challenger is assumed to be the incumbent")
+                incumbent = challenger
+            else:
+                inc_runs = run_history.get_runs_for_config(incumbent, only_max_observed_budget=True)
+                if len(inc_runs) > 0:
+                    self.logger.debug("Skipping RUN_FIRST_CONFIG stage since incumbent is already run before")
+                    self.stage = IntensifierStage.RUN_INCUMBENT
 
         self.logger.debug("Intensify on %s", challenger)
         if hasattr(challenger, 'origin'):

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -600,4 +600,3 @@ class TestIntensify(unittest.TestCase):
 
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(len(self.rh.get_runs_for_config(self.config1, only_max_observed_budget=True)), 2)
-

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -421,6 +421,8 @@ class TestIntensify(unittest.TestCase):
         # regular intensification begins - run incumbent first
         config, _ = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
                                                     chooser=None)
+        self.assertEqual(config, inc)
+        self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
         inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
         self.assertEqual(self.stats.ta_runs, 2)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
@@ -519,6 +521,7 @@ class TestIntensify(unittest.TestCase):
         # regular intensification begins - run incumbent
         config, _ = intensifier.get_next_challenger(challengers=None,  # since incumbent is run, no configs required
                                                     chooser=None)
+        self.assertEqual(config, inc)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
         inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
 


### PR DESCRIPTION
Intensification now evaluates the 1st incumbent twice, just like previous versions of SMAC