### PR TITLE
FIX ROAR facade for AC

### DIFF
--- a/ci_scripts/run_examples.sh
+++ b/ci_scripts/run_examples.sh
@@ -11,12 +11,21 @@ do
 done
 
 cd spear_qcp
-bash run.sh
+bash run_SMAC.sh
 rval=$?
 if [ "$rval" != 0 ]; then
     echo "Error running example QCP"
     exit $rval
 fi
+
+bash run_ROAR.sh
+rval=$?
+if [ "$rval" != 0 ]; then
+    echo "Error running example QCP"
+    exit $rval
+fi
+
+
 python SMAC4AC_spear_qcp.py
 rval=$?
 if [ "$rval" != 0 ]; then

--- a/examples/spear_qcp/run.sh
+++ b/examples/spear_qcp/run.sh
@@ -1,1 +1,0 @@
-python3 ../../scripts/smac --scenario scenario.txt --verbose DEBUG

--- a/examples/spear_qcp/run_ROAR.sh
+++ b/examples/spear_qcp/run_ROAR.sh
@@ -1,0 +1,1 @@
+python3 ../../scripts/smac --scenario scenario.txt --verbose DEBUG --mode ROAR

--- a/examples/spear_qcp/run_SMAC.sh
+++ b/examples/spear_qcp/run_SMAC.sh
@@ -1,0 +1,1 @@
+python3 ../../scripts/smac --scenario scenario.txt --verbose DEBUG --mode SMAC4AC

--- a/smac/facade/roar_facade.py
+++ b/smac/facade/roar_facade.py
@@ -10,7 +10,7 @@ from smac.initial_design.initial_design import InitialDesign
 from smac.intensification.abstract_racer import AbstractRacer
 from smac.optimizer.ei_optimization import RandomSearch, AcquisitionFunctionMaximizer
 from smac.runhistory.runhistory import RunHistory
-from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost, RunHistory2EPM4LogCost
+from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost, RunHistory2EPM4LogCost, AbstractRunHistory2EPM
 from smac.stats.stats import Stats
 from smac.scenario.scenario import Scenario
 from smac.tae.execute_ta_run import ExecuteTARun
@@ -103,7 +103,7 @@ class ROAR(SMAC4AC):
 
         if scenario.run_obj == "runtime":
             # We need to do this to be on the same scale for imputation (although we only impute with a Random EPM)
-            runhistory2epm = RunHistory2EPM4LogCost
+            runhistory2epm = RunHistory2EPM4LogCost  # type: typing.Type[AbstractRunHistory2EPM]
         else:
             runhistory2epm = RunHistory2EPM4Cost
 

--- a/smac/facade/roar_facade.py
+++ b/smac/facade/roar_facade.py
@@ -10,7 +10,7 @@ from smac.initial_design.initial_design import InitialDesign
 from smac.intensification.abstract_racer import AbstractRacer
 from smac.optimizer.ei_optimization import RandomSearch, AcquisitionFunctionMaximizer
 from smac.runhistory.runhistory import RunHistory
-from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost
+from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost, RunHistory2EPM4LogCost
 from smac.stats.stats import Stats
 from smac.scenario.scenario import Scenario
 from smac.tae.execute_ta_run import ExecuteTARun
@@ -101,6 +101,12 @@ class ROAR(SMAC4AC):
         if acquisition_function_optimizer is None:
             acquisition_function_optimizer = RandomSearch
 
+        if scenario.run_obj == "runtime":
+            # We need to do this to be on the same scale for imputation (although we only impute with a Random EPM)
+            runhistory2epm = RunHistory2EPM4LogCost
+        else:
+            runhistory2epm = RunHistory2EPM4Cost
+
         # use SMAC facade
         super().__init__(
             scenario=scenario,
@@ -109,7 +115,7 @@ class ROAR(SMAC4AC):
             runhistory=runhistory,
             intensifier=intensifier,
             intensifier_kwargs=intensifier_kwargs,
-            runhistory2epm=RunHistory2EPM4Cost,
+            runhistory2epm=runhistory2epm,
             initial_design=initial_design,
             initial_design_kwargs=initial_design_kwargs,
             initial_configurations=initial_configurations,


### PR DESCRIPTION
The RandomEPM used in ROAR always predicts value ~0. If the actual values are much higher, imputation will fail as the predicted values are much below the lower threshold. Using log transformation for this case brings the values closer to zero and imputation will work.