### PR TITLE
Change behavior of donotadvance

### DIFF
--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -231,13 +231,13 @@ class Intensifier(AbstractRacer):
                 self._next_iteration()
 
             if not self.use_ta_time_bound and self.elapsed_time - time_bound >= 0:
-                self.logger.debug("Wallclock time limit for intensification reached ("
+                self.logger.info("Wallclock time limit for intensification reached ("
                                   "used: %f sec, available: %f sec)" %
                                   (self.elapsed_time, time_bound))
                 self._next_iteration()
 
             elif self._ta_time - time_bound >= 0:
-                self.logger.debug("TA time limit for intensification reached ("
+                self.logger.info("TA time limit for intensification reached ("
                                   "used: %f sec, available: %f sec)" %
                                   (self._ta_time, time_bound))
                 self._next_iteration()

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -231,15 +231,13 @@ class Intensifier(AbstractRacer):
                 self._next_iteration()
 
             if not self.use_ta_time_bound and self.elapsed_time - time_bound >= 0:
-                self.logger.info("Wallclock time limit for intensification reached ("
-                                  "used: %f sec, available: %f sec)" %
-                                  (self.elapsed_time, time_bound))
+                self.logger.info("Wallclock time limit for intensification reached (used: %f sec, available: %f sec)",
+                                 self.elapsed_time, time_bound)
                 self._next_iteration()
 
             elif self._ta_time - time_bound >= 0:
-                self.logger.info("TA time limit for intensification reached ("
-                                  "used: %f sec, available: %f sec)" %
-                                  (self._ta_time, time_bound))
+                self.logger.info("TA time limit for intensification reached (used: %f sec, available: %f sec)",
+                                 self._ta_time, time_bound)
                 self._next_iteration()
 
         inc_perf = run_history.get_cost(incumbent)

--- a/smac/optimizer/epm_configuration_chooser.py
+++ b/smac/optimizer/epm_configuration_chooser.py
@@ -14,6 +14,7 @@ from smac.runhistory.runhistory import RunHistory
 from smac.runhistory.runhistory2epm import AbstractRunHistory2EPM
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
+from smac.tae.execute_ta_run import StatusType
 
 
 class EPMChooser(object):
@@ -110,6 +111,11 @@ class EPMChooser(object):
                        if self.runhistory.data[run].status in self.rh2EPM.consider_for_higher_budgets_state
                        and run.budget < b}
                 config_ids.update(add)
+                add2 = {run.config_id for run in self.runhistory.data.keys()
+                        if self.runhistory.data[run].status == StatusType.TIMEOUT
+                        and self.runhistory.data[run].time >= self.rh2EPM.cutoff_time
+                        and run.budget == b}
+                config_ids.update(add2)
                 configurations = [self.runhistory.ids_config[config_id] for config_id in config_ids]
                 configs_array = convert_configurations_to_array(configurations)
                 return X, Y, configs_array

--- a/smac/optimizer/epm_configuration_chooser.py
+++ b/smac/optimizer/epm_configuration_chooser.py
@@ -14,7 +14,6 @@ from smac.runhistory.runhistory import RunHistory
 from smac.runhistory.runhistory2epm import AbstractRunHistory2EPM
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
-from smac.tae.execute_ta_run import StatusType
 
 
 class EPMChooser(object):
@@ -103,21 +102,8 @@ class EPMChooser(object):
             X, Y = self.rh2EPM.transform(self.runhistory, budget_subset=[b, ])
             if X.shape[0] >= self.min_samples_model:
                 self.currently_considered_budgets = [b, ]
-                config_ids = {run.config_id for run in self.runhistory.data.keys()
-                              if run.budget == b
-                              and self.runhistory.data[run].status in self.rh2EPM.success_states}
-                # Additionally add these states from lower budgets
-                add = {run.config_id for run in self.runhistory.data.keys()
-                       if self.runhistory.data[run].status in self.rh2EPM.consider_for_higher_budgets_state
-                       and run.budget < b}
-                config_ids.update(add)
-                add2 = {run.config_id for run in self.runhistory.data.keys()
-                        if self.runhistory.data[run].status == StatusType.TIMEOUT
-                        and self.runhistory.data[run].time >= self.rh2EPM.cutoff_time
-                        and run.budget == b}
-                config_ids.update(add2)
-                configurations = [self.runhistory.ids_config[config_id] for config_id in config_ids]
-                configs_array = convert_configurations_to_array(configurations)
+                configs_array = self.rh2EPM.get_configurations(
+                    self.runhistory, budget_subset=self.currently_considered_budgets)
                 return X, Y, configs_array
 
         return np.empty(shape=[0, 0]), np.empty(shape=[0, ]), np.empty(shape=[0, 0])

--- a/test/test_intensify/test_successive_halving.py
+++ b/test/test_intensify/test_successive_halving.py
@@ -190,7 +190,7 @@ class TestSuccessiveHalving(unittest.TestCase):
                     status=StatusType.SUCCESS, instance_id=2, seed=None,
                     additional_info=None)
 
-        with self.assertRaisesRegex(AssertionError, 'Cannot compare configs'):
+        with self.assertRaisesRegex(ValueError, 'Cannot compare configs'):
             intensifier._top_k(configs=[self.config2, self.config1, self.config3],
                                k=1, run_history=self.rh)
 

--- a/test/test_intensify/test_successive_halving.py
+++ b/test/test_intensify/test_successive_halving.py
@@ -339,6 +339,62 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertIsInstance(intensifier.configs_to_run, list)
         self.assertEqual(len(intensifier.configs_to_run), 0)
 
+    @unittest.mock.patch.object(SuccessiveHalving, '_top_k')
+    def test_update_stage_2(self, top_k_mock):
+        """
+            test update_stage - everything good is in state do not advance
+        """
+
+        intensifier = SuccessiveHalving(
+            tae_runner=None, stats=self.stats, traj_logger=None,
+            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
+            cutoff=1, initial_budget=1, max_budget=4, eta=2, instances=None)
+
+        # update variables
+        intensifier._update_stage(run_history=None)
+
+        intensifier.success_challengers.add(self.config1)
+        intensifier.success_challengers.add(self.config2)
+        intensifier.do_not_advance_challengers.add(self.config3)
+        intensifier.do_not_advance_challengers.add(self.config4)
+
+        top_k_mock.return_value = [self.config1, self.config3]
+
+        # Test that we update the stage as there is one configuration advanced to the next budget
+        self.assertEqual(intensifier.stage, 0)
+        intensifier._update_stage(run_history=None)
+        self.assertEqual(intensifier.stage, 1)
+        self.assertEqual(intensifier.configs_to_run, [self.config1])
+        self.assertEqual(intensifier.fail_chal_offset, 1)
+        self.assertEqual(len(intensifier.success_challengers), 0)
+        self.assertEqual(len(intensifier.do_not_advance_challengers), 0)
+
+        intensifier = SuccessiveHalving(
+            tae_runner=None, stats=self.stats, traj_logger=None,
+            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
+            cutoff=1, initial_budget=1, max_budget=4, eta=2, instances=None)
+
+        # update variables
+        intensifier._update_stage(run_history=None)
+
+        intensifier.success_challengers.add(self.config1)
+        intensifier.success_challengers.add(self.config2)
+        intensifier.do_not_advance_challengers.add(self.config3)
+        intensifier.do_not_advance_challengers.add(self.config4)
+
+        top_k_mock.return_value = [self.config3, self.config4]
+
+        # Test that we update the stage as there is no configuration advanced to the next budget
+        self.assertEqual(intensifier.stage, 0)
+        intensifier._update_stage(run_history=None)
+        self.assertEqual(intensifier.stage, 0)
+        self.assertEqual(intensifier.configs_to_run, [])
+        self.assertEqual(intensifier.fail_chal_offset, 0)
+        self.assertEqual(len(intensifier.success_challengers), 0)
+        self.assertEqual(len(intensifier.do_not_advance_challengers), 0)
+
+        top_k_mock.return_value = []
+
     def test_eval_challenger_1(self):
         """
            test eval_challenger with quality objective & real-valued budget

--- a/test/test_smbo/test_epm_configuration_chooser.py
+++ b/test/test_smbo/test_epm_configuration_chooser.py
@@ -77,9 +77,10 @@ class TestEPMChooser(unittest.TestCase):
         smbo.epm_chooser.min_samples_model = 2
 
         # Return two configurations evaluated with budget==2
-        x, y = smbo.epm_chooser._collect_data_to_train_model()
-        self.assertListEqual(list(y.flatten()), [2, 3])
-        self.assertEqual(x.shape[0], 2)
+        X, Y, X_configurations = smbo.epm_chooser._collect_data_to_train_model()
+        self.assertListEqual(list(Y.flatten()), [2, 3])
+        self.assertEqual(X.shape[0], 2)
+        self.assertEqual(X_configurations.shape[0], 2)
 
     def test_choose_next_w_empty_rh(self):
         seed = 42

--- a/test/test_smbo/test_epm_configuration_chooser.py
+++ b/test/test_smbo/test_epm_configuration_chooser.py
@@ -1,4 +1,5 @@
 import sys
+import shutil
 import unittest
 from unittest import mock
 
@@ -27,6 +28,13 @@ class TestEPMChooser(unittest.TestCase):
         self.scenario = Scenario({'cs': test_helpers.get_branin_config_space(),
                                   'run_obj': 'quality',
                                   'output_dir': 'data-test_epmchooser'})
+        self.output_dirs = []
+        self.output_dirs.append(self.scenario.output_dir)
+
+    def tearDown(self):
+        for output_dir in self.output_dirs:
+            if output_dir:
+                shutil.rmtree(output_dir, ignore_errors=True)
 
     def branin(self, x):
         y = (x[:, 1] - (5.1 / (4 * np.pi ** 2)) * x[:, 0] ** 2 + 5 * x[:, 0] / np.pi - 6) ** 2


### PR DESCRIPTION
Update the behavior of the new DONOTADVANCE state. Configurations are first sorted by their performance when deciding which configurations to advance to the next budget. If a configuration with state DONOTADVANCE ends up in the higher budget, it is not executed any more. This can reduce the number of configurations to be executed in higher budgets to save time.

CC @KEggensperger @ashraaghav 