### PR TITLE
Evaluate acquisition function only if necessary

### DIFF
--- a/smac/optimizer/ei_optimization.py
+++ b/smac/optimizer/ei_optimization.py
@@ -88,7 +88,8 @@ class AcquisitionFunctionMaximizer(object, metaclass=abc.ABCMeta):
         iterable
             An iterable consisting of :class:`smac.configspace.Configuration`.
         """
-        next_configs_by_acq_value = lambda: [t[1] for t in self._maximize(runhistory, stats, num_points)]
+        def next_configs_by_acq_value() -> List[Configuration]:
+            return [t[1] for t in self._maximize(runhistory, stats, num_points)]
 
         challengers = ChallengerList(next_configs_by_acq_value,
                                      self.config_space,

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -321,7 +321,7 @@ class RunHistory(object):
     def get_runs_for_config(self,
                             config: Configuration, only_max_observed_budget: bool) -> typing.List[InstSeedBudgetKey]:
         """Return all runs (instance seed pairs) for a configuration.
-        
+
         Note
         ----
         This method ignores capped runs.

--- a/test/test_smbo/test_ei_optimization.py
+++ b/test/test_smbo/test_ei_optimization.py
@@ -15,7 +15,7 @@ from smac.optimizer.acquisition import EI
 from smac.optimizer.ei_optimization import LocalSearch, RandomSearch
 from smac.runhistory.runhistory import RunHistory
 from smac.tae.execute_ta_run import StatusType
-from smac.configspace import ConfigurationSpace, Configuration
+from smac.configspace import ConfigurationSpace
 from ConfigSpace.hyperparameters import CategoricalHyperparameter, \
     UniformFloatHyperparameter, UniformIntegerHyperparameter
 from smac.utils import test_helpers
@@ -45,10 +45,7 @@ class TestEIMaximization(unittest.TestCase):
     @unittest.mock.patch('smac.optimizer.acquisition.convert_configurations_to_array')
     @unittest.mock.patch.object(EI, '__call__')
     @unittest.mock.patch.object(ConfigurationSpace, 'sample_configuration')
-    def test_challenger_list_callback(self,
-                                              patch_sample,
-                                              patch_ei,
-                                              patch_impute):
+    def test_challenger_list_callback(self, patch_sample, patch_ei, patch_impute):
         values = (10, 1, 9, 2, 8, 3, 7, 4, 6, 5)
         patch_sample.return_value = ConfigurationMock(1)
         patch_ei.return_value = np.array([[_] for _ in values], dtype=float)
@@ -108,7 +105,6 @@ class TestEIMaximization(unittest.TestCase):
             self.assertIsInstance(rval[i][1], ConfigurationMock)
             self.assertEqual(rval[i][1].origin, 'Random Search')
             self.assertEqual(rval[i][0], 0)
-
 
 
 class TestLocalSearch(unittest.TestCase):

--- a/test/test_smbo/test_ei_optimization.py
+++ b/test/test_smbo/test_ei_optimization.py
@@ -15,7 +15,7 @@ from smac.optimizer.acquisition import EI
 from smac.optimizer.ei_optimization import LocalSearch, RandomSearch
 from smac.runhistory.runhistory import RunHistory
 from smac.tae.execute_ta_run import StatusType
-from smac.configspace import ConfigurationSpace
+from smac.configspace import ConfigurationSpace, Configuration
 from ConfigSpace.hyperparameters import CategoricalHyperparameter, \
     UniformFloatHyperparameter, UniformIntegerHyperparameter
 from smac.utils import test_helpers
@@ -39,6 +39,76 @@ def rosenbrock_4d(cfg):
         x3 - x2 ** 2) ** 2 + (x2 - 1) ** 2 + 100 * (x4 - x3 ** 2) ** 2 + (x3 - 1) ** 2)
 
     return(val)
+
+
+class TestEIMaximization(unittest.TestCase):
+    @unittest.mock.patch('smac.optimizer.acquisition.convert_configurations_to_array')
+    @unittest.mock.patch.object(EI, '__call__')
+    @unittest.mock.patch.object(ConfigurationSpace, 'sample_configuration')
+    def test_challenger_list_callback(self,
+                                              patch_sample,
+                                              patch_ei,
+                                              patch_impute):
+        values = (10, 1, 9, 2, 8, 3, 7, 4, 6, 5)
+        patch_sample.return_value = ConfigurationMock(1)
+        patch_ei.return_value = np.array([[_] for _ in values], dtype=float)
+        patch_impute.side_effect = lambda l: values
+        cs = ConfigurationSpace()
+        ei = EI(None)
+        rs = RandomSearch(ei, cs)
+        rs._maximize = unittest.mock.Mock()
+        rs._maximize.return_value = [(0, 0)]
+
+        rval = rs.maximize(
+            runhistory=None, stats=None, num_points=10,
+        )
+        self.assertEqual(rs._maximize.call_count, 0)
+        next(rval)
+        self.assertEqual(rs._maximize.call_count, 1)
+
+        random_configuration_chooser = unittest.mock.Mock()
+        random_configuration_chooser.check.side_effect = [True, False, False, False]
+        rs._maximize = unittest.mock.Mock()
+        rs._maximize.return_value = [(0, 0), (1, 1)]
+
+        rval = rs.maximize(
+            runhistory=None, stats=None, num_points=10, random_configuration_chooser=random_configuration_chooser,
+        )
+        self.assertEqual(rs._maximize.call_count, 0)
+        # The first configuration is chosen at random (see the random_configuration_chooser mock)
+        conf = next(rval)
+        self.assertIsInstance(conf, ConfigurationMock)
+        self.assertEqual(rs._maximize.call_count, 0)
+        # The 2nd configuration triggers the call to the callback (see the random_configuration_chooser mock)
+        conf = next(rval)
+        self.assertEqual(rs._maximize.call_count, 1)
+        self.assertEqual(conf, 0)
+        # The 3rd configuration doesn't trigger the callback any more
+        conf = next(rval)
+        self.assertEqual(rs._maximize.call_count, 1)
+        self.assertEqual(conf, 1)
+
+        with self.assertRaises(StopIteration):
+            next(rval)
+
+    @unittest.mock.patch.object(ConfigurationSpace, 'sample_configuration')
+    def test_get_next_by_random_search(self, patch):
+        def side_effect(size):
+            return [ConfigurationMock()] * size
+
+        patch.side_effect = side_effect
+        cs = ConfigurationSpace()
+        ei = EI(None)
+        rs = RandomSearch(ei, cs)
+        rval = rs._maximize(
+            runhistory=None, stats=None, num_points=10, _sorted=False
+        )
+        self.assertEqual(len(rval), 10)
+        for i in range(10):
+            self.assertIsInstance(rval[i][1], ConfigurationMock)
+            self.assertEqual(rval[i][1].origin, 'Random Search')
+            self.assertEqual(rval[i][0], 0)
+
 
 
 class TestLocalSearch(unittest.TestCase):

--- a/test/test_smbo/test_epm_configuration_chooser.py
+++ b/test/test_smbo/test_epm_configuration_chooser.py
@@ -146,7 +146,7 @@ class TestEPMChooser(unittest.TestCase):
         # For each configuration it is randomly sampled whether to take it from the list of challengers or to sample it
         # completely at random. Therefore, it is not guaranteed to obtain twice the number of configurations selected
         # by EI.
-        self.assertEqual(len(challengers), 9968)
+        self.assertEqual(len(challengers), 10198)
         num_random_search_sorted = 0
         num_random_search = 0
         num_local_search = 0
@@ -163,7 +163,7 @@ class TestEPMChooser(unittest.TestCase):
 
         self.assertEqual(num_local_search, 11)
         self.assertEqual(num_random_search_sorted, 5000)
-        self.assertEqual(num_random_search, 4957)
+        self.assertEqual(num_random_search, 5187)
 
     @unittest.skipIf(sys.version_info < (3, 6), 'Test not deterministic for Python 3.5 and earlier')
     def test_choose_next_3(self):
@@ -195,7 +195,7 @@ class TestEPMChooser(unittest.TestCase):
         # For each configuration it is randomly sampled whether to take it from the list of challengers or to sample it
         # completely at random. Therefore, it is not guaranteed to obtain twice the number of configurations selected
         # by EI
-        self.assertEqual(len(challengers), 9983)
+        self.assertEqual(len(challengers), 9986)
         num_random_search_sorted = 0
         num_random_search = 0
         num_local_search = 0
@@ -210,9 +210,9 @@ class TestEPMChooser(unittest.TestCase):
             else:
                 raise ValueError(c.origin)
 
-        self.assertEqual(num_local_search, 25)
+        self.assertEqual(num_local_search, 26)
         self.assertEqual(num_random_search_sorted, 5000)
-        self.assertEqual(num_random_search, 4958)
+        self.assertEqual(num_random_search, 4960)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
by creating a callback which is only triggered if a non-random configuration is necessary. This does not yet prevent SMAC from constructing unnecessary models.