### PR TITLE
fix bug in adaptive capping of successive halving

### DIFF
--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -185,6 +185,7 @@ class SuccessiveHalving(AbstractRacer):
         self.running_challenger = None
         self.curr_challengers = set()  # type: typing.Set[Configuration]
         self.fail_challengers = set()  # type: typing.Set[Configuration]
+        self.fail_chal_offset = 0
 
     def _init_sh_params(self,
                         initial_budget: typing.Optional[float],
@@ -369,7 +370,7 @@ class SuccessiveHalving(AbstractRacer):
                     status == StatusType.SUCCESS:
                 self.curr_challengers.add(challenger)  # successful configs
             else:
-                self.fail_challengers.add(challenger)   # capped/crashed configs
+                self.fail_challengers.add(challenger)  # capped/crashed configs
 
             # get incumbent in the last stage if all instances have been evaluated
             if n_insts_remaining <= 0:
@@ -383,7 +384,7 @@ class SuccessiveHalving(AbstractRacer):
                               "Interrupting optimization run and returning current incumbent")
 
         # if all configurations for the current stage have been evaluated, reset stage
-        num_chal_evaluated = len(self.curr_challengers.union(self.fail_challengers))
+        num_chal_evaluated = len(self.curr_challengers.union(self.fail_challengers)) + self.fail_chal_offset
         if num_chal_evaluated == self.n_configs_in_stage[self.stage] and n_insts_remaining <= 0:
 
             self.logger.info('Successive Halving iteration-step: %d-%d with '
@@ -497,6 +498,7 @@ class SuccessiveHalving(AbstractRacer):
             self.running_challenger = None
             self.curr_challengers = set()  # successful configs
             self.fail_challengers = set()   # capped configs
+            self.fail_chal_offset = 0
 
         else:
             self.stage += 1
@@ -516,9 +518,9 @@ class SuccessiveHalving(AbstractRacer):
                 # to handle that, we keep some failed configurations (since they are technically failed here too)
                 missing_challengers = int(self.n_configs_in_stage[self.stage]) - len(self.configs_to_run)
                 if missing_challengers > 0:
-                    self.fail_challengers = set(list(self.fail_challengers)[:missing_challengers])
+                    self.fail_chal_offset = missing_challengers
                 else:
-                    self.fail_challengers = set()
+                    self.fail_chal_offset = 0
             else:
                 # update stats for the prev iteration
                 self.stats.update_average_configs_per_intensify(n_configs=self._chall_indx)
@@ -532,7 +534,7 @@ class SuccessiveHalving(AbstractRacer):
                 self.sh_iters += 1
                 self.stage = 0
                 self.configs_to_run = []
-                self.fail_challengers = set()  # capped/failed configs
+                self.fail_chal_offset = 0
 
                 # randomize instance-seed pairs per successive halving run, if user specifies
                 if self.instance_order == 'shuffle':
@@ -540,6 +542,7 @@ class SuccessiveHalving(AbstractRacer):
 
         # to track configurations for the next stage
         self.curr_challengers = set()  # successful configs
+        self.fail_challengers = set()  # capped/failed configs
         self.curr_inst_idx = 0
         self.running_challenger = None
 

--- a/test/test_intensify/test_successive_halving.py
+++ b/test/test_intensify/test_successive_halving.py
@@ -486,6 +486,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(list(self.rh.data.values())[2][2], StatusType.CAPPED)
         self.assertEqual(list(self.rh.data.values())[3][2], StatusType.CAPPED)
         self.assertEqual(intensifier.stage, 1)
+        self.assertEqual(intensifier.fail_chal_offset, 1)  # 2 configs expected, but 1 failure
 
         # run next stage - should run only 1 configuration since other 3 were capped
         # 1 runs for config1

--- a/test/test_intensify/test_successive_halving.py
+++ b/test/test_intensify/test_successive_halving.py
@@ -451,6 +451,66 @@ class TestSuccessiveHalving(unittest.TestCase):
             config, _ = intensifier.get_next_challenger(challengers=None,
                                                         chooser=None, run_history=self.rh)
 
+    def test_eval_challenger_capping_2(self):
+        """
+            test eval_challenger for adaptive capping with all but one configuration capped
+        """
+        def target(x):
+            if x['a'] + x['b'] > 0:
+                time.sleep(1.5)
+            return x['a']
+
+        taf = ExecuteTAFuncDict(ta=target, stats=self.stats, run_obj="runtime")
+        taf.runhistory = self.rh
+
+        intensifier = SuccessiveHalving(
+            tae_runner=taf, stats=self.stats,
+            traj_logger=TrajLogger(output_dir=None, stats=self.stats),
+            rng=np.random.RandomState(12345), deterministic=False, cutoff=1,
+            instances=[1, 2], n_seeds=2, initial_budget=1, max_budget=4, eta=2, instance_order=None)
+
+        # first configuration run
+        config, _ = intensifier.get_next_challenger(challengers=[self.config4],
+                                                    chooser=None, run_history=self.rh)
+        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=None, run_history=self.rh, )
+        self.assertEqual(inc, self.config4)
+
+        # remaining 3 runs should be capped
+        for i in [self.config1, self.config2, self.config3]:
+            config, _ = intensifier.get_next_challenger(challengers=[i],
+                                                        chooser=None, run_history=self.rh)
+            inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+
+        self.assertEqual(inc, self.config4)
+        self.assertEqual(list(self.rh.data.values())[1][2], StatusType.CAPPED)
+        self.assertEqual(list(self.rh.data.values())[2][2], StatusType.CAPPED)
+        self.assertEqual(list(self.rh.data.values())[3][2], StatusType.CAPPED)
+        self.assertEqual(intensifier.stage, 1)
+
+        # run next stage - should run only 1 configuration since other 3 were capped
+        # 1 runs for config1
+        config, _ = intensifier.get_next_challenger(challengers=[],
+                                                    chooser=None, run_history=self.rh)
+        self.assertEqual(config, self.config4)
+        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        self.assertEqual(intensifier.stage, 2)
+
+        # run next stage with only config1
+        # should go to next iteration since no more configurations left
+        for _ in range(2):
+            config, _ = intensifier.get_next_challenger(challengers=[],
+                                                        chooser=None, run_history=self.rh)
+            self.assertEqual(config, self.config4)
+            inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+
+        self.assertEqual(inc, self.config4)
+        self.assertEqual(len(self.rh.get_runs_for_config(self.config4, only_max_observed_budget=True)), 4)
+        self.assertEqual(intensifier.sh_iters, 1)
+        self.assertEqual(intensifier.stage, 0)
+
+        with self.assertRaisesRegex(ValueError, 'No configurations/chooser provided.'):
+            intensifier.get_next_challenger(challengers=[], chooser=None, run_history=self.rh)
+
     def test_eval_challenger_3(self):
         """
             test eval_challenger for updating to next stage and shuffling instance order every run


### PR DESCRIPTION
This bug was because of incomplete handling of the capped/failed challengers between stage changes. I've fixed it now and also added a test case for the same.

This would fix the failing spear_qcp example in development.