### PR TITLE
Fix infinite loop

### DIFF
--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -168,7 +168,7 @@ class RunHistory(object):
         status: StatusType,
         instance_id: typing.Optional[str] = None,
         seed: typing.Optional[int] = None,
-        budget: float = 0,
+        budget: float = 0.0,
         additional_info: typing.Optional[typing.Dict] = None,
         origin: DataOrigin = DataOrigin.INTERNAL,
     ) -> None:


### PR DESCRIPTION
Fixes an infinite loop in intensification which could occur if the acquisition function would always return the same configuration and no random configurations were used. The fix is to only end intensify if there are either no challengers left or one challenger was executed (and therefore the model would change for the next iteration).