### PR TITLE
Separated next challenger form eval

### DIFF
--- a/smac/facade/smac_ac_facade.py
+++ b/smac/facade/smac_ac_facade.py
@@ -386,7 +386,6 @@ class SMAC4AC(object):
 
         # initialize intensification
         intensifier_def_kwargs = {
-            'tae_runner': tae_runner_instance,
             'stats': self.stats,
             'traj_logger': traj_logger,
             'rng': rng,
@@ -544,7 +543,8 @@ class SMAC4AC(object):
             'acquisition_func': acquisition_function_instance,
             'rng': rng,
             'restore_incumbent': restore_incumbent,
-            'random_configuration_chooser': random_configuration_chooser_instance
+            'random_configuration_chooser': random_configuration_chooser_instance,
+            'tae_runner': tae_runner_instance,
         }  # type: Dict[str, Any]
 
         if smbo_class is None:
@@ -631,7 +631,7 @@ class SMAC4AC(object):
         TAE: smac.tae.execute_ta_run.ExecuteTARun
 
         """
-        return self.solver.intensifier.tae_runner
+        return self.solver.tae_runner
 
     def get_runhistory(self) -> RunHistory:
         """

--- a/smac/facade/smac_ac_facade.py
+++ b/smac/facade/smac_ac_facade.py
@@ -349,7 +349,6 @@ class SMAC4AC(object):
         tae_def_kwargs = {
             'stats': self.stats,
             'run_obj': scenario.run_obj,
-            'runhistory': runhistory,
             'par_factor': scenario.par_factor,  # type: ignore[attr-defined] # noqa F821
             'cost_for_crash': scenario.cost_for_crash,  # type: ignore[attr-defined] # noqa F821
             'abort_on_first_run_crash': scenario.abort_on_first_run_crash  # type: ignore[attr-defined] # noqa F821

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -2,6 +2,7 @@ import logging
 import typing
 import time
 from collections import OrderedDict
+from enum import Enum
 
 import numpy as np
 
@@ -18,6 +19,19 @@ _config_to_run_type = typing.Iterator[typing.Optional[Configuration]]
 __author__ = "Ashwin Raaghav Narayanan"
 __copyright__ = "Copyright 2019, ML4AAD"
 __license__ = "3-clause BSD"
+
+
+class IntensifierBehest(Enum):
+    """Class to define different request on how to process
+    the runinfo
+
+    Gives the flexibility to indicate whether no more configs
+    are available (TERMINATE in this case), no need to rerun
+    previous configurations (SKIP) or we simple should run
+    """
+    RUN = 0  # Normal run execution of a run info
+    SKIP = 1  # Skip running the run info
+    TERMINATE = 2  # No more configurations to try
 
 
 class AbstractRacer(object):
@@ -115,7 +129,8 @@ class AbstractRacer(object):
                      incumbent: Configuration,
                      chooser: typing.Optional[EPMChooser],
                      run_history: RunHistory,
-                     repeat_configs: bool = True) -> RunInfo:
+                     repeat_configs: bool = True
+                     ) -> typing.Tuple[IntensifierBehest, RunInfo]:
         """
         Abstract method for choosing the next challenger, to allow for different selections across intensifiers
         uses ``_next_challenger()`` by default
@@ -139,6 +154,8 @@ class AbstractRacer(object):
         -------
         run_info: RunInfo
             An object that encapsulates necessary information for a config run
+        behest: IntensifierBehest
+            Indicator of how to consume the RunInfo object
         """
         raise NotImplementedError()
 

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -25,23 +25,25 @@ class RunInfoIntent(Enum):
     """Class to define different requests on how to process
     the runinfo
 
-    Gives the flexibility to indicate whether no more configs
-    are available (STOP_ITERATION in this case), no need to rerun
-    previous configurations (SKIP) or if the SMBO should simple
+    Gives the flexibility to indicate whether a configuration
+    should be skipped (SKIP) or if the SMBO should simple
     run a generated run_info.
     """
     RUN = 0  # Normal run execution of a run info
     SKIP = 1  # Skip running the run_info
-    STOP_ITERATION = 2  # No more configurations to try
 
 
 class AbstractRacer(object):
     """
     Base class for all racing methods
 
-    The "intensification" is designed to be spread across multiple ``eval_challenger()`` runs.
-    This is to facilitate on-demand configuration sampling if multiple configurations are required,
-    like Successive Halving or Hyperband.
+    The "intensification" is designed to output a RunInfo object with enough information
+    to run a given configuration (for example, the run info contains the instance/seed
+    pair, as well as the associated resources).
+
+    A worker can execute this RunInfo object and produce a RunValue object with the
+    execution results. Each intensifier process the RunValue object and updates it's
+    internal state in preparation for the next iteration.
 
     **Note: Do not use directly**
 
@@ -136,7 +138,8 @@ class AbstractRacer(object):
         Abstract method for choosing the next challenger, to allow for different selections across intensifiers
         uses ``_next_challenger()`` by default
 
-        If no more challengers are available, the method should return None as configuration
+        If no more challengers are available, the method should issue a SKIP via
+        RunInfoIntent.SKIP, so that a new iteration can sample new configurations.
 
         Parameters
         ----------

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -110,15 +110,17 @@ class AbstractRacer(object):
         # to mark the end of an iteration
         self.iteration_done = False
 
-    def get_next_challenger(self,
-                            challengers: typing.Optional[typing.List[Configuration]],
-                            incumbent: Configuration,
-                            chooser: typing.Optional[EPMChooser],
-                            run_history: RunHistory,
-                            repeat_configs: bool = True) -> RunInfo:
+    def get_next_run(self,
+                     challengers: typing.Optional[typing.List[Configuration]],
+                     incumbent: Configuration,
+                     chooser: typing.Optional[EPMChooser],
+                     run_history: RunHistory,
+                     repeat_configs: bool = True) -> RunInfo:
         """
         Abstract method for choosing the next challenger, to allow for different selections across intensifiers
         uses ``_next_challenger()`` by default
+
+        If no more challengers are available, the method should return None as configuration
 
         Parameters
         ----------
@@ -170,7 +172,7 @@ class AbstractRacer(object):
             The tracked time of a configuration execution
         time_bound : float, optional (default=2 ** 31 - 1)
             time in [sec] available to perform intensify
-        status:  typing.Optional[StatusType],
+        status:  typing.Optional[StatusType]
             The status of the execution of a given config
         runtime:
             The elapsed time according to the ta runner

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -21,17 +21,18 @@ __copyright__ = "Copyright 2019, ML4AAD"
 __license__ = "3-clause BSD"
 
 
-class IntensifierBehest(Enum):
-    """Class to define different request on how to process
+class RunInfoIntent(Enum):
+    """Class to define different requests on how to process
     the runinfo
 
     Gives the flexibility to indicate whether no more configs
-    are available (TERMINATE in this case), no need to rerun
-    previous configurations (SKIP) or we simple should run
+    are available (STOP_ITERATION in this case), no need to rerun
+    previous configurations (SKIP) or if the SMBO should simple
+    run a generated run_info.
     """
     RUN = 0  # Normal run execution of a run info
-    SKIP = 1  # Skip running the run info
-    TERMINATE = 2  # No more configurations to try
+    SKIP = 1  # Skip running the run_info
+    STOP_ITERATION = 2  # No more configurations to try
 
 
 class AbstractRacer(object):
@@ -130,7 +131,7 @@ class AbstractRacer(object):
                      chooser: typing.Optional[EPMChooser],
                      run_history: RunHistory,
                      repeat_configs: bool = True
-                     ) -> typing.Tuple[IntensifierBehest, RunInfo]:
+                     ) -> typing.Tuple[RunInfoIntent, RunInfo]:
         """
         Abstract method for choosing the next challenger, to allow for different selections across intensifiers
         uses ``_next_challenger()`` by default
@@ -154,7 +155,7 @@ class AbstractRacer(object):
         -------
         run_info: RunInfo
             An object that encapsulates necessary information for a config run
-        behest: IntensifierBehest
+        intent: RunInfoIntent
             Indicator of how to consume the RunInfo object
         """
         raise NotImplementedError()
@@ -178,12 +179,12 @@ class AbstractRacer(object):
         challenger : Configuration
             A configuration that was previously executed, and whose status
             will be used to define the next stage.
-        incumbent : Configuration
+        incumbent : typing.Optional[Configuration]
             Best configuration seen so far
-        run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
+        run_history : RunHistory
             stores all runs we ran so far
             if False, an evaluated configuration will not be generated again
-        time_bound : float, optional (default=2 ** 31 - 1)
+        time_bound : float
             time in [sec] available to perform intensify
         result: RunValue
             Contain the result (status and other methadata) of exercising

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -9,7 +9,7 @@ from smac.optimizer.epm_configuration_chooser import EPMChooser
 
 from smac.stats.stats import Stats
 from smac.configspace import Configuration
-from smac.runhistory.runhistory import RunHistory, RunInfo, StatusType
+from smac.runhistory.runhistory import RunHistory, RunInfo, RunValue
 from smac.utils.io.traj_logging import TrajLogger
 
 _config_to_run_type = typing.Iterator[typing.Optional[Configuration]]
@@ -146,10 +146,8 @@ class AbstractRacer(object):
                         challenger: Configuration,
                         incumbent: typing.Optional[Configuration],
                         run_history: RunHistory,
-                        elapsed_time: float,
                         time_bound: float,
-                        status: StatusType,
-                        runtime: float,
+                        result: RunValue,
                         log_traj: bool = True,
                         ) -> \
             typing.Tuple[Configuration, float]:
@@ -168,14 +166,11 @@ class AbstractRacer(object):
         run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
             stores all runs we ran so far
             if False, an evaluated configuration will not be generated again
-        elapsed_time:
-            The tracked time of a configuration execution
         time_bound : float, optional (default=2 ** 31 - 1)
             time in [sec] available to perform intensify
-        status:  typing.Optional[StatusType]
-            The status of the execution of a given config
-        runtime:
-            The elapsed time according to the ta runner
+        result: RunValue
+            Contain the result (status and other methadata) of exercising
+            a challenger/incumbent.
         log_traj: bool
             Whether to log changes of incumbents in trajectory
 

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -120,7 +120,7 @@ class Hyperband(SuccessiveHalving):
                         result: RunValue,
                         log_traj: bool = True,
                         ) -> \
-            typing.Tuple[typing.Optional[Configuration], float]:
+            typing.Tuple[Configuration, float]:
         """
         The intensifier stage will be updated based on the results/status
         of a configuration execution.

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -131,7 +131,7 @@ class Hyperband(SuccessiveHalving):
         challenger : Configuration
             A configuration that was previously executed, and whose status
             will be used to define the next stage.
-        incumbet : typing.Optional[Configuration]
+        incumbent : typing.Optional[Configuration]
             Best configuration seen so far
         run_history : RunHistory
             stores all runs we ran so far

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -3,6 +3,7 @@ import typing
 
 import numpy as np
 
+from smac.intensification.abstract_racer import IntensifierBehest
 from smac.intensification.successive_halving import SuccessiveHalving
 from smac.optimizer.epm_configuration_chooser import EPMChooser
 from smac.stats.stats import Stats
@@ -171,7 +172,7 @@ class Hyperband(SuccessiveHalving):
                      incumbent: Configuration,
                      chooser: typing.Optional[EPMChooser],
                      run_history: RunHistory,
-                     repeat_configs: bool = True) -> RunInfo:
+                     repeat_configs: bool = True) -> typing.Tuple[IntensifierBehest, RunInfo]:
         """
         Selects which challenger to use based on the iteration stage and set the iteration parameters.
         First iteration will choose configurations from the ``chooser`` or input challengers,
@@ -196,6 +197,8 @@ class Hyperband(SuccessiveHalving):
         -------
         run_info: RunInfo
                An object that encapsulates necessary information for a config run
+        behest: IntensifierBehest
+               Indicator of how to consume the RunInfo object
         """
 
         if not hasattr(self, 's'):
@@ -205,7 +208,7 @@ class Hyperband(SuccessiveHalving):
         # sampling from next challenger marks the beginning of a new iteration
         self.iteration_done = False
 
-        run_info = self.sh_intensifier.get_next_run(
+        behest, run_info = self.sh_intensifier.get_next_run(
             challengers=challengers,
             incumbent=incumbent,
             chooser=chooser,
@@ -218,7 +221,7 @@ class Hyperband(SuccessiveHalving):
         # perspective
         self.new_challenger = self.sh_intensifier.new_challenger
 
-        return run_info
+        return behest, run_info
 
     def _update_stage(self, run_history: RunHistory = None) -> None:
         """

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -3,7 +3,7 @@ import typing
 
 import numpy as np
 
-from smac.intensification.abstract_racer import IntensifierBehest
+from smac.intensification.abstract_racer import RunInfoIntent
 from smac.intensification.successive_halving import SuccessiveHalving
 from smac.optimizer.epm_configuration_chooser import EPMChooser
 from smac.stats.stats import Stats
@@ -131,12 +131,12 @@ class Hyperband(SuccessiveHalving):
         challenger : Configuration
             A configuration that was previously executed, and whose status
             will be used to define the next stage.
-        incumbet : Configuration
+        incumbet : typing.Optional[Configuration]
             Best configuration seen so far
-        run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
+        run_history : RunHistory
             stores all runs we ran so far
             if False, an evaluated configuration will not be generated again
-        time_bound : float, optional (default=2 ** 31 - 1)
+        time_bound : float
             time in [sec] available to perform intensify
         result: RunValue
             Contain the result (status and other methadata) of exercising
@@ -146,7 +146,7 @@ class Hyperband(SuccessiveHalving):
 
         Returns
         -------
-        incumbent: Configuration()
+        incumbent: Configuration
             current (maybe new) incumbent configuration
         inc_perf: float
             empirical performance of incumbent configuration
@@ -172,7 +172,7 @@ class Hyperband(SuccessiveHalving):
                      incumbent: Configuration,
                      chooser: typing.Optional[EPMChooser],
                      run_history: RunHistory,
-                     repeat_configs: bool = True) -> typing.Tuple[IntensifierBehest, RunInfo]:
+                     repeat_configs: bool = True) -> typing.Tuple[RunInfoIntent, RunInfo]:
         """
         Selects which challenger to use based on the iteration stage and set the iteration parameters.
         First iteration will choose configurations from the ``chooser`` or input challengers,
@@ -195,10 +195,10 @@ class Hyperband(SuccessiveHalving):
 
         Returns
         -------
+        intent: RunInfoIntent
+               Indicator of how to consume the RunInfo object
         run_info: RunInfo
                An object that encapsulates necessary information for a config run
-        behest: IntensifierBehest
-               Indicator of how to consume the RunInfo object
         """
 
         if not hasattr(self, 's'):
@@ -208,7 +208,7 @@ class Hyperband(SuccessiveHalving):
         # sampling from next challenger marks the beginning of a new iteration
         self.iteration_done = False
 
-        behest, run_info = self.sh_intensifier.get_next_run(
+        intent, run_info = self.sh_intensifier.get_next_run(
             challengers=challengers,
             incumbent=incumbent,
             chooser=chooser,
@@ -221,7 +221,7 @@ class Hyperband(SuccessiveHalving):
         # perspective
         self.new_challenger = self.sh_intensifier.new_challenger
 
-        return behest, run_info
+        return intent, run_info
 
     def _update_stage(self, run_history: RunHistory = None) -> None:
         """

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -8,7 +8,7 @@ from smac.optimizer.epm_configuration_chooser import EPMChooser
 from smac.stats.stats import Stats
 from smac.configspace import Configuration
 from smac.runhistory.runhistory import RunHistory
-from smac.runhistory.runhistory import RunInfo, StatusType  # noqa: F401
+from smac.runhistory.runhistory import RunValue, RunInfo, StatusType  # noqa: F401
 from smac.utils.io.traj_logging import TrajLogger
 
 __author__ = "Ashwin Raaghav Narayanan"
@@ -115,10 +115,8 @@ class Hyperband(SuccessiveHalving):
                         challenger: Configuration,
                         incumbent: typing.Optional[Configuration],
                         run_history: RunHistory,
-                        elapsed_time: float,
                         time_bound: float,
-                        status: StatusType,
-                        runtime: float,
+                        result: RunValue,
                         log_traj: bool = True,
                         ) -> \
             typing.Tuple[typing.Optional[Configuration], float]:
@@ -137,16 +135,11 @@ class Hyperband(SuccessiveHalving):
         run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
             stores all runs we ran so far
             if False, an evaluated configuration will not be generated again
-        elapsed_time:
-            The tracked time of a configuration execution
         time_bound : float, optional (default=2 ** 31 - 1)
             time in [sec] available to perform intensify
-        status: typing.Optional[StatusType]
-            The status of the execution of a given config
-            If None, it is assumed that the previous run was not completely
-            executed, for example when there is no more budget
-        runtime:
-            The elapsed time according to the ta runner
+        result: RunValue
+            Contain the result (status and other methadata) of exercising
+            a challenger/incumbent.
         log_traj: bool
             Whether to log changes of incumbents in trajectory
 
@@ -162,10 +155,8 @@ class Hyperband(SuccessiveHalving):
         incumbent, inc_perf = self.sh_intensifier.process_results(challenger=challenger,
                                                                   incumbent=incumbent,
                                                                   run_history=run_history,
-                                                                  elapsed_time=elapsed_time,
                                                                   time_bound=time_bound,
-                                                                  status=status,
-                                                                  runtime=runtime,
+                                                                  result=result,
                                                                   log_traj=log_traj)
         self.num_run += 1
 

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -175,16 +175,18 @@ class Hyperband(SuccessiveHalving):
 
         return incumbent, inc_perf
 
-    def get_next_challenger(self,
-                            challengers: typing.Optional[typing.List[Configuration]],
-                            incumbent: Configuration,
-                            chooser: typing.Optional[EPMChooser],
-                            run_history: RunHistory,
-                            repeat_configs: bool = True) -> RunInfo:
+    def get_next_run(self,
+                     challengers: typing.Optional[typing.List[Configuration]],
+                     incumbent: Configuration,
+                     chooser: typing.Optional[EPMChooser],
+                     run_history: RunHistory,
+                     repeat_configs: bool = True) -> RunInfo:
         """
         Selects which challenger to use based on the iteration stage and set the iteration parameters.
         First iteration will choose configurations from the ``chooser`` or input challengers,
         while the later iterations pick top configurations from the previously selected challengers in that iteration
+
+        If no new run is available, the method returns a configuration of None.
 
         Parameters
         ----------
@@ -212,7 +214,7 @@ class Hyperband(SuccessiveHalving):
         # sampling from next challenger marks the beginning of a new iteration
         self.iteration_done = False
 
-        run_info = self.sh_intensifier.get_next_challenger(
+        run_info = self.sh_intensifier.get_next_run(
             challengers=challengers,
             incumbent=incumbent,
             chooser=chooser,
@@ -220,7 +222,9 @@ class Hyperband(SuccessiveHalving):
             repeat_configs=self.sh_intensifier.repeat_configs
         )
 
-        # For debug purposes, set this flag
+        # For testing purposes, this attribute highlights whether a
+        # new challenger is proposed or not. Not required from a functional
+        # perspective
         self.new_challenger = self.sh_intensifier.new_challenger
 
         return run_info

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -261,7 +261,6 @@ class Intensifier(AbstractRacer):
                 run_history=run_history,
                 repeat_configs=repeat_configs,
             )
-            print(f"Using challenger = {challenger}")
 
             # if first ever run, then assume current challenger to be the incumbent
             # In this case, we need a branch new challenger
@@ -410,7 +409,6 @@ class Intensifier(AbstractRacer):
             if hasattr(challenger, 'origin'):
                 self.logger.debug("Configuration origin: %s", challenger.origin)
 
-            print(f"stage={self.stage}")
             if self.stage in [IntensifierStage.RUN_CHALLENGER, IntensifierStage.RUN_BASIS]:
                 # Lines 8-11
                 incumbent, instance, seed, cutoff = self._get_next_racer(

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -697,13 +697,13 @@ class Intensifier(AbstractRacer):
         # return currently running challenger
         return self.current_challenger, False
 
-    def get_next_challenger(self,
-                            challengers: typing.Optional[typing.List[Configuration]],
-                            incumbent: Configuration,
-                            chooser: typing.Optional[EPMChooser],
-                            run_history: RunHistory,
-                            repeat_configs: bool = True,
-                            ) -> RunInfo:
+    def get_next_run(self,
+                     challengers: typing.Optional[typing.List[Configuration]],
+                     incumbent: Configuration,
+                     chooser: typing.Optional[EPMChooser],
+                     run_history: RunHistory,
+                     repeat_configs: bool = True,
+                     ) -> RunInfo:
         """
         Wrapper around query challengers, to get the next configuration
         to run, as well as updating the internal state of the intensifier.
@@ -759,7 +759,7 @@ class Intensifier(AbstractRacer):
                     capped=False,
                     budget=0.0,
                 )
-            return self.get_next_challenger(
+            return self.get_next_run(
                 challengers=challengers,
                 incumbent=incumbent,
                 chooser=chooser,
@@ -772,7 +772,7 @@ class Intensifier(AbstractRacer):
             self.logger.debug(
                 "Challenger was the same as the current incumbent; Skipping challenger"
             )
-            return self.get_next_challenger(
+            return self.get_next_run(
                 challengers=challengers,
                 incumbent=incumbent,
                 chooser=chooser,
@@ -821,7 +821,7 @@ class Intensifier(AbstractRacer):
             # If there is no instance, move to a new
             # iteration
             if instance is None and seed is None:
-                return self.get_next_challenger(
+                return self.get_next_run(
                     challengers=challengers,
                     incumbent=incumbent,
                     chooser=chooser,
@@ -873,7 +873,7 @@ class Intensifier(AbstractRacer):
                         capped=False,
                         budget=0.0,
                     )
-                return self.get_next_challenger(
+                return self.get_next_run(
                     challengers=challengers,
                     incumbent=incumbent,
                     chooser=chooser,

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -18,7 +18,7 @@ from smac.runhistory.runhistory import (
 from smac.utils.io.traj_logging import TrajLogger
 from smac.intensification.abstract_racer import (
     AbstractRacer,
-    IntensifierBehest,
+    RunInfoIntent,
     _config_to_run_type,
 )
 from smac.optimizer.epm_configuration_chooser import EPMChooser
@@ -51,43 +51,41 @@ class IntensifierStage(Enum):
 class Intensifier(AbstractRacer):
     """Races challengers against an incumbent
 
-    SMAC's intensification procedure is denoted below.
-    This class honors bellow procedure and implements it's sequential
-    nature via stages (IntensifierStage), which are also highlighted below
+    SMAC's intensification procedure, in detail:
 
-    Procedure 2: Intensify(Θ~new, θinc, M, R, tintensify, Π, cˆ)
+    Procedure 2: Intensify(Θ_new, θ_inc, M, R, t_intensify, Π, cˆ)
     cˆ(θ, Π0) denotes the empirical cost of θ on the subset of instances
     Π0 ⊆ Π, based on the runs in R; maxR is a parameter
+    where:
+    Θ_new: Sequence of parameter settings to evaluate, challengers in this class.
+    θ_inc: incumbent parameter setting, incumbent in this class.
     ____________________________________________________________
-    1 for i := 1, . . . , length(Θ~ new) do
-    2 θnew ← Θ~ new[i]
-                        _____________________
-                        STAGE-->RUN_INCUMBENT
-                        ---------------------
-    3 if R contains less than maxR runs with configuration θinc then
-    4 Π0 ← {π
-    0 ∈ Π | R contains less than or equal number of runs using θinc and π
-    0
-    than using θinc and any other π
-    00 ∈ Π}
-    5 π ← instance sampled uniformly at random from Π0
-    6 s ← seed, drawn uniformly at random
-    7 R ← ExecuteRun(R, θinc, π, s)
-    8 N ← 1
-                        ______________________
-                        STAGE-->RUN_CHALLENGER
-                        ----------------------
-    9 while true do
-    10 Smissing ← hinstance, seedi pairs for which θinc was run before, but not θnew
-    11 Storun ←random subset of Smissing of size min(N, |Smissing|)
-    12 foreach (π, s) ∈ Storun do R ← ExecuteRun(R, θnew, π, s)
-    13 Smissing ← Smissing \ Storun
-    14 Πcommon ← instances for which we previously ran both θinc and θnew
-    15 if cˆ(θnew, Πcommon) > cˆ(θinc, Πcommon) then break
-    16 else if Smissing = ∅ then θinc ← θnew; break
-    17 else N ← 2 · N
-    18 if time spent in this call to this procedure exceeds tintensify and i ≥ 2 then break
-    19 return [R, θinc]
+    1 for i := 1, . . . , length(Θ_new) do
+    2     θ_new ← Θ_new[i]
+                            _____________________
+                            STAGE-->RUN_INCUMBENT
+                            ---------------------
+    3     if R contains less than maxR runs with configuration θ_inc then
+    4         Π' ← {π'∈ Π | R contains less than or equal number of runs using θ_inc and π'
+    0         than using θ_inc and any other π''∈ Π}
+    5         π ← instance sampled uniformly at random from Π'
+    6         s ← seed, drawn uniformly at random
+    7         R ← ExecuteRun(R, θ_inc, π, s)
+    8     N ← 1
+                            ______________________
+                            STAGE-->RUN_CHALLENGER
+                            ----------------------
+    9     while true do
+   10         S_missing ← {instance, seed} pairs for which θ_inc was run before, but not θ_new
+   11         S_torun ←random subset of S_missing of size min(N, |S_missing|)
+   12         foreach (π, s) ∈ S_torun do R ← ExecuteRun(R, θ_new, π, s)
+   13         S_missing ← S_missing \ S_torun
+   14         Π_common ← instances for which we previously ran both θ_inc and θ_new
+   15         if cˆ(θ_new, Π_common) > cˆ(θ_inc, Π_common) then break
+   16         else if S_missing = ∅ then θ_inc ← θ_new; break
+   17         else N ← 2 · N
+   18     if time spent in this call to this procedure exceeds t_intensify and i ≥ 2 then break
+   19 return [R, θ_inc]
 
     Parameters
     ----------
@@ -198,7 +196,7 @@ class Intensifier(AbstractRacer):
                      chooser: typing.Optional[EPMChooser],
                      run_history: RunHistory,
                      repeat_configs: bool = True,
-                     ) -> typing.Tuple[IntensifierBehest, RunInfo]:
+                     ) -> typing.Tuple[RunInfoIntent, RunInfo]:
         """
         This procedure is in charge of generating a RunInfo object to comply
         with lines 7 (in case stage is stage==RUN_INCUMBENT) or line 12
@@ -209,11 +207,11 @@ class Intensifier(AbstractRacer):
         This could happen because no more configurations are available or the new
         configuration to try was already executed.
 
-        To circumvent this, a behest is also returned:
+        To circumvent this, a intent is also returned:
 
-        - (behest=RUN) Run the RunInfo object (Normal Execution
-        - (behest=TERMINATE) No more challengers available (Line 19 should occur)
-        - (behest=SKIP) Skip this iteration. No challenger is available, in particular
+        - (intent=RUN) Run the RunInfo object (Normal Execution
+        - (intent=STOP_ITERATION) No more challengers available (Line 19 should occur)
+        - (intent=SKIP) Skip this iteration. No challenger is available, in particular
             because challenger is the same as incumbent
 
 
@@ -232,11 +230,17 @@ class Intensifier(AbstractRacer):
 
         Returns
         -------
-        behest: IntensifierBehest
+        intent: RunInfoIntent
             What should the smbo object do with the runinfo.
         run_info: RunInfo
             An object that encapsulates necessary information for a config run
         """
+
+        # If this function is called, it means the iteration is
+        # not complete (we can be starting a new iteration, or re-running a
+        # challenger due to line 17). We evaluate if a iteration is complete or not
+        # via _process_results
+        self.iteration_done = False
 
         # In case a crash happens, and FirstRunCrashedException prevents a
         # failure, revert back to running the incumbent
@@ -247,155 +251,175 @@ class Intensifier(AbstractRacer):
         elif self.stage == IntensifierStage.PROCESS_INCUMBENT_RUN:
             self.stage = IntensifierStage.RUN_INCUMBENT
 
-        try:
-
-            # Line 2:
-            # Understand who is the challenger.
-            # Not necessarily a challenger is always a new configuration,
-            # as this method might be called multiple times to
-            # gain more confidence on incumbent, or even run the same
-            # challenger on multiple N (line 17)
-            challenger = self.query_challenger(
-                challengers=challengers,
-                chooser=chooser,
-                run_history=run_history,
-                repeat_configs=repeat_configs,
-            )
-
-            # if first ever run, then assume current challenger to be the incumbent
-            # In this case, we need a branch new challenger
-            if self.stage == IntensifierStage.RUN_FIRST_CONFIG:
-                if incumbent is None:
-                    self.logger.info(
-                        "First run, no incumbent provided;"
-                        " challenger is assumed to be the incumbent"
-                    )
-                    incumbent = challenger
-                else:
-                    inc_runs = run_history.get_runs_for_config(
-                        incumbent,
-                        only_max_observed_budget=True
-                    )
-                    if len(inc_runs) > 0:
-                        self.logger.debug(
-                            "Skipping RUN_FIRST_CONFIG stage since "
-                            "incumbent is already run before"
-                        )
-                        self.stage = IntensifierStage.RUN_INCUMBENT
-
-            # Before we proceed with the intensification loop,
-            # we have to check if it makes sense to run the challenger
-            # That is, if running lines 8-18 but there is no more time due
-            # to adaptive caping or there are no more instances to run
-            # then we can proactively assume we will do a new intensification
-            # round
-            if self.stage in [IntensifierStage.RUN_CHALLENGER, IntensifierStage.RUN_BASIS]:
-                if not self.to_run:
-                    self.to_run, self.inc_sum_cost = self._get_instances_to_run(
-                        incumbent=incumbent,
-                        challenger=challenger,
-                        run_history=run_history,
-                        N=self.N
-                    )
-
-                is_there_time_due_to_adaptive_cap = self._is_there_time_due_to_adaptive_cap(
-                    challenger=challenger,
-                    run_history=run_history,
+        # if first ever run, then assume current challenger to be the incumbent
+        # Because this is the first ever run, we need to sample a new challenger
+        # This new challenger is also assumed to be the incumbent
+        if self.stage == IntensifierStage.RUN_FIRST_CONFIG:
+            if incumbent is None:
+                self.logger.info(
+                    "First run, no incumbent provided;"
+                    " challenger is assumed to be the incumbent"
                 )
-
-                if len(self.to_run) == 0 or not is_there_time_due_to_adaptive_cap:
-
-                    # If no more time, stage transition is a must
-                    if not is_there_time_due_to_adaptive_cap:
-                        self.stage = IntensifierStage.RUN_INCUMBENT
-                        self.logger.debug(
-                            "Stop challenger itensification due "
-                            "to adaptive capping."
-                        )
-
-                    # Nevertheless, if there are no more instances to run,
-                    # we might need to comply with line 17 and keep running the
-                    # same challenger
-                    self.logger.debug("No further runs for challenger possible")
-                    self._process_racer_results(
-                        challenger=challenger,
-                        incumbent=incumbent,
-                        run_history=run_history,
-                    )
-
-                    # Remove the challenger
-                    if challengers:
-                        challengers = [c for c in challengers if c != challenger]
-                    challenger = self.query_challenger(
-                        challengers=challengers,
-                        chooser=chooser,
-                        run_history=run_history,
-                        repeat_configs=repeat_configs,
-                    )
-
-            # LINES 3-7
-            if self.stage in [IntensifierStage.RUN_FIRST_CONFIG, IntensifierStage.RUN_INCUMBENT]:
-
-                # Line 3
-                # A modified version, that not only checks for maxR
-                # but also makes sure that there are runnable instances,
-                # that is, instances has not been exhausted
+                challenger, self.new_challenger = self.get_next_challenger(
+                    challengers=challengers,
+                    chooser=chooser,
+                )
+                incumbent = challenger
+            else:
                 inc_runs = run_history.get_runs_for_config(
                     incumbent,
                     only_max_observed_budget=True
                 )
-
-                # Line 4
-                available_insts = self._get_inc_available_inst(incumbent, run_history)
-                if available_insts and len(inc_runs) < self.maxR:
-                    # Lines 5-6-7
-                    instance, seed, cutoff = self._get_next_inc_config(available_insts)
-
-                    instance_specific = "0"
-                    if instance is not None:
-                        instance_specific = self.instance_specifics.get(instance, "0")
-
-                    return IntensifierBehest.RUN, RunInfo(
-                        config=incumbent,
-                        instance=instance,
-                        instance_specific=instance_specific,
-                        seed=seed,
-                        cutoff=cutoff,
-                        capped=False,
-                        budget=0.0,
-                    )
-                else:
-                    # This point marks the transitions from lines 3-7
-                    # to 8-18.
-
+                if len(inc_runs) > 0:
                     self.logger.debug(
-                        "No further instance-seed pairs for incumbent available."
+                        "Skipping RUN_FIRST_CONFIG stage since "
+                        "incumbent has already been ran"
                     )
+                    self.stage = IntensifierStage.RUN_INCUMBENT
 
-                    self.stage = IntensifierStage.RUN_CHALLENGER
+        # LINES 3-7
+        if self.stage in [IntensifierStage.RUN_FIRST_CONFIG, IntensifierStage.RUN_INCUMBENT]:
 
-                    self._process_inc_run(
-                        incumbent=incumbent,
-                        run_history=run_history,
-                    )
+            # Line 3
+            # A modified version, that not only checks for maxR
+            # but also makes sure that there are runnable instances,
+            # that is, instances has not been exhausted
+            inc_runs = run_history.get_runs_for_config(
+                incumbent,
+                only_max_observed_budget=True
+            )
 
-                    # Because we are moving to lines 8-18
-                    # make sure that the challenger is properly
-                    # set
-                    challenger = self.query_challenger(
-                        challengers=challengers,
-                        chooser=chooser,
-                        run_history=run_history,
-                        repeat_configs=repeat_configs,
-                    )
+            # Line 4
+            available_insts = self._get_inc_available_inst(incumbent, run_history)
+            if available_insts and len(inc_runs) < self.maxR:
+                # Lines 5-6-7
+                instance, seed, cutoff = self._get_next_inc_config(available_insts)
 
-            # Skip the iteration if the challenger was previously run
-            if challenger == incumbent and self.stage == IntensifierStage.RUN_CHALLENGER:
-                self.challenger_same_as_incumbent = True
-                self.logger.debug(
-                    "Challenger was the same as the current incumbent; Skipping challenger"
+                instance_specific = "0"
+                if instance is not None:
+                    instance_specific = self.instance_specifics.get(instance, "0")
+
+                return RunInfoIntent.RUN, RunInfo(
+                    config=incumbent,
+                    instance=instance,
+                    instance_specific=instance_specific,
+                    seed=seed,
+                    cutoff=cutoff,
+                    capped=False,
+                    budget=0.0,
                 )
-                return IntensifierBehest.SKIP, RunInfo(
+            else:
+                # This point marks the transitions from lines 3-7
+                # to 8-18.
+
+                self.logger.debug(
+                    "No further instance-seed pairs for incumbent available."
+                )
+
+                self.stage = IntensifierStage.RUN_CHALLENGER
+
+                self._process_inc_run(
+                    incumbent=incumbent,
+                    run_history=run_history,
+                )
+
+        # Understand who is the active challenger.
+        if self.stage == IntensifierStage.RUN_BASIS:
+            # if in RUN_BASIS stage,
+            # return the basis configuration (i.e., `always_race_against`)
+            self.logger.debug("Race against basis configuration after incumbent change.")
+            challenger = self.always_race_against
+        elif self.current_challenger and self.continue_challenger:
+            # if the current challenger could not be rejected,
+            # it is run again on more instances
+            challenger = self.current_challenger
+        else:
+            # Get a new challenger if all instance/pairs have
+            # been completed. Else return the currently running
+            # challenger
+            challenger, self.new_challenger = self.get_next_challenger(
+                challengers=challengers,
+                chooser=chooser,
+            )
+
+        # No new challengers are available for this iteration,
+        # Move to the next iteration. This can only happen
+        # when all configurations for this iteration are exhausted
+        # and have been run in all proposed instance/pairs.
+        if challenger is None:
+            return RunInfoIntent.SKIP, RunInfo(
+                config=None,
+                instance=None,
+                instance_specific="0",
+                seed=0,
+                cutoff=self.cutoff,
+                capped=False,
+                budget=0.0,
+            )
+
+        # Skip the iteration if the challenger was previously run
+        if challenger == incumbent and self.stage == IntensifierStage.RUN_CHALLENGER:
+            self.challenger_same_as_incumbent = True
+            self.logger.debug(
+                "Challenger was the same as the current incumbent; Skipping challenger"
+            )
+            return RunInfoIntent.SKIP, RunInfo(
+                config=None,
+                instance=None,
+                instance_specific="0",
+                seed=0,
+                cutoff=self.cutoff,
+                capped=False,
+                budget=0.0,
+            )
+
+        self.logger.debug("Intensify on %s", challenger)
+        if hasattr(challenger, 'origin'):
+            self.logger.debug("Configuration origin: %s", challenger.origin)
+
+        if self.stage in [IntensifierStage.RUN_CHALLENGER, IntensifierStage.RUN_BASIS]:
+
+            if not self.to_run:
+                self.to_run, self.inc_sum_cost = self._get_instances_to_run(
+                    incumbent=incumbent,
+                    challenger=challenger,
+                    run_history=run_history,
+                    N=self.N
+                )
+
+            is_there_time_due_to_adaptive_cap = self._is_there_time_due_to_adaptive_cap(
+                challenger=challenger,
+                run_history=run_history,
+            )
+
+            # If there is no more configs to run in this iteration, or no more
+            # time to do so, change the current stage base on how the current
+            # challenger performs as compared to the incumbent. This is done
+            # via _process_racer_results
+            if len(self.to_run) == 0 or not is_there_time_due_to_adaptive_cap:
+
+                # If no more time, stage transition is a must
+                if not is_there_time_due_to_adaptive_cap:
+                    self.stage = IntensifierStage.RUN_INCUMBENT
+                    self.logger.debug(
+                        "Stop challenger itensification due "
+                        "to adaptive capping."
+                    )
+
+                # Nevertheless, if there are no more instances to run,
+                # we might need to comply with line 17 and keep running the
+                # same challenger
+                self.logger.debug("No further runs for challenger possible")
+                self._process_racer_results(
+                    challenger=challenger,
+                    incumbent=incumbent,
+                    run_history=run_history,
+                )
+
+                # Request SMBO to skip this run. This function will
+                # be called again, after the _process_racer_results
+                # has updated the intensifier stage
+                return RunInfoIntent.SKIP, RunInfo(
                     config=None,
                     instance=None,
                     instance_specific="0",
@@ -405,11 +429,7 @@ class Intensifier(AbstractRacer):
                     budget=0.0,
                 )
 
-            self.logger.debug("Intensify on %s", challenger)
-            if hasattr(challenger, 'origin'):
-                self.logger.debug("Configuration origin: %s", challenger.origin)
-
-            if self.stage in [IntensifierStage.RUN_CHALLENGER, IntensifierStage.RUN_BASIS]:
+            else:
                 # Lines 8-11
                 incumbent, instance, seed, cutoff = self._get_next_racer(
                     challenger=challenger,
@@ -426,7 +446,7 @@ class Intensifier(AbstractRacer):
                     instance_specific = self.instance_specifics.get(instance, "0")
 
                 # Line 12
-                return IntensifierBehest.RUN, RunInfo(
+                return RunInfoIntent.RUN, RunInfo(
                     config=challenger,
                     instance=instance,
                     instance_specific=instance_specific,
@@ -435,21 +455,8 @@ class Intensifier(AbstractRacer):
                     capped=capped,
                     budget=0.0,
                 )
-            else:
-                raise ValueError('No valid stage found!')
-
-        except NoMoreChallengers:
-            # No new challengers are available even after a request to draw from the
-            # epm/initial configs. This means we exhausted the loop condition on line 1
-            return IntensifierBehest.TERMINATE, RunInfo(
-                config=None,
-                instance=None,
-                instance_specific="0",
-                seed=0,
-                cutoff=self.cutoff,
-                capped=False,
-                budget=0.0,
-            )
+        else:
+            raise ValueError('No valid stage found!')
 
     def process_results(self,
                         challenger: Configuration,
@@ -464,13 +471,14 @@ class Intensifier(AbstractRacer):
         The intensifier stage will be updated based on the results/status
         of a configuration execution.
 
-        During intensification, a the following can happen:
-        -> Challenger raced against incumbent. self.added_challenger_run
-           is set to true and that run result need to be processed
+        During intensification, the following can happen:
+        -> Challenger raced against incumbent
         -> Also, during a challenger run, a capped exception
            can be triggered, where no racer post processing is needed
         -> A run on the incumbent for more confidence needs to
            be processed, IntensifierStage.PROCESS_INCUMBENT_RUN
+        -> The first run results need to be processed
+           (PROCESS_FIRST_CONFIG_RUN)
 
         At the end of any run, checks are done to move to a new iteration.
 
@@ -481,10 +489,10 @@ class Intensifier(AbstractRacer):
             will be used to define the next stage.
         incumbet : typing.Optional[Configuration]
             best configuration so far, None in 1st run
-        run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
+        run_history : RunHistory
             stores all runs we ran so far
             if False, an evaluated configuration will not be generated again
-        time_bound : float, optional (default=2 ** 31 - 1)
+        time_bound : float
             time in [sec] available to perform intensify
         result: RunValue
              Contain the result (status and other methadata) of exercising
@@ -631,7 +639,7 @@ class Intensifier(AbstractRacer):
         ----------
         incumbent: Configuration
             Either challenger or incumbent
-        run_history : smac.runhistory.runhistory.RunHistory
+        run_history : RunHistory
             stores all runs we ran so far
         log_traj: bool
             Whether to log changes of incumbents in trajectory
@@ -673,7 +681,7 @@ class Intensifier(AbstractRacer):
         ----------
         incumbent: Configuration
             Either challenger or incumbent
-        run_history : smac.runhistory.runhistory.RunHistory
+        run_history : RunHistory
             stores all runs we ran so far
         log_traj: bool
             Whether to log changes of incumbents in trajectory
@@ -721,7 +729,7 @@ class Intensifier(AbstractRacer):
             Configuration which challenges incumbent
         incumbent : Configuration
             Best configuration so far
-        run_history : smac.runhistory.runhistory.RunHistory
+        run_history : RunHistory
             Stores all runs we ran so far
         log_traj: bool
                Whether to log changes of incumbents in trajectory
@@ -781,7 +789,7 @@ class Intensifier(AbstractRacer):
         ----------
         challenger : Configuration
             Configuration which challenges incumbent
-        run_history : smac.runhistory.runhistory.RunHistory
+        run_history : RunHistory
             Stores all runs we ran so far
         Returns
         -------
@@ -817,7 +825,7 @@ class Intensifier(AbstractRacer):
             Configuration which challenges incumbent
         incumbent : Configuration
             Best configuration so far
-        run_history : smac.runhistory.runhistory.RunHistory
+        run_history : RunHistory
             Stores all runs we ran so far
 
         Returns
@@ -883,7 +891,7 @@ class Intensifier(AbstractRacer):
             incumbent configuration
         challenger: Configuration
             promising configuration that is presently being evaluated
-        run_history: smac.runhistory.runhistory.RunHistory
+        run_history: RunHistory
             Stores all runs we ran so far
         N: int
             number of <instance, seed> pairs to select
@@ -920,96 +928,23 @@ class Intensifier(AbstractRacer):
 
         return to_run, inc_sum_cost
 
-    def query_challenger(self,
-                         challengers: typing.Optional[typing.List[Configuration]],
-                         chooser: typing.Optional[EPMChooser],
-                         run_history: typing.Optional[RunHistory] = None,
-                         repeat_configs: bool = True) -> Configuration:
-        """
-        Handy wrapper around _query challenger to try to get a new configuration.
-
-        In case of failure, it raise a NoMoreChallengers exception, suggesting
-        a termination of the intensification procedure as there are no more
-        challengers to be extracted from the initial configs/epm
-
-        Parameters
-        ----------
-        challengers : typing.List[Configuration]
-            promising configurations
-        chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
-            optimizer that generates next configurations to use for racing
-        run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
-            stores all runs we ran so far
-        repeat_configs : bool
-            if False, an evaluated configuration will not be generated again
-
-        Returns
-        -------
-        typing.Optional[Configuration]
-            next configuration to evaluate
-        bool
-            flag telling if the configuration is newly sampled or one currently being tracked
-
-        Raises
-        ------
-        NoMoreChallengers:
-            Indication that for this iterations, no more challengers are pertinent.
-            The caller should catch this to proceed with a new iteration accordingly.
-        """
-        # Line 8-18
-        # Query if a new challenger is required based on the stage
-        # No new challenger is required if we continue running a challenger
-        # or we gain confidence on the incumbent. In any other case, a new
-        # challenger is generated, which marks a new iteration of the for in line 1
-        try:
-            challenger, self.new_challenger = self._query_challenger(
-                challengers=challengers,
-                chooser=chooser,
-                run_history=run_history,
-                repeat_configs=repeat_configs,
-            )
-        except StopIteration:
-            # out of challengers for the current iteration, start next incumbent iteration
-            self._next_iteration()
-            try:
-                challenger, self.new_challenger = self._query_challenger(
-                    challengers=challengers,
-                    chooser=chooser,
-                    run_history=run_history,
-                    repeat_configs=repeat_configs,
-                )
-            except StopIteration:
-                raise NoMoreChallengers()
-
-        return challenger
-
-    def _query_challenger(self,
-                          challengers: typing.Optional[typing.List[Configuration]],
-                          chooser: typing.Optional[EPMChooser],
-                          run_history: typing.Optional[RunHistory] = None,
-                          repeat_configs: bool = True) -> \
+    def get_next_challenger(self,
+                            challengers: typing.Optional[typing.List[Configuration]],
+                            chooser: typing.Optional[EPMChooser],
+                            ) -> \
             typing.Tuple[typing.Optional[Configuration], bool]:
         """
-        The intensify procedure can be called multiple times for the same configuration.
+        This function returns the next challenger, that should be exercised
+        though lines 8-17.
 
-        That is, not necessarily a new challenger will be produce, as following scenarios
-        are relevant (in order of priority):
+        It does so by populating configs_to_run, which is a pool of configuration
+        from which the racer will sample. Each configuration within configs_to_run,
+        will be intensified on different instances/seed registered in self.to_run
+        as stated in line 11.
 
-        -> RUN_BASIS:
-            Prioritize running against a configuration
-        -> Line 17:
-            Not enough N runs available to decide if the challenger is better/worst than
-            the incumbent, so continue challenger is honored.
-        -> Line 2/11:
-            Get a new configuration to intensify
-        -> Line 3-7:
-            Keep going over incumbent
+        A brand new configuration should only be sampled, after all self.to_run
+        instance seed pairs are exhausted.
 
-        Regarding challengers, the first iteration will choose configurations from the
-        ``chooser`` or input challengers, while the later iterations pick top configurations
-        from the previously selected challengers in that iteration
-
-        This proposed challenger can be None, which marks the start of a new iteration.
 
         Parameters
         ----------
@@ -1017,10 +952,6 @@ class Intensifier(AbstractRacer):
             promising configurations
         chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
             optimizer that generates next configurations to use for racing
-        run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
-            stores all runs we ran so far
-        repeat_configs : bool
-            if False, an evaluated configuration will not be generated again
 
         Returns
         -------
@@ -1029,24 +960,7 @@ class Intensifier(AbstractRacer):
         bool
             flag telling if the configuration is newly sampled or one currently being tracked
 
-        Raises
-        ------
-        StopIteration:
-            Indication that for this iterations, no more challengers are pertinent.
-            The caller should catch this to proceed with a new iteration accordingly.
         """
-
-        # sampling from next challenger marks the beginning of a new iteration
-        self.iteration_done = False
-
-        # if in RUN_BASIS stage, return the basis configuration (i.e., `always_race_against`)
-        if self.stage == IntensifierStage.RUN_BASIS:
-            self.logger.debug("Race against basis configuration after incumbent change.")
-            return self.always_race_against, False
-
-        # if the current challenger could not be rejected, it is run again on more instances
-        if self.current_challenger and self.continue_challenger:
-            return self.current_challenger, False
 
         # select new configuration when entering 'race challenger' stage
         # or for the first run
@@ -1060,7 +974,12 @@ class Intensifier(AbstractRacer):
                 self.update_configs_to_run = False
 
             # pick next configuration from the generator
-            challenger = next(self.configs_to_run)
+            try:
+                challenger = next(self.configs_to_run)
+            except StopIteration:
+                # out of challengers for the current iteration, start next incumbent iteration
+                self._next_iteration()
+                return None, False
 
             if challenger:
                 # reset instance index for the new challenger

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -16,12 +16,22 @@ from smac.runhistory.runhistory import (
     StatusType
 )
 from smac.utils.io.traj_logging import TrajLogger
-from smac.intensification.abstract_racer import AbstractRacer, _config_to_run_type
+from smac.intensification.abstract_racer import (
+    AbstractRacer,
+    IntensifierBehest,
+    _config_to_run_type,
+)
 from smac.optimizer.epm_configuration_chooser import EPMChooser
 
 __author__ = "Katharina Eggensperger, Marius Lindauer"
 __copyright__ = "Copyright 2018, ML4AAD"
 __license__ = "3-clause BSD"
+
+
+class NoMoreChallengers(Exception):
+    """Indicates that no more challengers are available
+    for the intensification to proceed"""
+    pass
 
 
 class IntensifierStage(Enum):
@@ -31,10 +41,53 @@ class IntensifierStage(Enum):
     RUN_CHALLENGER = 2  # Lines 8-17
     RUN_BASIS = 3
 
+    # helpers to determine what type of run to process
+    # A challenger is assumed to be processed if the stage
+    # is not from first_config or incumbent
+    PROCESS_FIRST_CONFIG_RUN = 4
+    PROCESS_INCUMBENT_RUN = 5
+
 
 class Intensifier(AbstractRacer):
-    """Races challengers against an incumbent (a.k.a. SMAC's intensification
-    procedure).
+    """Races challengers against an incumbent
+
+    SMAC's intensification procedure is denoted below.
+    This class honors bellow procedure and implements it's sequential
+    nature via stages (IntensifierStage), which are also highlighted below
+
+    Procedure 2: Intensify(Θ~new, θinc, M, R, tintensify, Π, cˆ)
+    cˆ(θ, Π0) denotes the empirical cost of θ on the subset of instances
+    Π0 ⊆ Π, based on the runs in R; maxR is a parameter
+    ____________________________________________________________
+    1 for i := 1, . . . , length(Θ~ new) do
+    2 θnew ← Θ~ new[i]
+                        _____________________
+                        STAGE-->RUN_INCUMBENT
+                        ---------------------
+    3 if R contains less than maxR runs with configuration θinc then
+    4 Π0 ← {π
+    0 ∈ Π | R contains less than or equal number of runs using θinc and π
+    0
+    than using θinc and any other π
+    00 ∈ Π}
+    5 π ← instance sampled uniformly at random from Π0
+    6 s ← seed, drawn uniformly at random
+    7 R ← ExecuteRun(R, θinc, π, s)
+    8 N ← 1
+                        ______________________
+                        STAGE-->RUN_CHALLENGER
+                        ----------------------
+    9 while true do
+    10 Smissing ← hinstance, seedi pairs for which θinc was run before, but not θnew
+    11 Storun ←random subset of Smissing of size min(N, |Smissing|)
+    12 foreach (π, s) ∈ Storun do R ← ExecuteRun(R, θnew, π, s)
+    13 Smissing ← Smissing \ Storun
+    14 Πcommon ← instances for which we previously ran both θinc and θnew
+    15 if cˆ(θnew, Πcommon) > cˆ(θinc, Πcommon) then break
+    16 else if Smissing = ∅ then θinc ← θnew; break
+    17 else N ← 2 · N
+    18 if time spent in this call to this procedure exceeds tintensify and i ≥ 2 then break
+    19 return [R, θinc]
 
     Parameters
     ----------
@@ -70,7 +123,8 @@ class Intensifier(AbstractRacer):
     adaptive_capping_slackfactor: float
         slack factor of adpative capping (factor * adpative cutoff)
     min_chall: int
-        minimal number of challengers to be considered (even if time_bound is exhausted earlier)
+        minimal number of challengers to be considered
+        (even if time_bound is exhausted earlier)
     """
 
     def __init__(self,
@@ -133,26 +187,271 @@ class Intensifier(AbstractRacer):
         self.configs_to_run = iter([])  # type: _config_to_run_type
         self.update_configs_to_run = True
 
-        # Status Tracking variables
-        # To handle multi-stage transition
-
-        # When racing challengers, a
-        # challenger competes against incumbent
-        # We wait for the run to complete, and
-        # then post process the racer result
-        # this variable is an indicator to do that
-        self.added_challenger_run = False
-
-        # To gain more confidence over the incumbent
-        # we run another instance on that configuration.
-        # When the run is complete, we need to compare the configs
-        # This variables indicates when to do so
-        self.added_incumbent_run = False
-
         # racing related variables
         self.to_run = []  # type: typing.List[InstSeedBudgetKey]
         self.inc_sum_cost = np.inf
         self.N = -1
+
+    def get_next_run(self,
+                     challengers: typing.Optional[typing.List[Configuration]],
+                     incumbent: Configuration,
+                     chooser: typing.Optional[EPMChooser],
+                     run_history: RunHistory,
+                     repeat_configs: bool = True,
+                     ) -> typing.Tuple[IntensifierBehest, RunInfo]:
+        """
+        This procedure is in charge of generating a RunInfo object to comply
+        with lines 7 (in case stage is stage==RUN_INCUMBENT) or line 12
+        (In case of stage==RUN_CHALLENGER)
+
+        A RunInfo object encapsulates the necessary information for a worker
+        to execute the job, nevertheless, a challenger is not always available.
+        This could happen because no more configurations are available or the new
+        configuration to try was already executed.
+
+        To circumvent this, a behest is also returned:
+
+        - (behest=RUN) Run the RunInfo object (Normal Execution
+        - (behest=TERMINATE) No more challengers available (Line 19 should occur)
+        - (behest=SKIP) Skip this iteration. No challenger is available, in particular
+            because challenger is the same as incumbent
+
+
+        Parameters
+        ----------
+        challengers : typing.List[Configuration]
+            promising configurations
+        incumbent: Configuration
+            incumbent configuration
+        chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
+            optimizer that generates next configurations to use for racing
+        run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
+            stores all runs we ran so far
+        repeat_configs : bool
+            if False, an evaluated configuration will not be generated again
+
+        Returns
+        -------
+        behest: IntensifierBehest
+            What should the smbo object do with the runinfo.
+        run_info: RunInfo
+            An object that encapsulates necessary information for a config run
+        """
+
+        # In case a crash happens, and FirstRunCrashedException prevents a
+        # failure, revert back to running the incumbent
+        # Challenger case is by construction ok, as there is no special
+        # stage for its processing
+        if self.stage == IntensifierStage.PROCESS_FIRST_CONFIG_RUN:
+            self.stage = IntensifierStage.RUN_FIRST_CONFIG
+        elif self.stage == IntensifierStage.PROCESS_INCUMBENT_RUN:
+            self.stage = IntensifierStage.RUN_INCUMBENT
+
+        try:
+
+            # Line 2:
+            # Understand who is the challenger.
+            # Not necessarily a challenger is always a new configuration,
+            # as this method might be called multiple times to
+            # gain more confidence on incumbent, or even run the same
+            # challenger on multiple N (line 17)
+            challenger = self.query_challenger(
+                challengers=challengers,
+                chooser=chooser,
+                run_history=run_history,
+                repeat_configs=repeat_configs,
+            )
+            print(f"Using challenger = {challenger}")
+
+            # if first ever run, then assume current challenger to be the incumbent
+            # In this case, we need a branch new challenger
+            if self.stage == IntensifierStage.RUN_FIRST_CONFIG:
+                if incumbent is None:
+                    self.logger.info(
+                        "First run, no incumbent provided;"
+                        " challenger is assumed to be the incumbent"
+                    )
+                    incumbent = challenger
+                else:
+                    inc_runs = run_history.get_runs_for_config(
+                        incumbent,
+                        only_max_observed_budget=True
+                    )
+                    if len(inc_runs) > 0:
+                        self.logger.debug(
+                            "Skipping RUN_FIRST_CONFIG stage since "
+                            "incumbent is already run before"
+                        )
+                        self.stage = IntensifierStage.RUN_INCUMBENT
+
+            # Before we proceed with the intensification loop,
+            # we have to check if it makes sense to run the challenger
+            # That is, if running lines 8-18 but there is no more time due
+            # to adaptive caping or there are no more instances to run
+            # then we can proactively assume we will do a new intensification
+            # round
+            if self.stage in [IntensifierStage.RUN_CHALLENGER, IntensifierStage.RUN_BASIS]:
+                if not self.to_run:
+                    self.to_run, self.inc_sum_cost = self._get_instances_to_run(
+                        incumbent=incumbent,
+                        challenger=challenger,
+                        run_history=run_history,
+                        N=self.N
+                    )
+
+                is_there_time_due_to_adaptive_cap = self._is_there_time_due_to_adaptive_cap(
+                    challenger=challenger,
+                    run_history=run_history,
+                )
+
+                if len(self.to_run) == 0 or not is_there_time_due_to_adaptive_cap:
+
+                    # If no more time, stage transition is a must
+                    if not is_there_time_due_to_adaptive_cap:
+                        self.stage = IntensifierStage.RUN_INCUMBENT
+                        self.logger.debug(
+                            "Stop challenger itensification due "
+                            "to adaptive capping."
+                        )
+
+                    # Nevertheless, if there are no more instances to run,
+                    # we might need to comply with line 17 and keep running the
+                    # same challenger
+                    self.logger.debug("No further runs for challenger possible")
+                    self._process_racer_results(
+                        challenger=challenger,
+                        incumbent=incumbent,
+                        run_history=run_history,
+                    )
+
+                    # Remove the challenger
+                    if challengers:
+                        challengers = [c for c in challengers if c != challenger]
+                    challenger = self.query_challenger(
+                        challengers=challengers,
+                        chooser=chooser,
+                        run_history=run_history,
+                        repeat_configs=repeat_configs,
+                    )
+
+            # LINES 3-7
+            if self.stage in [IntensifierStage.RUN_FIRST_CONFIG, IntensifierStage.RUN_INCUMBENT]:
+
+                # Line 3
+                # A modified version, that not only checks for maxR
+                # but also makes sure that there are runnable instances,
+                # that is, instances has not been exhausted
+                inc_runs = run_history.get_runs_for_config(
+                    incumbent,
+                    only_max_observed_budget=True
+                )
+
+                # Line 4
+                available_insts = self._get_inc_available_inst(incumbent, run_history)
+                if available_insts and len(inc_runs) < self.maxR:
+                    # Lines 5-6-7
+                    instance, seed, cutoff = self._get_next_inc_config(available_insts)
+
+                    instance_specific = "0"
+                    if instance is not None:
+                        instance_specific = self.instance_specifics.get(instance, "0")
+
+                    return IntensifierBehest.RUN, RunInfo(
+                        config=incumbent,
+                        instance=instance,
+                        instance_specific=instance_specific,
+                        seed=seed,
+                        cutoff=cutoff,
+                        capped=False,
+                        budget=0.0,
+                    )
+                else:
+                    # This point marks the transitions from lines 3-7
+                    # to 8-18.
+
+                    self.logger.debug(
+                        "No further instance-seed pairs for incumbent available."
+                    )
+
+                    self.stage = IntensifierStage.RUN_CHALLENGER
+
+                    self._process_inc_run(
+                        incumbent=incumbent,
+                        run_history=run_history,
+                    )
+
+                    # Because we are moving to lines 8-18
+                    # make sure that the challenger is properly
+                    # set
+                    challenger = self.query_challenger(
+                        challengers=challengers,
+                        chooser=chooser,
+                        run_history=run_history,
+                        repeat_configs=repeat_configs,
+                    )
+
+            # Skip the iteration if the challenger was previously run
+            if challenger == incumbent and self.stage == IntensifierStage.RUN_CHALLENGER:
+                self.challenger_same_as_incumbent = True
+                self.logger.debug(
+                    "Challenger was the same as the current incumbent; Skipping challenger"
+                )
+                return IntensifierBehest.SKIP, RunInfo(
+                    config=None,
+                    instance=None,
+                    instance_specific="0",
+                    seed=0,
+                    cutoff=self.cutoff,
+                    capped=False,
+                    budget=0.0,
+                )
+
+            self.logger.debug("Intensify on %s", challenger)
+            if hasattr(challenger, 'origin'):
+                self.logger.debug("Configuration origin: %s", challenger.origin)
+
+            print(f"stage={self.stage}")
+            if self.stage in [IntensifierStage.RUN_CHALLENGER, IntensifierStage.RUN_BASIS]:
+                # Lines 8-11
+                incumbent, instance, seed, cutoff = self._get_next_racer(
+                    challenger=challenger,
+                    incumbent=incumbent,
+                    run_history=run_history,
+                )
+
+                capped = False
+                if (self.cutoff is not None) and (cutoff < self.cutoff):  # type: ignore[operator] # noqa F821
+                    capped = True
+
+                instance_specific = "0"
+                if instance is not None:
+                    instance_specific = self.instance_specifics.get(instance, "0")
+
+                # Line 12
+                return IntensifierBehest.RUN, RunInfo(
+                    config=challenger,
+                    instance=instance,
+                    instance_specific=instance_specific,
+                    seed=seed,
+                    cutoff=cutoff,
+                    capped=capped,
+                    budget=0.0,
+                )
+            else:
+                raise ValueError('No valid stage found!')
+
+        except NoMoreChallengers:
+            # No new challengers are available even after a request to draw from the
+            # epm/initial configs. This means we exhausted the loop condition on line 1
+            return IntensifierBehest.TERMINATE, RunInfo(
+                config=None,
+                instance=None,
+                instance_specific="0",
+                seed=0,
+                cutoff=self.cutoff,
+                capped=False,
+                budget=0.0,
+            )
 
     def process_results(self,
                         challenger: Configuration,
@@ -173,7 +472,7 @@ class Intensifier(AbstractRacer):
         -> Also, during a challenger run, a capped exception
            can be triggered, where no racer post processing is needed
         -> A run on the incumbent for more confidence needs to
-           be processed, in such case self.added_incumbent_run is True
+           be processed, IntensifierStage.PROCESS_INCUMBENT_RUN
 
         At the end of any run, checks are done to move to a new iteration.
 
@@ -202,7 +501,7 @@ class Intensifier(AbstractRacer):
         inc_perf: float
             empirical performance of incumbent configuration
         """
-        if self.stage == IntensifierStage.RUN_FIRST_CONFIG:
+        if self.stage == IntensifierStage.PROCESS_FIRST_CONFIG_RUN:
             if incumbent is None:
                 self.logger.info(
                     "First run, no incumbent provided;"
@@ -210,17 +509,17 @@ class Intensifier(AbstractRacer):
                 )
                 incumbent = challenger
 
-        if self.added_incumbent_run:
+        if self.stage in [IntensifierStage.PROCESS_INCUMBENT_RUN,
+                          IntensifierStage.PROCESS_FIRST_CONFIG_RUN]:
             self._ta_time += result.time
             self.num_run += 1
-            self.added_incumbent_run = False
             self._process_inc_run(
                 incumbent=incumbent,
                 run_history=run_history,
                 log_traj=log_traj,
             )
 
-        if self.added_challenger_run:
+        else:
             self.num_run += 1
             self.num_chall_run += 1
             if result.status == StatusType.CAPPED:
@@ -233,7 +532,6 @@ class Intensifier(AbstractRacer):
             else:
 
                 self._ta_time += result.time
-                self.added_challenger_run = False
                 incumbent = self._process_racer_results(
                     challenger=challenger,
                     incumbent=incumbent,
@@ -242,54 +540,94 @@ class Intensifier(AbstractRacer):
                 )
 
         elapsed_time = result.endtime - result.starttime
-        if not result.status == StatusType.BUDGETEXHAUSTED:
-            # check if 1 intensification run is complete - line 18
-            # this is different to regular SMAC as it requires at least successful challenger run,
-            # which is necessary to work on a fixed grid of configurations.
-            if (
-                self.stage == IntensifierStage.RUN_INCUMBENT
-                and self._chall_indx >= self.min_chall
-                and self.num_chall_run > 0
-            ):
-                if self.num_run > self.run_limit:
-                    self.logger.info("Maximum #runs for intensification reached")
-                    self._next_iteration()
+        # check if 1 intensification run is complete - line 18
+        # this is different to regular SMAC as it requires at least successful challenger run,
+        # which is necessary to work on a fixed grid of configurations.
+        if (
+            self.stage == IntensifierStage.RUN_INCUMBENT
+            and self._chall_indx >= self.min_chall
+            and self.num_chall_run > 0
+        ):
+            if self.num_run > self.run_limit:
+                self.logger.info("Maximum #runs for intensification reached")
+                self._next_iteration()
 
-                if not self.use_ta_time_bound and elapsed_time - time_bound >= 0:
-                    self.logger.info(
-                        "Wallclock time limit for intensification reached "
-                        "(used: %f sec, available: %f sec)",
-                        elapsed_time,
-                        time_bound
-                    )
+            if not self.use_ta_time_bound and elapsed_time - time_bound >= 0:
+                self.logger.info(
+                    "Wallclock time limit for intensification reached "
+                    "(used: %f sec, available: %f sec)",
+                    elapsed_time,
+                    time_bound
+                )
 
-                    self._next_iteration()
+                self._next_iteration()
 
-                elif self._ta_time - time_bound >= 0:
-                    self.logger.info(
-                        "TA time limit for intensification reached (used: %f sec, available: %f sec)",
-                        self._ta_time, time_bound
-                    )
+            elif self._ta_time - time_bound >= 0:
+                self.logger.info(
+                    "TA time limit for intensification reached (used: %f sec, available: %f sec)",
+                    self._ta_time, time_bound
+                )
 
-                    self._next_iteration()
+                self._next_iteration()
 
         inc_perf = run_history.get_cost(incumbent)
 
         return incumbent, inc_perf
 
-    def _get_next_inc(self,
-                      incumbent: Configuration,
-                      run_history: RunHistory,
-                      log_traj: bool = True,
-                      ) -> \
-            typing.Tuple[
-                typing.Optional[Configuration],
-                typing.Optional[str],
-                typing.Optional[float],
-                typing.Optional[float]]:
+    def _get_next_inc_config(self,
+                             available_insts: typing.List[str],
+                             ) -> typing.Tuple[str, int, typing.Optional[float]]:
         """Method to extract the next seed/instance in which a
-        incumbent run most be evaluated. Defaults to None if no new
-        incumbent config can be found.
+        incumbent run most be evaluated.
+
+        Parameters
+        ----------
+        available_insts : typing.List[str]
+            A list of instances from which to extract the next incumbent run
+
+        Returns
+        -------
+        instance: str
+            Next instance to evaluate
+        seed: float
+            Seed in which to evaluate the instance
+        cutoff: Optional[float]
+            Max time for a given instance/seed pair
+
+        """
+        # Line 5
+        next_instance = self.rs.choice(available_insts)
+
+        # Line 6
+        if self.deterministic:
+            next_seed = 0
+        else:
+            next_seed = self.rs.randint(low=0, high=MAXINT, size=1)[0]
+
+        # Line 7
+        self.logger.debug(
+            "Add run of incumbent for instance={}".format(
+                next_instance
+            )
+        )
+        if self.stage == IntensifierStage.RUN_FIRST_CONFIG:
+            self.stage = IntensifierStage.PROCESS_FIRST_CONFIG_RUN
+        else:
+            self.stage = IntensifierStage.PROCESS_INCUMBENT_RUN
+
+        return next_instance, next_seed, self.cutoff
+
+    def _get_inc_available_inst(
+        self,
+        incumbent: Configuration,
+        run_history: RunHistory,
+        log_traj: bool = True,
+    ) -> typing.List[str]:
+        """
+        Implementation of line 4 of Intensification
+
+        This method queries the inc runs in the run history
+        and return the pending instances if any is available
 
         Parameters
         ----------
@@ -300,89 +638,30 @@ class Intensifier(AbstractRacer):
         log_traj: bool
             Whether to log changes of incumbents in trajectory
 
-        Returns
-        -------
-        incumbent: typing.Optional[Configuration]
-            Best configuration seen so far
-        instance: typing.Optional[str]
-            Next instance to evaluate
-        seed: typing.Optional[float]
-            Seed in which to evaluate the instance
-        cutoff: typing.Optional[float]
-            Max time for a given instance/seed pair
-
         """
+        # Line 4
+        # find all instances that have the most runs on the inc
         inc_runs = run_history.get_runs_for_config(
             incumbent,
             only_max_observed_budget=True
         )
+        inc_inst = [s.instance for s in inc_runs]
+        inc_inst = list(Counter(inc_inst).items())
+        inc_inst.sort(key=lambda x: x[1], reverse=True)
+        try:
+            max_runs = inc_inst[0][1]
+        except IndexError:
+            self.logger.debug("No run for incumbent found")
+            max_runs = 0
+        inc_inst = [x[0] for x in inc_inst if x[1] == max_runs]
 
-        # Line 3
-        # First evaluate incumbent on a new instance
-        # seed/instance can be None and hence no config run needed
-        next_instance = None
-        next_seed = None
-        if len(inc_runs) < self.maxR:
-            # Line 4
-            # find all instances that have the most runs on the inc
-            inc_runs = run_history.get_runs_for_config(
-                incumbent,
-                only_max_observed_budget=True
-            )
-            inc_inst = [s.instance for s in inc_runs]
-            inc_inst = list(Counter(inc_inst).items())
-            inc_inst.sort(key=lambda x: x[1], reverse=True)
-            try:
-                max_runs = inc_inst[0][1]
-            except IndexError:
-                self.logger.debug("No run for incumbent found")
-                max_runs = 0
-            inc_inst = [x[0] for x in inc_inst if x[1] == max_runs]
+        available_insts = list(sorted(set(self.instances) - set(inc_inst)))
 
-            available_insts = list(sorted(set(self.instances) - set(inc_inst)))
-
-            # if all instances were used n times, we can pick an instances
-            # from the complete set again
-            if not self.deterministic and not available_insts:
-                available_insts = self.instances
-
-            if available_insts:
-                # Line 6 (Line 5 is further down...)
-                if self.deterministic:
-                    next_seed = 0
-                else:
-                    next_seed = self.rs.randint(low=0, high=MAXINT, size=1)[0]
-
-                # Line 5 (here for easier code)
-                next_instance = self.rs.choice(available_insts)
-                # Line 7
-                self.logger.debug(
-                    "Add run of incumbent for instance={}".format(
-                        next_instance
-                    )
-                )
-                self.added_incumbent_run = True
-            else:
-                self.logger.debug("No further instance-seed pairs for "
-                                  "incumbent available.")
-                # stop incumbent runs
-                self.stage = IntensifierStage.RUN_CHALLENGER
-                self._process_inc_run(
-                    incumbent=incumbent,
-                    run_history=run_history,
-                    log_traj=log_traj,
-                )
-        else:
-            # maximum runs for incumbent reached, do not run incumbent
-            self.stage = IntensifierStage.RUN_CHALLENGER
-            self._compare_configs(
-                incumbent=incumbent,
-                challenger=incumbent,
-                run_history=run_history,
-                log_traj=log_traj
-            )
-
-        return incumbent, next_instance, next_seed, self.cutoff
+        # if all instances were used n times, we can pick an instances
+        # from the complete set again
+        if not self.deterministic and not available_insts:
+            available_insts = self.instances
+        return available_insts
 
     def _process_inc_run(self,
                          incumbent: Configuration,
@@ -409,7 +688,8 @@ class Intensifier(AbstractRacer):
                          % (len(inc_runs), inc_perf))
 
         # if running first configuration, go to next stage after 1st run
-        if self.stage == IntensifierStage.RUN_FIRST_CONFIG:
+        if self.stage in [IntensifierStage.RUN_FIRST_CONFIG,
+                          IntensifierStage.PROCESS_FIRST_CONFIG_RUN]:
             self.stage = IntensifierStage.RUN_INCUMBENT
             self._next_iteration()
         else:
@@ -417,6 +697,8 @@ class Intensifier(AbstractRacer):
             # whether further runs are necessary due to minR
             if len(inc_runs) >= self.minR or len(inc_runs) >= self.maxR:
                 self.stage = IntensifierStage.RUN_CHALLENGER
+            else:
+                self.stage = IntensifierStage.RUN_INCUMBENT
 
         self._compare_configs(
             incumbent=incumbent,
@@ -425,17 +707,13 @@ class Intensifier(AbstractRacer):
             log_traj=log_traj
         )
 
-    def _get_next_racer(self,
-                        challenger: Configuration,
-                        incumbent: Configuration,
-                        run_history: RunHistory,
-                        log_traj: bool = True,
-                        ) -> \
-            typing.Tuple[
-                typing.Optional[Configuration],
-                typing.Optional[str],
-                typing.Optional[float],
-                typing.Optional[float]]:
+    def _get_next_racer(
+        self,
+        challenger: Configuration,
+        incumbent: Configuration,
+        run_history: RunHistory,
+        log_traj: bool = True,
+    ) -> typing.Tuple[Configuration, str, int, typing.Optional[float]]:
         """Method to return the next config setting to
         aggressively race challenger against incumbent.
 
@@ -452,59 +730,79 @@ class Intensifier(AbstractRacer):
 
         Returns
         -------
-        new_incumbent: typing.Optional[Configuration]
+        new_incumbent: Configuration
             Either challenger or incumbent
-        instance: typing.Optional[str]
+        instance: str
             Next instance to evaluate
-        seed: typing.Optional[float]
+        seed: int
             Seed in which to evaluate the instance
-        cutoff: typing.Optional[float]
+        cutoff: Optional[float]
             Max time for a given instance/seed pair
         """
 
-        # if list of <instance, seed> to run is not available, compute it
+        # By the time this function is called, the run history might
+        # have shifted. Re-populate the list if necessary
         if not self.to_run:
-            self.to_run, self.inc_sum_cost = self._get_instances_to_run(incumbent=incumbent,
-                                                                        challenger=challenger,
-                                                                        run_history=run_history,
-                                                                        N=self.N)
-        if len(self.to_run) == 0:
-            self.logger.debug("No further runs for challenger available")
-            self._process_racer_results(
-                challenger=challenger,
+
+            # Lines 10/11
+            self.to_run, self.inc_sum_cost = self._get_instances_to_run(
                 incumbent=incumbent,
+                challenger=challenger,
                 run_history=run_history,
-                log_traj=log_traj,
+                N=self.N
             )
 
-            return incumbent, None, None, None
+        # Run challenger on all <instance, seed> to run
+        instance, seed, _ = self.to_run.pop()
 
+        cutoff = self.cutoff
+        if self.run_obj_time:
+            cutoff = self._adapt_cutoff(challenger=challenger,
+                                        run_history=run_history,
+                                        inc_sum_cost=self.inc_sum_cost)
+
+        self.logger.debug('Cutoff for challenger: %s' % str(cutoff))
+
+        self.logger.debug("Add run of challenger")
+
+        # Line 12
+        return incumbent, instance, seed, cutoff
+
+    def _is_there_time_due_to_adaptive_cap(
+        self,
+        challenger: Configuration,
+        run_history: RunHistory,
+    ) -> bool:
+        """
+        A check to see if there is no more time for a challenger
+        given the fact, that we are optimizing time and the
+        incumbent looks more promising
+        Line 18
+
+        Parameters
+        ----------
+        challenger : Configuration
+            Configuration which challenges incumbent
+        run_history : smac.runhistory.runhistory.RunHistory
+            Stores all runs we ran so far
+        Returns
+        -------
+        bool:
+            whether or not there is more time for a challenger run
+        """
+        # If time is not objective, then there is always time!
+        if not self.run_obj_time:
+            return True
+
+        cutoff = self._adapt_cutoff(
+            challenger=challenger,
+            run_history=run_history,
+            inc_sum_cost=self.inc_sum_cost
+        )
+        if cutoff is not None and cutoff <= 0:
+            return False
         else:
-            # Line 12
-            # Run challenger on all <instance, seed> to run
-            instance, seed, _ = self.to_run.pop()
-
-            cutoff = self.cutoff
-            if self.run_obj_time:
-                cutoff = self._adapt_cutoff(challenger=challenger,
-                                            run_history=run_history,
-                                            inc_sum_cost=self.inc_sum_cost)
-                if cutoff is not None and cutoff <= 0:
-                    # no time to validate challenger
-                    self.logger.debug(
-                        "Stop challenger itensification due "
-                        "to adaptive capping."
-                    )
-                    # challenger performance is worse than incumbent
-                    # move on to the next iteration
-                    self.stage = IntensifierStage.RUN_INCUMBENT
-                    return incumbent, None, None, None
-
-            self.logger.debug('Cutoff for challenger: %s' % str(cutoff))
-
-            self.logger.debug("Add run of challenger")
-            self.added_challenger_run = True
-            return incumbent, instance, seed, cutoff
+            return True
 
     def _process_racer_results(self,
                                challenger: Configuration,
@@ -624,16 +922,94 @@ class Intensifier(AbstractRacer):
 
         return to_run, inc_sum_cost
 
-    def _query_next_challenger(self,
-                               challengers: typing.Optional[typing.List[Configuration]],
-                               chooser: typing.Optional[EPMChooser],
-                               run_history: typing.Optional[RunHistory] = None,
-                               repeat_configs: bool = True) -> \
+    def query_challenger(self,
+                         challengers: typing.Optional[typing.List[Configuration]],
+                         chooser: typing.Optional[EPMChooser],
+                         run_history: typing.Optional[RunHistory] = None,
+                         repeat_configs: bool = True) -> Configuration:
+        """
+        Handy wrapper around _query challenger to try to get a new configuration.
+
+        In case of failure, it raise a NoMoreChallengers exception, suggesting
+        a termination of the intensification procedure as there are no more
+        challengers to be extracted from the initial configs/epm
+
+        Parameters
+        ----------
+        challengers : typing.List[Configuration]
+            promising configurations
+        chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
+            optimizer that generates next configurations to use for racing
+        run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
+            stores all runs we ran so far
+        repeat_configs : bool
+            if False, an evaluated configuration will not be generated again
+
+        Returns
+        -------
+        typing.Optional[Configuration]
+            next configuration to evaluate
+        bool
+            flag telling if the configuration is newly sampled or one currently being tracked
+
+        Raises
+        ------
+        NoMoreChallengers:
+            Indication that for this iterations, no more challengers are pertinent.
+            The caller should catch this to proceed with a new iteration accordingly.
+        """
+        # Line 8-18
+        # Query if a new challenger is required based on the stage
+        # No new challenger is required if we continue running a challenger
+        # or we gain confidence on the incumbent. In any other case, a new
+        # challenger is generated, which marks a new iteration of the for in line 1
+        try:
+            challenger, self.new_challenger = self._query_challenger(
+                challengers=challengers,
+                chooser=chooser,
+                run_history=run_history,
+                repeat_configs=repeat_configs,
+            )
+        except StopIteration:
+            # out of challengers for the current iteration, start next incumbent iteration
+            self._next_iteration()
+            try:
+                challenger, self.new_challenger = self._query_challenger(
+                    challengers=challengers,
+                    chooser=chooser,
+                    run_history=run_history,
+                    repeat_configs=repeat_configs,
+                )
+            except StopIteration:
+                raise NoMoreChallengers()
+
+        return challenger
+
+    def _query_challenger(self,
+                          challengers: typing.Optional[typing.List[Configuration]],
+                          chooser: typing.Optional[EPMChooser],
+                          run_history: typing.Optional[RunHistory] = None,
+                          repeat_configs: bool = True) -> \
             typing.Tuple[typing.Optional[Configuration], bool]:
         """
-        Selects which challenger to use based on the iteration stage and set the iteration parameters.
-        First iteration will choose configurations from the ``chooser`` or input challengers,
-        while the later iterations pick top configurations from the previously selected challengers in that iteration
+        The intensify procedure can be called multiple times for the same configuration.
+
+        That is, not necessarily a new challenger will be produce, as following scenarios
+        are relevant (in order of priority):
+
+        -> RUN_BASIS:
+            Prioritize running against a configuration
+        -> Line 17:
+            Not enough N runs available to decide if the challenger is better/worst than
+            the incumbent, so continue challenger is honored.
+        -> Line 2/11:
+            Get a new configuration to intensify
+        -> Line 3-7:
+            Keep going over incumbent
+
+        Regarding challengers, the first iteration will choose configurations from the
+        ``chooser`` or input challengers, while the later iterations pick top configurations
+        from the previously selected challengers in that iteration
 
         This proposed challenger can be None, which marks the start of a new iteration.
 
@@ -654,6 +1030,12 @@ class Intensifier(AbstractRacer):
             next configuration to evaluate
         bool
             flag telling if the configuration is newly sampled or one currently being tracked
+
+        Raises
+        ------
+        StopIteration:
+            Indication that for this iterations, no more challengers are pertinent.
+            The caller should catch this to proceed with a new iteration accordingly.
         """
 
         # sampling from next challenger marks the beginning of a new iteration
@@ -680,12 +1062,7 @@ class Intensifier(AbstractRacer):
                 self.update_configs_to_run = False
 
             # pick next configuration from the generator
-            try:
-                challenger = next(self.configs_to_run)
-            except StopIteration:
-                # out of challengers for the current iteration, start next incumbent iteration
-                self._next_iteration()
-                return None, False
+            challenger = next(self.configs_to_run)
 
             if challenger:
                 # reset instance index for the new challenger
@@ -698,202 +1075,6 @@ class Intensifier(AbstractRacer):
 
         # return currently running challenger
         return self.current_challenger, False
-
-    def get_next_run(self,
-                     challengers: typing.Optional[typing.List[Configuration]],
-                     incumbent: Configuration,
-                     chooser: typing.Optional[EPMChooser],
-                     run_history: RunHistory,
-                     repeat_configs: bool = True,
-                     ) -> RunInfo:
-        """
-        Wrapper around query challengers, to get the next configuration
-        to run, as well as updating the internal state of the intensifier.
-
-        If query challenger suggest a new iteration through a None challenger,
-        this function calls itself recursively until a valid configuration is
-        available.
-        If all runs are exhausted, a None configuration is returned as an indicator that
-        there are no more valid runs to launch
-
-
-        Parameters
-        ----------
-        challengers : typing.List[Configuration]
-            promising configurations
-        incumbent: Configuration
-            incumbent configuration
-        chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
-            optimizer that generates next configurations to use for racing
-        run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
-            stores all runs we ran so far
-        repeat_configs : bool
-            if False, an evaluated configuration will not be generated again
-
-        Returns
-        -------
-        run_info: typing.Optional[RunInfo]
-            An object that encapsulates necessary information for a config run
-        """
-
-        challenger, self.new_challenger = self._query_next_challenger(
-            challengers=challengers,
-            chooser=chooser,
-            run_history=run_history,
-            repeat_configs=repeat_configs,
-        )
-
-        if challenger is None:
-            if challengers == [incumbent]:
-                self.logger.warn(
-                    "New iteration with only the incumbent {}, as "
-                    "valid challengers. The incumbent has already ran, and the next "
-                    "challenger is itself. Nothing more to do".format(
-                        incumbent
-                    )
-                )
-                return RunInfo(
-                    config=None,
-                    instance=None,
-                    instance_specific="0",
-                    seed=0,
-                    cutoff=self.cutoff,
-                    capped=False,
-                    budget=0.0,
-                )
-            return self.get_next_run(
-                challengers=challengers,
-                incumbent=incumbent,
-                chooser=chooser,
-                run_history=run_history,
-                repeat_configs=repeat_configs,
-            )
-
-        if challenger == incumbent and self.stage == IntensifierStage.RUN_CHALLENGER:
-            self.challenger_same_as_incumbent = True
-            self.logger.debug(
-                "Challenger was the same as the current incumbent; Skipping challenger"
-            )
-            return self.get_next_run(
-                challengers=challengers,
-                incumbent=incumbent,
-                chooser=chooser,
-                run_history=run_history,
-                repeat_configs=repeat_configs,
-            )
-
-        # if first ever run, then assume current challenger to be the incumbent
-        if self.stage == IntensifierStage.RUN_FIRST_CONFIG:
-            if incumbent is None:
-                self.logger.info(
-                    "First run, no incumbent provided;"
-                    " challenger is assumed to be the incumbent"
-                )
-                incumbent = challenger
-            else:
-                inc_runs = run_history.get_runs_for_config(
-                    incumbent,
-                    only_max_observed_budget=True
-                )
-                if len(inc_runs) > 0:
-                    self.logger.debug(
-                        "Skipping RUN_FIRST_CONFIG stage since "
-                        "incumbent is already run before"
-                    )
-                    self.stage = IntensifierStage.RUN_INCUMBENT
-
-        self.logger.debug("Intensify on %s", challenger)
-        if hasattr(challenger, 'origin'):
-            self.logger.debug("Configuration origin: %s", challenger.origin)
-
-        # since it runs only 1 "ExecuteRun" per iteration,
-        # we run incumbent once and then challenger in the next
-        if self.stage == IntensifierStage.RUN_FIRST_CONFIG or \
-                self.stage == IntensifierStage.RUN_INCUMBENT:
-            # Lines 3-7
-            incumbent, instance, seed, cutoff = self._get_next_inc(
-                incumbent=incumbent,
-                run_history=run_history,
-            )
-
-            instance_specific = "0"
-            if instance is not None:
-                instance_specific = self.instance_specifics.get(instance, "0")
-
-            # If there is no instance, move to a new
-            # iteration
-            if instance is None and seed is None:
-                return self.get_next_run(
-                    challengers=challengers,
-                    incumbent=incumbent,
-                    chooser=chooser,
-                    run_history=run_history,
-                    repeat_configs=repeat_configs,
-                )
-            else:
-                return RunInfo(
-                    config=incumbent,
-                    instance=instance,
-                    instance_specific=instance_specific,
-                    seed=seed,
-                    cutoff=cutoff,
-                    capped=False,
-                    budget=0.0,
-                )
-        elif self.stage == IntensifierStage.RUN_CHALLENGER or \
-                self.stage == IntensifierStage.RUN_BASIS:
-            # Lines 8-17
-            incumbent, instance, seed, cutoff = self._get_next_racer(
-                challenger=challenger,
-                incumbent=incumbent,
-                run_history=run_history,
-            )
-
-            capped = False
-            if (self.cutoff is not None) and (cutoff < self.cutoff):  # type: ignore[operator] # noqa F821
-                capped = True
-
-            instance_specific = "0"
-            if instance is not None:
-                instance_specific = self.instance_specifics.get(instance, "0")
-
-            if instance is None and seed is None:
-                # Remove the challenger
-                if challengers:
-                    challengers = [c for c in challengers if c != challenger]
-                if not challengers:
-                    self.logger.warn(
-                        "Stage is RUN_CHALLENGER, yet no more challengers are "
-                        "available. "
-                    )
-                    return RunInfo(
-                        config=None,
-                        instance=None,
-                        instance_specific=instance_specific,
-                        seed=0,
-                        cutoff=self.cutoff,
-                        capped=False,
-                        budget=0.0,
-                    )
-                return self.get_next_run(
-                    challengers=challengers,
-                    incumbent=incumbent,
-                    chooser=chooser,
-                    run_history=run_history,
-                    repeat_configs=repeat_configs,
-                )
-            else:
-                return RunInfo(
-                    config=challenger,
-                    instance=instance,
-                    instance_specific=instance_specific,
-                    seed=seed,
-                    cutoff=cutoff,
-                    capped=capped,
-                    budget=0.0,
-                )
-        else:
-            raise ValueError('No valid stage found!')
 
     def _generate_challengers(self,
                               challengers: typing.Optional[typing.List[Configuration]],
@@ -948,5 +1129,3 @@ class Intensifier(AbstractRacer):
 
         self.stats.update_average_configs_per_intensify(
             n_configs=self._chall_indx)
-        self.added_incumbent_run = False
-        self.added_challenger_run = False

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -459,7 +459,7 @@ class Intensifier(AbstractRacer):
                         result: RunValue,
                         log_traj: bool = True,
                         ) -> \
-            typing.Tuple[typing.Optional[Configuration], float]:
+            typing.Tuple[Configuration, float]:
         """
         The intensifier stage will be updated based on the results/status
         of a configuration execution.

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -540,7 +540,7 @@ class Intensifier(AbstractRacer):
                     log_traj=log_traj,
                 )
 
-        elapsed_time = result.endtime - result.starttime
+        self.elapsed_time += (result.endtime - result.starttime)
         # check if 1 intensification run is complete - line 18
         # this is different to regular SMAC as it requires at least successful challenger run,
         # which is necessary to work on a fixed grid of configurations.
@@ -553,11 +553,11 @@ class Intensifier(AbstractRacer):
                 self.logger.info("Maximum #runs for intensification reached")
                 self._next_iteration()
 
-            if not self.use_ta_time_bound and elapsed_time - time_bound >= 0:
+            if not self.use_ta_time_bound and self.elapsed_time - time_bound >= 0:
                 self.logger.info(
                     "Wallclock time limit for intensification reached "
                     "(used: %f sec, available: %f sec)",
-                    elapsed_time,
+                    self.elapsed_time,
                     time_bound
                 )
 

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -8,8 +8,8 @@ from smac.optimizer.epm_configuration_chooser import EPMChooser
 from smac.stats.stats import Stats
 from smac.utils.constants import MAXINT
 from smac.configspace import Configuration
-from smac.runhistory.runhistory import RunHistory
-from smac.tae.execute_ta_run import BudgetExhaustedException, CappedRunException, ExecuteTARun, StatusType
+from smac.runhistory.runhistory import RunHistory, RunInfo
+from smac.tae.execute_ta_run import ExecuteTARun, StatusType
 from smac.utils.io.traj_logging import TrajLogger
 
 
@@ -273,34 +273,194 @@ class SuccessiveHalving(AbstractRacer):
                                                                      -np.linspace(0, max_sh_iter, max_sh_iter + 1))
         self.n_configs_in_stage = self.n_configs_in_stage.tolist()
 
-    def eval_challenger(self,
+    def process_results(self,
                         challenger: Configuration,
                         incumbent: typing.Optional[Configuration],
                         run_history: RunHistory,
-                        time_bound: float = float(MAXINT),
-                        log_traj: bool = True) -> typing.Tuple[Configuration, float]:
+                        elapsed_time: float,
+                        time_bound: float,
+                        status: StatusType,
+                        runtime: float,
+                        log_traj: bool = True,
+                        ) -> \
+            typing.Tuple[typing.Optional[Configuration], float]:
         """
-        Running intensification via successive halving to determine the incumbent configuration.
-        *Side effect:* adds runs to run_history
+        The intensifier stage will be updated based on the results/status
+        of a configuration execution.
+        Also, a incumbent will be determined.
 
         Parameters
         ----------
         challenger : Configuration
-            promising configuration
-        incumbent : typing.Optional[Configuration]
-            best configuration so far, None in 1st run
-        run_history : smac.runhistory.runhistory.RunHistory
+            A configuration to challenge the incumbent. Can even be the incumbent
+            to gain more confidence on it.
+        incumbet : Configuration
+            Best configuration seen so far
+        run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
             stores all runs we ran so far
+            if False, an evaluated configuration will not be generated again
+        elapsed_time:
+            The tracked time of a configuration execution
         time_bound : float, optional (default=2 ** 31 - 1)
             time in [sec] available to perform intensify
-        log_traj : bool
-            whether to log changes of incumbents in trajectory
+        status: StatusType
+            The status of the execution of a given config
+        runtime:
+            The elapsed time according to the ta runner
+        log_traj: bool
+            Whether to log changes of incumbents in trajectory
 
         Returns
         -------
-        typing.Tuple[Configuration, float]
-            incumbent and incumbent cost
+        incumbent: Configuration()
+            current (maybe new) incumbent configuration
+        inc_perf: float
+            empirical performance of incumbent configuration
         """
+
+        # If The incumbent is None and it is the first run, we use the challenger
+        if not incumbent and self.first_run:
+            self.logger.info(
+                "First run, no incumbent provided; challenger is assumed to be the incumbent"
+            )
+            incumbent = challenger
+            self.first_run = False
+
+        # selecting instance-seed subset for this budget, depending on the kind of budget
+        curr_budget = self.all_budgets[self.stage]
+        if self.instance_as_budget:
+            prev_budget = int(self.all_budgets[self.stage - 1]) if self.stage > 0 else 0
+            curr_insts = self.inst_seed_pairs[int(prev_budget):int(curr_budget)]
+        else:
+            curr_insts = self.inst_seed_pairs
+        n_insts_remaining = len(curr_insts) - self.curr_inst_idx - 1
+
+        if challenger:
+
+            # Make sure that there is no Budget exhausted
+            if status:
+                if status == StatusType.CAPPED:
+                    self.curr_inst_idx = np.inf
+                    n_insts_remaining = 0
+                else:
+                    self._ta_time += runtime
+                    self.num_run += 1
+                    self.curr_inst_idx += 1
+
+                # adding challengers to the list of evaluated challengers
+                #  - Stop: CAPPED/CRASHED/TIMEOUT/MEMOUT/DONOTADVANCE (!= SUCCESS)
+                #  - Advance to next stage: SUCCESS
+                # curr_challengers is a set, so "at least 1" success can be counted by set addition (no duplicates)
+                # If a configuration is successful, it is added to curr_challengers.
+                # if it fails it is added to fail_challengers.
+                if np.isfinite(self.curr_inst_idx) and status == StatusType.SUCCESS:
+                    self.success_challengers.add(challenger)  # successful configs
+                elif np.isfinite(self.curr_inst_idx) and status == StatusType.DONOTADVANCE:
+                    self.do_not_advance_challengers.add(challenger)
+                else:
+                    self.fail_challengers.add(challenger)  # capped/crashed/do not advance configs
+
+                # get incumbent if all instances have been evaluated
+                if n_insts_remaining <= 0:
+                    incumbent = self._compare_configs(challenger=challenger,
+                                                      incumbent=incumbent,
+                                                      run_history=run_history,
+                                                      log_traj=log_traj)
+            # if all configurations for the current stage have been evaluated, reset stage
+            num_chal_evaluated = (
+                len(self.success_challengers | self.fail_challengers | self.do_not_advance_challengers)
+                + self.fail_chal_offset
+            )
+            if num_chal_evaluated == self.n_configs_in_stage[self.stage] and n_insts_remaining <= 0:
+
+                self.logger.info('Successive Halving iteration-step: %d-%d with '
+                                 'budget [%.2f / %d] - evaluated %d challenger(s)' %
+                                 (self.sh_iters + 1, self.stage + 1, self.all_budgets[self.stage], self.max_budget,
+                                  self.n_configs_in_stage[self.stage]))
+
+                self._update_stage(run_history=run_history)
+
+        # get incumbent cost
+        inc_perf = run_history.get_cost(incumbent)
+
+        return incumbent, inc_perf
+
+    def get_next_challenger(self,
+                            challengers: typing.Optional[typing.List[Configuration]],
+                            incumbent: Configuration,
+                            chooser: typing.Optional[EPMChooser],
+                            run_history: RunHistory,
+                            repeat_configs: bool = True,
+                            ) -> RunInfo:
+        """
+        Selects which challenger to use based on the iteration stage and set the iteration parameters.
+        First iteration will choose configurations from the ``chooser`` or input challengers,
+        while the later iterations pick top configurations from the previously selected challengers in that iteration
+
+        Parameters
+        ----------
+        challengers : typing.List[Configuration]
+            promising configurations
+        incumbent: Configuration
+            incumbent configuration
+        chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
+            optimizer that generates next configurations to use for racing
+        run_history : smac.runhistory.runhistory.RunHistory
+            stores all runs we ran so far
+        repeat_configs : bool
+            if False, an evaluated configuration will not be generated again
+
+        Returns
+        -------
+        run_info: RunInfo
+            An object that encapsulates the minimum information to
+            evaluate a configuration
+         """
+        # if this is the first run, then initialize tracking variables
+        if not hasattr(self, 'stage'):
+            self._update_stage(run_history=run_history)
+
+        # sampling from next challenger marks the beginning of a new iteration
+        self.iteration_done = False
+
+        curr_budget = int(self.all_budgets[self.stage])
+
+        # if all instances have been executed, then reset and move on to next config
+        if self.instance_as_budget:
+            prev_budget = int(self.all_budgets[self.stage - 1]) if self.stage > 0 else 0
+            n_insts = (curr_budget - prev_budget)
+        else:
+            n_insts = len(self.inst_seed_pairs)
+        n_insts_remaining = n_insts - self.curr_inst_idx
+
+        # if there are instances pending, finish running configuration
+        if self.running_challenger and n_insts_remaining > 0:
+            challenger = self.running_challenger
+            new_challenger = False
+        else:
+            # select next configuration
+            if self.stage == 0:
+                # first stage, so sample from configurations/chooser provided
+                challenger = self._next_challenger(challengers=challengers,
+                                                   chooser=chooser,
+                                                   run_history=run_history,
+                                                   repeat_configs=repeat_configs)
+                new_challenger = True
+            else:
+                # sample top configs from previously sampled configurations
+                try:
+                    challenger = self.configs_to_run.pop(0)
+                    new_challenger = False
+                except IndexError:
+                    challenger = None
+                    new_challenger = False
+
+            if challenger:
+                # reset instance index for the new challenger
+                self.curr_inst_idx = 0
+                self._chall_indx += 1
+                self.running_challenger = challenger
+
         # calculating the incumbent's performance for adaptive capping
         # this check is required because:
         #   - there is no incumbent performance for the first ever 'intensify' run (from initial design)
@@ -313,7 +473,6 @@ class SuccessiveHalving(AbstractRacer):
             if self.first_run:
                 self.logger.info("First run, no incumbent provided; challenger is assumed to be the incumbent")
                 incumbent = challenger
-                self.first_run = False
 
         # select which instance to run current config on
         curr_budget = self.all_budgets[self.stage]
@@ -344,152 +503,14 @@ class SuccessiveHalving(AbstractRacer):
 
         self.logger.debug('Cutoff for challenger: %s' % str(cutoff))
 
-        try:
-            # run target algorithm for each instance-seed pair
-            self.logger.debug("Execute target algorithm")
-
-            try:
-                status, cost, dur, res = self.tae_runner.start(
-                    config=challenger,
-                    instance=instance,
-                    seed=seed,
-                    cutoff=cutoff,
-                    budget=0.0 if self.instance_as_budget else curr_budget,
-                    instance_specific=self.instance_specifics.get(instance, "0"),
-                    # Cutoff might be None if self.cutoff is None, but then the first if statement prevents
-                    # evaluation of the second if statement
-                    capped=(self.cutoff is not None) and (cutoff < self.cutoff)  # type: ignore[operator] # noqa F821
-                )
-                self._ta_time += dur
-                self.num_run += 1
-                self.curr_inst_idx += 1
-
-            except CappedRunException:
-                # We move on to the next configuration if a configuration is capped
-                self.logger.debug("Budget exhausted by adaptive capping; "
-                                  "Interrupting current challenger and moving on to the next one")
-                # ignore all pending instances
-                self.curr_inst_idx = np.inf
-                n_insts_remaining = 0
-                status = StatusType.CAPPED
-
-            # adding challengers to the list of evaluated challengers
-            #  - Stop: CAPPED/CRASHED/TIMEOUT/MEMOUT/DONOTADVANCE (!= SUCCESS)
-            #  - Advance to next stage: SUCCESS
-            # curr_challengers is a set, so "at least 1" success can be counted by set addition (no duplicates)
-            # If a configuration is successful, it is added to curr_challengers.
-            # if it fails it is added to fail_challengers.
-            if np.isfinite(self.curr_inst_idx) and status == StatusType.SUCCESS:
-                self.success_challengers.add(challenger)  # successful configs
-            elif np.isfinite(self.curr_inst_idx) and status == StatusType.DONOTADVANCE:
-                self.do_not_advance_challengers.add(challenger)
-            else:
-                self.fail_challengers.add(challenger)  # capped/crashed/do not advance configs
-
-            # get incumbent if all instances have been evaluated
-            if n_insts_remaining <= 0:
-                incumbent = self._compare_configs(challenger=challenger,
-                                                  incumbent=incumbent,
-                                                  run_history=run_history,
-                                                  log_traj=log_traj)
-        except BudgetExhaustedException:
-            # Returning the final incumbent selected so far because we ran out of optimization budget
-            self.logger.debug("Budget exhausted; "
-                              "Interrupting optimization run and returning current incumbent")
-
-        # if all configurations for the current stage have been evaluated, reset stage
-        num_chal_evaluated = (
-            len(self.success_challengers | self.fail_challengers | self.do_not_advance_challengers)
-            + self.fail_chal_offset
+        return RunInfo(
+            config=challenger,
+            new=new_challenger,
+            instance=instance,
+            seed=seed,
+            cutoff=cutoff,
+            budget=0.0 if self.instance_as_budget else curr_budget,
         )
-        if num_chal_evaluated == self.n_configs_in_stage[self.stage] and n_insts_remaining <= 0:
-
-            self.logger.info('Successive Halving iteration-step: %d-%d with '
-                             'budget [%.2f / %d] - evaluated %d challenger(s)' %
-                             (self.sh_iters + 1, self.stage + 1, self.all_budgets[self.stage], self.max_budget,
-                              self.n_configs_in_stage[self.stage]))
-
-            self._update_stage(run_history=run_history)
-
-        # get incumbent cost
-        inc_perf = run_history.get_cost(incumbent)
-
-        return incumbent, inc_perf
-
-    def get_next_challenger(self,
-                            challengers: typing.Optional[typing.List[Configuration]],
-                            chooser: typing.Optional[EPMChooser],
-                            run_history: RunHistory,
-                            repeat_configs: bool = True) -> \
-            typing.Tuple[typing.Optional[Configuration], bool]:
-        """
-        Selects which challenger to use based on the iteration stage and set the iteration parameters.
-        First iteration will choose configurations from the ``chooser`` or input challengers,
-        while the later iterations pick top configurations from the previously selected challengers in that iteration
-
-        Parameters
-        ----------
-        challengers : typing.List[Configuration]
-            promising configurations
-        chooser : smac.optimizer.epm_configuration_chooser.EPMChooser
-            optimizer that generates next configurations to use for racing
-        run_history : smac.runhistory.runhistory.RunHistory
-            stores all runs we ran so far
-        repeat_configs : bool
-            if False, an evaluated configuration will not be generated again
-
-        Returns
-        -------
-        typing.Optional[Configuration]
-            next configuration to evaluate
-        bool
-            flag telling if the configuration is newly sampled or one currently being tracked
-        """
-        # if this is the first run, then initialize tracking variables
-        if not hasattr(self, 'stage'):
-            self._update_stage(run_history=run_history)
-
-        # sampling from next challenger marks the beginning of a new iteration
-        self.iteration_done = False
-
-        curr_budget = int(self.all_budgets[self.stage])
-
-        # if all instances have been executed, then reset and move on to next config
-        if self.instance_as_budget:
-            prev_budget = int(self.all_budgets[self.stage - 1]) if self.stage > 0 else 0
-            n_insts = (curr_budget - prev_budget)
-        else:
-            n_insts = len(self.inst_seed_pairs)
-        n_insts_remaining = n_insts - self.curr_inst_idx
-
-        # if there are instances pending, finish running configuration
-        if self.running_challenger and n_insts_remaining > 0:
-            return self.running_challenger, False
-
-        # select next configuration
-        if self.stage == 0:
-            # first stage, so sample from configurations/chooser provided
-            challenger = self._next_challenger(challengers=challengers,
-                                               chooser=chooser,
-                                               run_history=run_history,
-                                               repeat_configs=repeat_configs)
-            new_challenger = True
-        else:
-            # sample top configs from previously sampled configurations
-            try:
-                challenger = self.configs_to_run.pop(0)
-                new_challenger = False
-            except IndexError:
-                challenger = None
-                new_challenger = False
-
-        if challenger:
-            # reset instance index for the new challenger
-            self.curr_inst_idx = 0
-            self._chall_indx += 1
-            self.running_challenger = challenger
-
-        return challenger, new_challenger
 
     def _update_stage(self, run_history: RunHistory) -> None:
         """

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -3,7 +3,7 @@ import typing
 
 import numpy as np
 
-from smac.intensification.abstract_racer import AbstractRacer, IntensifierBehest
+from smac.intensification.abstract_racer import AbstractRacer, RunInfoIntent
 from smac.optimizer.epm_configuration_chooser import EPMChooser
 from smac.stats.stats import Stats
 from smac.utils.constants import MAXINT
@@ -288,12 +288,12 @@ class SuccessiveHalving(AbstractRacer):
         challenger : Configuration
             A configuration that was previously executed, and whose status
             will be used to define the next stage.
-        incumbent : Configuration
+        incumbent : typing.Optional[Configuration]
             Best configuration seen so far
-        run_history : typing.Optional[smac.runhistory.runhistory.RunHistory]
+        run_history : RunHistory
             stores all runs we ran so far
             if False, an evaluated configuration will not be generated again
-        time_bound : float, optional (default=2 ** 31 - 1)
+        time_bound : float
             time in [sec] available to perform intensify
         result: RunValue
             Contain the result (status and other methadata) of exercising
@@ -379,7 +379,7 @@ class SuccessiveHalving(AbstractRacer):
                      chooser: typing.Optional[EPMChooser],
                      run_history: RunHistory,
                      repeat_configs: bool = True,
-                     ) -> typing.Tuple[IntensifierBehest, RunInfo]:
+                     ) -> typing.Tuple[RunInfoIntent, RunInfo]:
         """
         Selects which challenger to use based on the iteration stage and set the iteration parameters.
         First iteration will choose configurations from the ``chooser`` or input challengers,
@@ -403,7 +403,7 @@ class SuccessiveHalving(AbstractRacer):
         run_info: RunInfo
             An object that encapsulates the minimum information to
             evaluate a configuration
-        behest: IntensifierBehest
+        intent: RunInfoIntent
                Indicator of how to consume the RunInfo object
          """
         # if this is the first run, then initialize tracking variables
@@ -448,7 +448,7 @@ class SuccessiveHalving(AbstractRacer):
                     # if we run into a IndexError),
                     # then no new run will trigger update_stage,
                     # so issue a terminate
-                    return IntensifierBehest.TERMINATE, RunInfo(
+                    return RunInfoIntent.STOP_ITERATION, RunInfo(
                         config=None,
                         instance=None,
                         instance_specific="0",
@@ -515,7 +515,7 @@ class SuccessiveHalving(AbstractRacer):
         if (self.cutoff is not None) and (cutoff < self.cutoff):  # type: ignore[operator] # noqa F821
             capped = True
 
-        return IntensifierBehest.RUN, RunInfo(
+        return RunInfoIntent.RUN, RunInfo(
             config=challenger,
             instance=instance,
             instance_specific=self.instance_specifics.get(instance, "0"),

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -336,7 +336,7 @@ class SuccessiveHalving(AbstractRacer):
         if challenger:
 
             # Make sure that there is no Budget exhausted
-            if not status == StatusType.BUDGETEXHAUSTED:
+            if status != StatusType.BUDGETEXHAUSTED:
                 if status == StatusType.CAPPED:
                     self.curr_inst_idx = np.inf
                     n_insts_remaining = 0
@@ -383,13 +383,13 @@ class SuccessiveHalving(AbstractRacer):
 
         return incumbent, inc_perf
 
-    def get_next_challenger(self,
-                            challengers: typing.Optional[typing.List[Configuration]],
-                            incumbent: Configuration,
-                            chooser: typing.Optional[EPMChooser],
-                            run_history: RunHistory,
-                            repeat_configs: bool = True,
-                            ) -> RunInfo:
+    def get_next_run(self,
+                     challengers: typing.Optional[typing.List[Configuration]],
+                     incumbent: Configuration,
+                     chooser: typing.Optional[EPMChooser],
+                     run_history: RunHistory,
+                     repeat_configs: bool = True,
+                     ) -> RunInfo:
         """
         Selects which challenger to use based on the iteration stage and set the iteration parameters.
         First iteration will choose configurations from the ``chooser`` or input challengers,
@@ -452,7 +452,7 @@ class SuccessiveHalving(AbstractRacer):
                 except IndexError:
                     # If there are no new challengers, try a new call
                     # so that a new iteration is triggered
-                    return self.get_next_challenger(
+                    return self.get_next_run(
                         challengers=challengers,
                         incumbent=incumbent,
                         chooser=chooser,
@@ -508,7 +508,9 @@ class SuccessiveHalving(AbstractRacer):
 
         self.logger.debug('Cutoff for challenger: %s' % str(cutoff))
 
-        # For debug purposes
+        # For testing purposes, this attribute highlights whether a
+        # new challenger is proposed or not. Not required from a functional
+        # perspective
         self.new_challenger = new_challenger
 
         capped = False

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -400,11 +400,11 @@ class SuccessiveHalving(AbstractRacer):
 
         Returns
         -------
+        intent: RunInfoIntent
+               Indicator of how to consume the RunInfo object
         run_info: RunInfo
             An object that encapsulates the minimum information to
             evaluate a configuration
-        intent: RunInfoIntent
-               Indicator of how to consume the RunInfo object
          """
         # if this is the first run, then initialize tracking variables
         if not hasattr(self, 'stage'):
@@ -446,9 +446,7 @@ class SuccessiveHalving(AbstractRacer):
                     # which is triggered after the completion of a run
                     # If by there are no more configs to run (which is the case
                     # if we run into a IndexError),
-                    # then no new run will trigger update_stage,
-                    # so issue a terminate
-                    return RunInfoIntent.STOP_ITERATION, RunInfo(
+                    return RunInfoIntent.SKIP, RunInfo(
                         config=None,
                         instance=None,
                         instance_specific="0",

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -277,7 +277,7 @@ class SuccessiveHalving(AbstractRacer):
                         result: RunValue,
                         log_traj: bool = True,
                         ) -> \
-            typing.Tuple[typing.Optional[Configuration], float]:
+            typing.Tuple[Configuration, float]:
         """
         The intensifier stage will be updated based on the results/status
         of a configuration execution.
@@ -442,14 +442,20 @@ class SuccessiveHalving(AbstractRacer):
                     challenger = self.configs_to_run.pop(0)
                     new_challenger = False
                 except IndexError:
-                    # If there are no new challengers, try a new call
-                    # so that a new iteration is triggered
-                    return self.get_next_run(
-                        challengers=challengers,
-                        incumbent=incumbent,
-                        chooser=chooser,
-                        run_history=run_history,
-                        repeat_configs=repeat_configs,
+                    # self.configs_to_run is populated via update_stage,
+                    # which is triggered after the completion of a run
+                    # If by there are no more configs to run (which is the case
+                    # if we run into a IndexError),
+                    # then no new run will trigger update_stage,
+                    # so issue a terminate
+                    return IntensifierBehest.TERMINATE, RunInfo(
+                        config=None,
+                        instance=None,
+                        instance_specific="0",
+                        seed=0,
+                        cutoff=self.cutoff,
+                        capped=False,
+                        budget=0.0,
                     )
 
             if challenger:

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -254,7 +254,6 @@ class SMBO(object):
                         # Add the results of the run to the run history
                         self._incorporate_run_results(run_info, result)
 
-
                         # Update the intensifier with the result of the runs
                         # Has to be executed regardless the config to run is None,
                         # as the control logic has to prepare for the next iteration

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -206,11 +206,6 @@ class SMBO(object):
                 repeat_configs=self.intensifier.repeat_configs,
             )
 
-            # Check if no more configs,
-            if intent == RunInfoIntent.STOP_ITERATION:
-                self.logger.warn("No more valid configurations to try during intensification")
-                break
-
             # remove config from initial design challengers to not repeat it again
             self.initial_design_configs = [c for c in self.initial_design_configs if c != run_info.config]
 

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -208,6 +208,8 @@ class RunHistory(object):
                 information from TA or fields such as start time and host_id)
             origin: DataOrigin
                 Defines how data will be used.
+            force_update: bool (default: False)
+                Forces the addition of a config to the history
         """
 
         if config is None:

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -32,6 +32,10 @@ class RunKey(collections.namedtuple('RunKey', ['config_id', 'instance_id', 'seed
         return super().__new__(cls, config_id, instance_id, seed, budget)
 
 
+RunInfo = collections.namedtuple(
+    'RunInfo', ['config', 'new', 'instance', 'seed', 'cutoff', 'budget'])
+
+
 InstSeedKey = collections.namedtuple(
     'InstSeedKey', ['instance', 'seed'])
 

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -33,7 +33,7 @@ class RunKey(collections.namedtuple('RunKey', ['config_id', 'instance_id', 'seed
 
 
 RunInfo = collections.namedtuple(
-    'RunInfo', ['config', 'new', 'instance', 'seed', 'cutoff', 'budget'])
+    'RunInfo', ['config', 'instance', 'instance_specific', 'seed', 'cutoff', 'capped', 'budget'])
 
 
 InstSeedKey = collections.namedtuple(

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -255,7 +255,7 @@ class RunHistory(object):
         # Capped data is added above
         # Do not register the cost until the run has completed
         if origin in (DataOrigin.INTERNAL, DataOrigin.EXTERNAL_SAME_INSTANCES) \
-                and (status != StatusType.CAPPED and status != StatusType.RUNNING):
+                and status not in [StatusType.CAPPED, StatusType.RUNNING]:
             # also add to fast data structure
             is_k = InstSeedKey(k.instance_id, k.seed)
             self._configid_to_inst_seed_budget[k.config_id] = self._configid_to_inst_seed_budget.get(k.config_id, {})

--- a/smac/tae/execute_ta_run.py
+++ b/smac/tae/execute_ta_run.py
@@ -1,17 +1,10 @@
 import logging
-import math
-import time
 from enum import Enum
 import typing
-
-import numpy as np
 
 from smac.configspace import Configuration
 from smac.stats.stats import Stats
 from smac.utils.constants import MAXINT
-
-if typing.TYPE_CHECKING:
-    from smac.runhistory.runhistory import RunHistory  # noqa F401
 
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2015, ML4AAD"
@@ -37,6 +30,8 @@ class StatusType(Enum):
     DONOTADVANCE = 7
     # In case of budget exception
     BUDGETEXHAUSTED = 8
+    # In case a job was submited, but it has not finished
+    RUNNING = 9
 
     @staticmethod
     def enum_hook(obj: typing.Dict) -> typing.Any:
@@ -84,7 +79,6 @@ class ExecuteTARun(object):
     ----------
     ta
     stats
-    runhistory
     run_obj
 
     par_factor
@@ -97,7 +91,6 @@ class ExecuteTARun(object):
         self,
         ta: typing.Union[typing.List[str], typing.Callable],
         stats: Stats,
-        runhistory: typing.Optional['RunHistory'] = None,
         run_obj: str = "runtime",
         par_factor: int = 1,
         cost_for_crash: float = float(MAXINT),
@@ -109,8 +102,6 @@ class ExecuteTARun(object):
         ----------
         ta : list
             target algorithm command line as list of arguments
-        runhistory: RunHistory, optional
-            runhistory to keep track of all runs; only used if set
         stats: Stats()
              stats object to collect statistics about runtime and so on
         run_obj: str
@@ -125,154 +116,15 @@ class ExecuteTARun(object):
         """
         self.ta = ta
         self.stats = stats
-        self.runhistory = runhistory
         self.run_obj = run_obj
 
         self.par_factor = par_factor
-        self.crash_cost = cost_for_crash
+        self.cost_for_crash = cost_for_crash
         self.abort_on_first_run_crash = abort_on_first_run_crash
 
         self.logger = logging.getLogger(
             self.__module__ + '.' + self.__class__.__name__)
         self._supports_memory_limit = False
-
-    def start(
-        self,
-        config: Configuration,
-        instance: str,
-        cutoff: typing.Optional[float] = None,
-        seed: int = 12345,
-        budget: float = 0.0,
-        instance_specific: str = "0",
-        capped: bool = False,
-    ) -> typing.Tuple[StatusType, float, float, typing.Dict]:
-        """Wrapper function for ExecuteTARun.run() to check configuration
-        budget before the runs and to update stats after run
-
-        Parameters
-        ----------
-            config : Configuration
-                Mainly a dictionary param -> value
-            instance : string
-                Problem instance
-            cutoff : float, optional
-                Runtime cutoff
-            seed : int
-                Random seed
-            budget : float, optional
-                A positive, real-valued number representing an arbitrary limit to the target algorithm
-                Handled by the target algorithm internally
-            instance_specific: str
-                Instance specific information (e.g., domain file or solution)
-            capped: bool
-                If true and status is StatusType.TIMEOUT,
-                uses StatusType.CAPPED
-
-        Returns
-        -------
-            status: enum of StatusType (int)
-                {SUCCESS, TIMEOUT, CRASHED, ABORT}
-            cost: float
-                cost/regret/quality (float) (None, if not returned by TA)
-            runtime: float
-                runtime (None if not returned by TA)
-            additional_info: dict
-                all further additional run information
-        """
-
-        if self.stats.is_budget_exhausted():
-            raise BudgetExhaustedException(
-                "Skip target algorithm run due to exhausted "
-                "configuration budget")
-
-        if cutoff is not None:
-            cutoff = int(math.ceil(cutoff))
-        if cutoff is None and self.run_obj == "runtime":
-            self.logger.critical("For scenarios optimizing running time "
-                                 "(run objective), a cutoff time is required, "
-                                 "but not given to this call.")
-            raise ValueError("For scenarios optimizing running time "
-                             "(run objective), a cutoff time is required, "
-                             "but not given to this call.")
-
-        start = time.time()
-        status, cost, runtime, additional_info = self.run(config=config,
-                                                          instance=instance,
-                                                          cutoff=cutoff,
-                                                          seed=seed,
-                                                          budget=budget,
-                                                          instance_specific=instance_specific)
-        end = time.time()
-
-        if budget == 0 and status == StatusType.DONOTADVANCE:
-            raise ValueError("Cannot handle DONOTADVANCE state when using intensify or SH/HB on "
-                             "instances.")
-        # update SMAC stats
-        self.stats.ta_runs += 1
-        self.stats.ta_time_used += float(runtime)
-
-        # Catch NaN or inf.
-        if (
-            self.run_obj == 'runtime' and not np.isfinite(runtime)
-            or self.run_obj == 'quality' and not np.isfinite(cost)
-        ):
-            self.logger.warning("Target Algorithm returned NaN or inf as {}. "
-                                "Algorithm run is treated as CRASHED, cost "
-                                "is set to {} for quality scenarios. "
-                                "(Change value through \"cost_for_crash\""
-                                "-option.)".format(self.run_obj,
-                                                   self.crash_cost))
-            status = StatusType.CRASHED
-
-        if status == StatusType.ABORT:
-            raise TAEAbortException("Target algorithm status ABORT - SMAC will "
-                                    "exit. The last incumbent can be found "
-                                    "in the trajectory-file.")
-
-        if self.run_obj == "runtime":
-            # The following line pleases mypy - we already check for cutoff not being none above, prior to calling
-            # run. However, mypy assumes that the data type of cutoff is still Optional[int]
-            assert cutoff is not None
-            if runtime > self.par_factor * cutoff:
-                self.logger.warning("Returned running time is larger "
-                                    "than {0} times the passed cutoff time. "
-                                    "Clamping to {0} x cutoff.".format(self.par_factor))
-                runtime = cutoff * self.par_factor
-                status = StatusType.TIMEOUT
-            if status == StatusType.SUCCESS:
-                cost = runtime
-            else:
-                cost = cutoff * self.par_factor
-            if status == StatusType.TIMEOUT and capped:
-                status = StatusType.CAPPED
-        else:
-            if status == StatusType.CRASHED:
-                cost = self.crash_cost
-
-        self.logger.debug("Return: Status: %r, cost: %f, time: %f, additional: %s" % (
-            status, cost, runtime, str(additional_info)))
-
-        if self.runhistory:
-            self.runhistory.add(config=config,
-                                cost=cost, time=runtime, status=status,
-                                instance_id=instance, seed=seed,
-                                budget=budget, starttime=start, endtime=end,
-                                additional_info=additional_info)
-            self.stats.n_configs = len(self.runhistory.config_ids)
-
-        if status == StatusType.CAPPED:
-            raise CappedRunException("")
-
-        if self.abort_on_first_run_crash and self.stats.ta_runs == 1 and status == StatusType.CRASHED:
-            raise FirstRunCrashedException("First run crashed, abort. "
-                                           "Please check your setup -- "
-                                           "we assume that your default"
-                                           "configuration does not crashes. "
-                                           "(To deactivate this exception,"
-                                           " use the SMAC scenario option "
-                                           "'abort_on_first_run_crash')")
-
-        return status, cost, runtime, additional_info
 
     def run(
         self, config: Configuration,
@@ -314,4 +166,4 @@ class ExecuteTARun(object):
             additional_info: dict
                 all further additional run information
         """
-        return StatusType.SUCCESS, 12345.0, 1.2345, {}
+        raise NotImplementedError()

--- a/smac/tae/execute_ta_run.py
+++ b/smac/tae/execute_ta_run.py
@@ -35,6 +35,8 @@ class StatusType(Enum):
     # 1) The run has converged and does not benefit from a higher budget
     # 2) The run has exhausted given resources and will not benefit from higher budgets
     DONOTADVANCE = 7
+    # In case of budget exception
+    BUDGETEXHAUSTED = 8
 
     @staticmethod
     def enum_hook(obj: typing.Dict) -> typing.Any:

--- a/smac/tae/execute_ta_run_wrapper.py
+++ b/smac/tae/execute_ta_run_wrapper.py
@@ -1,0 +1,157 @@
+import logging
+import math
+import time
+import typing
+
+import numpy as np
+
+from smac.runhistory.runhistory import RunValue, RunInfo
+from smac.tae.execute_ta_run import StatusType, ExecuteTARun, TAEAbortException
+
+
+def execute_ta_run_wrapper(
+    tae_runner: ExecuteTARun,
+    run_info: RunInfo,
+    logger: typing.Optional[logging.Logger] = None
+) -> RunValue:
+    """Wrapper around ExecuteTARun to run and check the execution of a given config file
+
+    This function relies on the tae runner object, in order to asses whether a run
+    was intended to be evaluated with a runtime goal or quality goal.
+
+    Parameters
+    ----------
+        tae_runner: 'ExecuteTARun'
+            An object with a run method to execute a config provided via run_info
+        run_info : RunInfo
+            Object that contains enough information to execute a configuration run in
+            isolation.
+
+    Returns
+    -------
+        RunValue:
+            Contains information about the status/performance of config
+    """
+    start = time.time()
+
+    if tae_runner.stats.is_budget_exhausted():
+        # In case there is a budget exhausted, return par_factor time.
+        # Cutoff can be None, and in such case not par factor can be taken
+        if run_info.cutoff is not None:
+            ehausted_cost = run_info.cutoff * tae_runner.par_factor
+        else:
+            ehausted_cost = run_info.cutoff
+        return RunValue(
+            status=StatusType.BUDGETEXHAUSTED,
+            cost=ehausted_cost,
+            time=0.0,
+            additional_info={},
+            starttime=start,
+            endtime=time.time()
+        )
+
+    if run_info.cutoff is None and tae_runner.run_obj == "runtime":
+        if logger:
+            logger.critical(
+                "For scenarios optimizing running time "
+                "(run objective), a cutoff time is required, "
+                "but not given to this call."
+            )
+        raise ValueError(
+            "For scenarios optimizing running time "
+            "(run objective), a cutoff time is required, "
+            "but not given to this call."
+        )
+    cutoff = None
+    if run_info.cutoff is not None:
+        cutoff = int(math.ceil(run_info.cutoff))
+
+    status, cost, runtime, additional_info = tae_runner.run(
+        config=run_info.config,
+        instance=run_info.instance,
+        cutoff=cutoff,
+        seed=run_info.seed,
+        budget=run_info.budget,
+        instance_specific=run_info.instance_specific
+    )
+    end = time.time()
+
+    if run_info.budget == 0 and status == StatusType.DONOTADVANCE:
+        raise ValueError(
+            "Cannot handle DONOTADVANCE state when using intensify or SH/HB on "
+            "instances."
+        )
+
+    # Catch NaN or inf.
+    if (
+        tae_runner.run_obj == 'runtime' and not np.isfinite(runtime)
+        or tae_runner.run_obj == 'quality' and not np.isfinite(cost)
+    ):
+        if logger:
+            logger.warning("Target Algorithm returned NaN or inf as {}. "
+                           "Algorithm run is treated as CRASHED, cost "
+                           "is set to {} for quality scenarios. "
+                           "(Change value through \"cost_for_crash\""
+                           "-option.)".format(tae_runner.run_obj,
+                                              tae_runner.cost_for_crash))
+        status = StatusType.CRASHED
+
+    if status == StatusType.ABORT:
+        raise TAEAbortException("Target algorithm status ABORT - SMAC will "
+                                "exit. The last incumbent can be found "
+                                "in the trajectory-file.")
+
+    if tae_runner.run_obj == "runtime":
+        # The following line pleases mypy - we already check for cutoff not being none above,    prior to calling
+        # run. However, mypy assumes that the data type of cutoff is still Optional[int]
+        assert cutoff is not None
+        if runtime > tae_runner.par_factor * cutoff:
+            if logger:
+                logger.warning("Returned running time is larger "
+                               "than {0} times the passed cutoff time. "
+                               "Clamping to {0} x cutoff.".format(tae_runner.par_factor))
+            runtime = cutoff * tae_runner.par_factor
+            status = StatusType.TIMEOUT
+        if status == StatusType.SUCCESS:
+            cost = runtime
+        else:
+            cost = cutoff * tae_runner.par_factor
+        if status == StatusType.TIMEOUT and run_info.capped:
+            status = StatusType.CAPPED
+            # In case of a capped run, we expect the
+            # status to be:
+            # status, cost, dur, res = StatusType.CAPPED, float(MAXINT), run_info.cutoff, {}
+            # This is set by the TA callable
+    else:
+        if status == StatusType.CRASHED:
+            cost = tae_runner.cost_for_crash
+
+    if tae_runner.run_obj == "runtime":
+        # The following line pleases mypy - we already check for cutoff not being none above,    prior to calling
+        # run. However, mypy assumes that the data type of cutoff is still Optional[int]
+        assert cutoff is not None
+        if runtime > tae_runner.par_factor * cutoff:
+            tae_runner.logger.warning(
+                "Returned running time is larger "
+                "than {0} times the passed cutoff time. "
+                "Clamping to {0} x cutoff.".format(tae_runner.par_factor))
+            runtime = cutoff * tae_runner.par_factor
+            status = StatusType.TIMEOUT
+        if status == StatusType.SUCCESS:
+            cost = runtime
+        else:
+            cost = cutoff * tae_runner.par_factor
+        if status == StatusType.TIMEOUT and run_info.capped:
+            status = StatusType.CAPPED
+    else:
+        if status == StatusType.CRASHED:
+            cost = tae_runner.cost_for_crash
+
+    return RunValue(
+        status=status,
+        cost=cost,
+        time=runtime,
+        additional_info=additional_info,
+        starttime=start,
+        endtime=end
+    )

--- a/smac/tae/execute_ta_run_wrapper.py
+++ b/smac/tae/execute_ta_run_wrapper.py
@@ -106,31 +106,6 @@ def execute_ta_run_wrapper(
         # run. However, mypy assumes that the data type of cutoff is still Optional[int]
         assert cutoff is not None
         if runtime > tae_runner.par_factor * cutoff:
-            if logger:
-                logger.warning("Returned running time is larger "
-                               "than {0} times the passed cutoff time. "
-                               "Clamping to {0} x cutoff.".format(tae_runner.par_factor))
-            runtime = cutoff * tae_runner.par_factor
-            status = StatusType.TIMEOUT
-        if status == StatusType.SUCCESS:
-            cost = runtime
-        else:
-            cost = cutoff * tae_runner.par_factor
-        if status == StatusType.TIMEOUT and run_info.capped:
-            status = StatusType.CAPPED
-            # In case of a capped run, we expect the
-            # status to be:
-            # status, cost, dur, res = StatusType.CAPPED, float(MAXINT), run_info.cutoff, {}
-            # This is set by the TA callable
-    else:
-        if status == StatusType.CRASHED:
-            cost = tae_runner.cost_for_crash
-
-    if tae_runner.run_obj == "runtime":
-        # The following line pleases mypy - we already check for cutoff not being none above,    prior to calling
-        # run. However, mypy assumes that the data type of cutoff is still Optional[int]
-        assert cutoff is not None
-        if runtime > tae_runner.par_factor * cutoff:
             tae_runner.logger.warning(
                 "Returned running time is larger "
                 "than {0} times the passed cutoff time. "

--- a/smac/utils/validate.py
+++ b/smac/utils/validate.py
@@ -28,7 +28,7 @@ __email__ = "joshua.marben@neptun.uni-freiburg.de"
 
 
 def _unbound_tae_starter(
-    tae: ExecuteTARun, runhistory: RunHistory, run_info: RunInfo,
+    tae: ExecuteTARun, runhistory: typing.Optional[RunHistory], run_info: RunInfo,
     *args: typing.Any, **kwargs: typing.Any
 ) -> RunValue:
     """
@@ -153,7 +153,7 @@ class Validator(object):
                  repetitions: int = 1,
                  n_jobs: int = 1,
                  backend: str = 'threading',
-                 runhistory: RunHistory = None,
+                 runhistory: typing.Optional[RunHistory] = None,
                  tae: ExecuteTARun = None,
                  output_fn: typing.Optional[str] = None,
                  ) -> RunHistory:
@@ -245,7 +245,7 @@ class Validator(object):
         runs: typing.List[_Run],
         n_jobs: int,
         backend: str,
-        runhistory: RunHistory = None,
+        runhistory: typing.Optional[RunHistory] = None,
     ) -> typing.List[RunValue]:
         """
         Validate runs with joblibs Parallel-interface

--- a/smac/utils/validate.py
+++ b/smac/utils/validate.py
@@ -11,12 +11,13 @@ from smac.configspace import Configuration, convert_configurations_to_array
 from smac.epm.rf_with_instances import RandomForestWithInstances
 from smac.epm.rfr_imputator import RFRImputator
 from smac.epm.util_funcs import get_types
-from smac.runhistory.runhistory import RunHistory, RunKey, StatusType
+from smac.runhistory.runhistory import RunHistory, RunInfo, RunKey, RunValue, StatusType
 from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
 from smac.tae.execute_ta_run import ExecuteTARun
 from smac.tae.execute_ta_run_old import ExecuteTARunOld
+from smac.tae.execute_ta_run_wrapper import execute_ta_run_wrapper
 from smac.utils.constants import MAXINT
 
 __author__ = "Joshua Marben"
@@ -27,8 +28,9 @@ __email__ = "joshua.marben@neptun.uni-freiburg.de"
 
 
 def _unbound_tae_starter(
-    tae: ExecuteTARun, *args: typing.Any, **kwargs: typing.Any
-) -> typing.Tuple[StatusType, float, float, typing.Dict]:
+    tae: ExecuteTARun, runhistory: RunHistory, run_info: RunInfo,
+    *args: typing.Any, **kwargs: typing.Any
+) -> RunValue:
     """
     Unbound function to be used by joblibs Parallel, since directly passing the
     TAE results in pickling-problems.
@@ -37,15 +39,34 @@ def _unbound_tae_starter(
     ----------
     tae: ExecuteTARun
         tae to be used
+    runhistory: RunHistory
+        runhistory to save
+    run_info: RunInfo
+        Config to be launched
     *args, **kwargs: various
         arguments to the tae
 
     Returns
     -------
-    tae_results: tuple
+    tae_results: RunValue
         return from tae.start
     """
-    return tae.start(*args, **kwargs)
+    result = execute_ta_run_wrapper(tae, run_info, *args, **kwargs)
+    tae.stats.ta_runs += 1
+    tae.stats.ta_time_used += float(result.time)
+    if runhistory:
+        runhistory.add(
+            config=run_info.config,
+            cost=result.cost,
+            time=result.time,
+            status=result.status,
+            instance_id=run_info.instance,
+            seed=run_info.seed,
+            budget=run_info.budget,
+        )
+        tae.stats.n_configs = len(runhistory.config_ids)
+
+    return result
 
 
 _Run = namedtuple('Run', 'config inst seed inst_specs')
@@ -192,7 +213,6 @@ class Validator(object):
         # Create TAE
         if not tae:
             tae = ExecuteTARunOld(ta=self.scen.ta,  # type: ignore[attr-defined] # noqa F821
-                                  runhistory=runhistory,
                                   stats=inf_stats,
                                   run_obj=self.scen.run_obj,
                                   par_factor=self.scen.par_factor,  # type: ignore[attr-defined] # noqa F821
@@ -202,19 +222,19 @@ class Validator(object):
             tae.stats = inf_stats
 
         # Validate!
-        run_results = self._validate_parallel(tae, runs, n_jobs, backend)
+        run_results = self._validate_parallel(tae, runs, n_jobs, backend, runhistory)
         assert len(run_results) == len(runs), (run_results, runs)
 
         # tae returns (status, cost, runtime, additional_info)
         # Add runs to RunHistory
         for run, result in zip(runs, run_results):
             validated_rh.add(config=run.config,
-                             cost=result[1],
-                             time=result[2],
-                             status=result[0],
+                             cost=result.cost,
+                             time=result.time,
+                             status=result.status,
                              instance_id=run.inst,
                              seed=run.seed,
-                             additional_info=result[3])
+                             additional_info=result.additional_info)
 
         self._save_results(validated_rh, output_fn, backup_fn="validated_runhistory.json")
         return validated_rh
@@ -225,7 +245,8 @@ class Validator(object):
         runs: typing.List[_Run],
         n_jobs: int,
         backend: str,
-    ) -> typing.List[typing.Tuple[StatusType, float, float, typing.Dict]]:
+        runhistory: RunHistory = None,
+    ) -> typing.List[RunValue]:
         """
         Validate runs with joblibs Parallel-interface
 
@@ -240,6 +261,8 @@ class Validator(object):
             number of cpus to use for validation (-1 to use all)
         backend: str
             what backend to use for parallelization
+        runhistory: RunHistory
+            optional, RunHistory-object to reuse runs
 
         Returns
         -------
@@ -248,12 +271,19 @@ class Validator(object):
         """
         # Runs with parallel
         run_results = Parallel(n_jobs=n_jobs, backend=backend)(
-            delayed(_unbound_tae_starter)(tae, run.config,
-                                          run.inst,
-                                          self.scen.cutoff,  # type: ignore[attr-defined] # noqa F821
-                                          run.seed,
-                                          run.inst_specs,
-                                          capped=False) for run in runs)
+            delayed(_unbound_tae_starter)(
+                tae,
+                runhistory,
+                RunInfo(
+                    config=run.config,
+                    instance=run.inst,
+                    instance_specific="0",
+                    seed=run.seed,
+                    cutoff=self.scen.cutoff,  # type: ignore[attr-defined] # noqa F821
+                    capped=False,
+                    budget=0
+                )
+            ) for run in runs)
         return run_results
 
     def validate_epm(self,

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -66,9 +66,9 @@ class TestSMACFacade(unittest.TestCase):
         def target_algorithm(conf, inst):
             return 5
         smac = SMAC4AC(tae_runner=target_algorithm, scenario=self.scenario)
-        self.assertIsInstance(smac.solver.intensifier.tae_runner,
+        self.assertIsInstance(smac.solver.tae_runner,
                               ExecuteTAFuncDict)
-        self.assertIs(smac.solver.intensifier.tae_runner.ta, target_algorithm)
+        self.assertIs(smac.solver.tae_runner.ta, target_algorithm)
 
     def test_pass_invalid_tae_runner(self):
         self.assertRaisesRegex(

--- a/test/test_initial_design/test_initial_design.py
+++ b/test/test_initial_design/test_initial_design.py
@@ -28,7 +28,7 @@ class TestSingleInitialDesign(unittest.TestCase):
         })
         self.stats = Stats(scenario=self.scenario)
         self.rh = RunHistory()
-        self.ta = ExecuteTAFuncDict(lambda x: x["x1"]**2, stats=self.stats, runhistory=self.rh)
+        self.ta = ExecuteTAFuncDict(lambda x: x["x1"]**2, stats=self.stats)
 
     def test_single_default_config_design(self):
         self.stats.start_timing()

--- a/test/test_intensify/test_abstract_racer.py
+++ b/test/test_intensify/test_abstract_racer.py
@@ -49,7 +49,7 @@ class TestAbstractRacer(unittest.TestCase):
 
     def test_compare_configs_no_joint_set(self):
         intensifier = AbstractRacer(
-            tae_runner=None, stats=self.stats,
+            stats=self.stats,
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=None, instances=[1])
 
@@ -84,7 +84,7 @@ class TestAbstractRacer(unittest.TestCase):
             challenger is better
         """
         intensifier = AbstractRacer(
-            tae_runner=None, stats=self.stats,
+            stats=self.stats,
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=None,
             instances=[1])
@@ -111,7 +111,7 @@ class TestAbstractRacer(unittest.TestCase):
             incumbent is better
         """
         intensifier = AbstractRacer(
-            tae_runner=None, stats=self.stats,
+            stats=self.stats,
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=None,
             instances=[1])
@@ -139,7 +139,7 @@ class TestAbstractRacer(unittest.TestCase):
             -> no decision (None)
         """
         intensifier = AbstractRacer(
-            tae_runner=None, stats=self.stats,
+            stats=self.stats,
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=None,
             instances=[1])
@@ -171,7 +171,7 @@ class TestAbstractRacer(unittest.TestCase):
             test _adapt_cutoff()
         """
         intensifier = AbstractRacer(
-            tae_runner=None, stats=self.stats,
+            stats=self.stats,
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=np.random.RandomState(12345),
             instances=list(range(5)),

--- a/test/test_intensify/test_abstract_racer.py
+++ b/test/test_intensify/test_abstract_racer.py
@@ -9,7 +9,6 @@ from ConfigSpace.hyperparameters import UniformIntegerHyperparameter
 from smac.runhistory.runhistory import RunHistory
 from smac.scenario.scenario import Scenario
 from smac.intensification.abstract_racer import AbstractRacer
-from smac.facade.smac_ac_facade import SMAC4AC
 from smac.tae.execute_ta_run import StatusType
 from smac.stats.stats import Stats
 from smac.utils.io.traj_logging import TrajLogger
@@ -47,67 +46,6 @@ class TestAbstractRacer(unittest.TestCase):
         self.stats.start_timing()
 
         self.logger = logging.getLogger(self.__module__ + "." + self.__class__.__name__)
-
-    def test_get_next_challenger(self):
-        """
-            test get_next_challenger - pick from list/chooser
-        """
-        intensifier = AbstractRacer(
-            tae_runner=None, stats=self.stats, traj_logger=None,
-            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
-            cutoff=1, instances=[1])
-
-        # Error when nothing to choose from
-        with self.assertRaisesRegex(ValueError, "No configurations/chooser provided"):
-            intensifier.get_next_challenger(challengers=None, chooser=None, run_history=self.rh)
-
-        # next challenger from a list
-        config, _ = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
-                                                    chooser=None, run_history=self.rh)
-        self.assertEqual(config, self.config1)
-
-        config, _ = intensifier.get_next_challenger(challengers=[self.config2, self.config3],
-                                                    chooser=None, run_history=self.rh)
-        self.assertEqual(config, self.config2)
-
-        # next challenger from a chooser
-        intensifier = AbstractRacer(
-            tae_runner=None, stats=self.stats, traj_logger=None,
-            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
-            cutoff=1, instances=[1])
-        chooser = SMAC4AC(self.scen, rng=1).solver.epm_chooser
-
-        config, _ = intensifier.get_next_challenger(challengers=None, chooser=chooser, run_history=self.rh)
-        self.assertEqual(len(list(config.get_dictionary().values())), 2)
-        self.assertTrue(24 in config.get_dictionary().values())
-        self.assertTrue(68 in config.get_dictionary().values())
-
-        config, _ = intensifier.get_next_challenger(challengers=None, chooser=chooser, run_history=self.rh)
-        self.assertEqual(len(list(config.get_dictionary().values())), 2)
-        self.assertTrue(95 in config.get_dictionary().values())
-        self.assertTrue(38 in config.get_dictionary().values())
-
-    def test_get_next_challenger_repeat(self):
-        """
-            test get_next_challenger - repeat configurations
-        """
-        intensifier = AbstractRacer(
-            tae_runner=None, stats=self.stats, traj_logger=None,
-            rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
-            cutoff=1, instances=[1])
-
-        # should not repeat configurations
-        self.rh.add(self.config1, 1, 1, StatusType.SUCCESS)
-        config, _ = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
-                                                    chooser=None, run_history=self.rh, repeat_configs=False)
-
-        self.assertEqual(config, self.config2)
-
-        # should repeat configurations
-        config, _ = intensifier.get_next_challenger(challengers=[self.config1, self.config2],
-                                                    chooser=None, run_history=self.rh, repeat_configs=True)
-
-        self.assertEqual(config, self.config1)
 
     def test_compare_configs_no_joint_set(self):
         intensifier = AbstractRacer(

--- a/test/test_intensify/test_eval_utils.py
+++ b/test/test_intensify/test_eval_utils.py
@@ -1,0 +1,37 @@
+from smac.runhistory.runhistory import RunHistory, RunInfo
+from smac.stats.stats import Stats
+from smac.tae.execute_func import ExecuteTAFuncDict
+from smac.tae.execute_ta_run_wrapper import execute_ta_run_wrapper
+
+
+def eval_challenger(
+    run_info: RunInfo,
+    taf: ExecuteTAFuncDict,
+    stats: Stats,
+    runhistory: RunHistory,
+):
+    """
+    Wrapper over challenger evaluation
+
+    SMBO objects handles run history now, but to keep
+    same testing functionality this function is a small
+    wrapper to launch the taf and add it to the history
+    """
+    # evaluating configuration
+    result = execute_ta_run_wrapper(
+        run_info=run_info,
+        tae_runner=taf,
+    )
+    stats.ta_runs += 1
+    stats.ta_time_used += float(result.time)
+    runhistory.add(
+        config=run_info.config,
+        cost=result.cost,
+        time=result.time,
+        status=result.status,
+        instance_id=run_info.instance,
+        seed=run_info.seed,
+        budget=run_info.budget,
+    )
+    stats.n_configs = len(runhistory.config_ids)
+    return result

--- a/test/test_intensify/test_hyperband.py
+++ b/test/test_intensify/test_hyperband.py
@@ -14,6 +14,7 @@ from smac.runhistory.runhistory import RunHistory
 from smac.tae.execute_ta_run import StatusType
 from smac.stats.stats import Stats
 from smac.utils.io.traj_logging import TrajLogger
+from smac.optimizer.smbo import SMBO
 
 
 def get_config_space():
@@ -54,7 +55,7 @@ class TestHyperband(unittest.TestCase):
             test initialization of all parameters and tracking variables
         """
         intensifier = Hyperband(
-            tae_runner=None, stats=self.stats, traj_logger=None,
+            stats=self.stats, traj_logger=None,
             rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
             instances=[1], initial_budget=0.1, max_budget=1, eta=2)
         intensifier._update_stage()
@@ -97,7 +98,7 @@ class TestHyperband(unittest.TestCase):
         taf.runhistory = self.rh
 
         intensifier = Hyperband(
-            tae_runner=taf, stats=self.stats,
+            stats=self.stats,
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=np.random.RandomState(12345), deterministic=True, run_obj_time=False,
             instances=[None], initial_budget=0.5, max_budget=1, eta=2)
@@ -133,7 +134,7 @@ class TestHyperband(unittest.TestCase):
 
         # evaluation should change the incumbent to config2
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = intensifier.eval_challenger(run_info)  # noqa: F841
+            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(

--- a/test/test_intensify/test_hyperband.py
+++ b/test/test_intensify/test_hyperband.py
@@ -14,7 +14,7 @@ from smac.runhistory.runhistory import RunHistory
 from smac.tae.execute_ta_run import StatusType
 from smac.stats.stats import Stats
 from smac.utils.io.traj_logging import TrajLogger
-from smac.optimizer.smbo import SMBO
+from smac.optimizer.smbo import eval_challenger
 
 
 def get_config_space():
@@ -87,7 +87,7 @@ class TestHyperband(unittest.TestCase):
 
     def test_eval_challenger(self):
         """
-            since hyperband uses eval_challenger and get_next_challenger of the internal successive halving,
+            since hyperband uses eval_challenger and get_next_run of the internal successive halving,
             we don't test these method extensively
         """
 
@@ -105,8 +105,8 @@ class TestHyperband(unittest.TestCase):
 
         self.assertFalse(hasattr(intensifier, 's'))
 
-        # Testing get_next_challenger - get next configuration
-        run_info = intensifier.get_next_challenger(
+        # Testing get_next_run - get next configuration
+        run_info = intensifier.get_next_run(
             challengers=[self.config2, self.config3],
             chooser=None,
             incumbent=None,
@@ -126,7 +126,7 @@ class TestHyperband(unittest.TestCase):
                     seed=0, budget=0.5)
         intensifier.sh_intensifier.success_challengers = {self.config2, self.config3}
         intensifier.sh_intensifier._update_stage(self.rh)
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config2, self.config3],
             chooser=None,
             incumbent=None,
@@ -134,7 +134,7 @@ class TestHyperband(unittest.TestCase):
 
         # evaluation should change the incumbent to config2
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(

--- a/test/test_intensify/test_hyperband.py
+++ b/test/test_intensify/test_hyperband.py
@@ -107,7 +107,7 @@ class TestHyperband(unittest.TestCase):
         self.assertFalse(hasattr(intensifier, 's'))
 
         # Testing get_next_run - get next configuration
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config2, self.config3],
             chooser=None,
             incumbent=None,
@@ -127,7 +127,7 @@ class TestHyperband(unittest.TestCase):
                     seed=0, budget=0.5)
         intensifier.sh_intensifier.success_challengers = {self.config2, self.config3}
         intensifier.sh_intensifier._update_stage(self.rh)
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config2, self.config3],
             chooser=None,
             incumbent=None,

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import unittest
 
 import logging
@@ -8,7 +9,7 @@ import time
 from ConfigSpace import Configuration, ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformIntegerHyperparameter
 
-from smac.runhistory.runhistory import RunHistory
+from smac.runhistory.runhistory import RunHistory, RunInfo
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
 from smac.tae.execute_func import ExecuteTAFuncDict
@@ -53,7 +54,9 @@ class TestIntensify(unittest.TestCase):
 
     def test_race_challenger(self):
         """
-           test _race_challenger without adaptive capping
+           Makes sure that a racing configuration with better performance,
+           is selected as incumbent
+           No adaptive capping
         """
 
         def target(x):
@@ -71,11 +74,39 @@ class TestIntensify(unittest.TestCase):
                     status=StatusType.SUCCESS, instance_id=1,
                     seed=None,
                     additional_info=None)
-        intensifier.N = 1
 
-        inc = intensifier._race_challenger(challenger=self.config2,
-                                           incumbent=self.config1,
-                                           run_history=self.rh)
+        # For Race challenger to be called, the intensifier has
+        # to be in RUN_CHALLENGER STAGE. Also, the substatus
+        # cariable intensifier.to_run_empty is set to true
+        # which means that all challenger configurations are ready
+        # to be compared
+        intensifier.N = 1
+        intensifier.stage = IntensifierStage.RUN_CHALLENGER
+        intensifier.to_run_empty = True
+        inc, instance, seed, cutoff = intensifier._race_challenger(
+            challenger=self.config2,
+            incumbent=self.config1,
+            run_history=self.rh
+        )
+        status, cost, dur, res = intensifier.eval_challenger(
+            RunInfo(
+                config=self.config2,
+                new=True,
+                instance=instance,
+                seed=seed,
+                cutoff=cutoff,
+                budget=0.0,
+            )
+        )
+        inc, perf = intensifier.process_results(
+            challenger=self.config2,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         self.assertEqual(inc, self.config2)
         self.assertEqual(intensifier.num_run, 1)
@@ -83,7 +114,8 @@ class TestIntensify(unittest.TestCase):
 
     def test_race_challenger_2(self):
         """
-           test _race_challenger with adaptive capping
+           Makes sure that a racing configuration with better performance,
+           that is capped, doesn't substitute the incumbent.
         """
 
         def target(x):
@@ -102,14 +134,42 @@ class TestIntensify(unittest.TestCase):
                     status=StatusType.SUCCESS, instance_id=1,
                     seed=12345,
                     additional_info=None)
+
+        # For Race challenger to be called, the intensifier has
+        # to be in RUN_CHALLENGER STAGE. Also, the substatus
+        # cariable intensifier.to_run_empty is set to true
+        # which means that all challenger configurations are ready
+        # to be compared
         intensifier.N = 1
+        intensifier.stage = IntensifierStage.RUN_CHALLENGER
+        intensifier.to_run_empty = True
+        inc, instance, seed, cutoff = intensifier._race_challenger(
+            challenger=self.config2,
+            incumbent=self.config1,
+            run_history=self.rh
+        )
+        status, cost, dur, res = intensifier.eval_challenger(
+            RunInfo(
+                config=self.config2,
+                new=True,
+                instance=instance,
+                seed=seed,
+                cutoff=cutoff,
+                budget=0.0,
+            )
+        )
+        inc, perf = intensifier.process_results(
+            challenger=self.config2,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         # config2 should have a timeout (due to adaptive capping)
         # and config1 should still be the incumbent
-        inc = intensifier._race_challenger(challenger=self.config2,
-                                           incumbent=self.config1,
-                                           run_history=self.rh,)
-
         self.assertEqual(inc, self.config1)
         self.assertEqual(intensifier.num_run, 1)
         self.assertEqual(intensifier.num_chall_run, 1)
@@ -142,10 +202,28 @@ class TestIntensify(unittest.TestCase):
 
         # config2 should have a timeout (due to adaptive capping)
         # and config1 should still be the incumbent
-        config, _ = intensifier.get_next_challenger(challengers=[self.config2, self.config3], chooser=None)
-        inc = intensifier._race_challenger(challenger=config,
-                                           incumbent=self.config1,
-                                           run_history=self.rh,)
+        run_info = intensifier.get_next_challenger(
+            challengers=[self.config2, self.config3],
+            incumbent=self.config1,
+            run_history=self.rh,
+            chooser=None
+        )
+        inc, instance, seed, cutoff = intensifier._race_challenger(
+            challenger=run_info.config,
+            incumbent=self.config1,
+            run_history=self.rh
+        )
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=0,
+        )
+
         self.assertEqual(inc, self.config1)
 
         # further run for incumbent
@@ -157,30 +235,95 @@ class TestIntensify(unittest.TestCase):
         # give config2 a second chance - now it should run on both instances
 
         # run on instance 1
-        config, _ = intensifier.get_next_challenger(challengers=[self.config2, self.config3], chooser=None)
-        inc = intensifier._race_challenger(challenger=config,
-                                           incumbent=self.config1,
-                                           run_history=self.rh,)
+
+        run_info = intensifier.get_next_challenger(
+            challengers=[self.config2, self.config3],
+            incumbent=self.config1,
+            run_history=self.rh,
+            chooser=None
+        )
+        inc, instance, seed, cutoff = intensifier._race_challenger(
+            challenger=run_info.config,
+            incumbent=self.config1,
+            run_history=self.rh
+        )
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=0,
+        )
 
         # run on instance 2
-        config, _ = intensifier.get_next_challenger(challengers=[self.config3], chooser=None)
-        self.assertEqual(config, self.config2)
-        self.assertTrue(intensifier.continue_challenger)
+        run_info = intensifier.get_next_challenger(
+            challengers=[self.config3],
+            incumbent=self.config1,
+            run_history=self.rh,
+            chooser=None
+        )
 
-        inc = intensifier._race_challenger(challenger=config,
-                                           incumbent=self.config1,
-                                           run_history=self.rh,)
+        # Because the run is capped, the stage do a forced transition to
+        # IntensifierStage.RUN_INCUMBENT. So the challenger to run has to
+        # be the incumbent
+        self.assertEqual(run_info.config, self.config1)
+        self.assertFalse(intensifier.continue_challenger)
+
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=0,
+        )
+
+        # Add a test to make sure continue challenger is set to True
+        # If comparing against config 2, not enough runs have been
+        # performed. So continue challenger is true so that a new
+        # run is encouraged
+        inc, perf = intensifier.process_results(
+            challenger=self.config2,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=0,
+        )
+        self.assertTrue(intensifier.continue_challenger)
 
         # the incumbent should still be config1 because
         # config2 should get on inst 1 a full timeout
         # such that c(config1) = 1.25 and c(config2) close to 1.3
         self.assertEqual(inc, self.config1)
+
         # the capped run should not be counted in runs_perf_config
-        self.assertAlmostEqual(self.rh.num_runs_per_config[2], 2)
-        self.assertFalse(intensifier.continue_challenger)
+        # This is something handled by tae runner
+        num_runs_per_config_before = copy.deepcopy(self.rh.num_runs_per_config)
+        status, cost, dur, res = intensifier.eval_challenger(
+            RunInfo(
+                config=self.config2,
+                new=True,
+                instance=1,
+                seed=12345,
+                cutoff=0.5,
+                budget=0.0,
+            )
+        )
+        self.assertEqual(status, StatusType.CAPPED)
+        self.assertDictEqual(self.rh.num_runs_per_config, num_runs_per_config_before)
 
         self.assertEqual(intensifier.num_run, 3)
-        self.assertEqual(intensifier.num_chall_run, 3)
+
+        # On capped runs, the incumbent is run. We do not expect
+        # 3 challenger runs to have executed, just 1
+        self.assertEqual(intensifier.num_chall_run, 1)
 
     def test_race_challenger_large(self):
         """
@@ -211,10 +354,22 @@ class TestIntensify(unittest.TestCase):
         # tie on first instances and then challenger should always win
         # and be returned as inc
         while True:
-            config, _ = intensifier.get_next_challenger(challengers=[self.config2, self.config3], chooser=None)
-            inc = intensifier._race_challenger(challenger=config,
-                                               incumbent=self.config1,
-                                               run_history=self.rh,)
+            run_info = intensifier.get_next_challenger(
+                challengers=[self.config2, self.config3],
+                incumbent=self.config1,
+                run_history=self.rh,
+                chooser=None
+            )
+            status, cost, dur, res = intensifier.eval_challenger(run_info)
+            inc, perf = intensifier.process_results(
+                challenger=run_info.config,
+                incumbent=self.config1,
+                run_history=self.rh,
+                time_bound=np.inf,
+                status=status,
+                runtime=dur,
+                elapsed_time=0,
+            )
 
             # stop when challenger evaluation is over
             if not intensifier.stage == IntensifierStage.RUN_CHALLENGER:
@@ -259,10 +414,22 @@ class TestIntensify(unittest.TestCase):
         # tie on first instances and then challenger should always win
         # and be returned as inc
         while True:
-            config, _ = intensifier.get_next_challenger(challengers=[self.config2, self.config3], chooser=None)
-            inc = intensifier._race_challenger(challenger=config,
-                                               incumbent=self.config1,
-                                               run_history=self.rh,)
+            run_info = intensifier.get_next_challenger(
+                challengers=[self.config2, self.config3],
+                incumbent=self.config1,
+                run_history=self.rh,
+                chooser=None
+            )
+            status, cost, dur, res = intensifier.eval_challenger(run_info)
+            inc, perf = intensifier.process_results(
+                challenger=run_info.config,
+                incumbent=self.config1,
+                run_history=self.rh,
+                time_bound=np.inf,
+                status=status,
+                runtime=dur,
+                elapsed_time=0,
+            )
 
             # stop when challenger evaluation is over
             if not intensifier.stage == IntensifierStage.RUN_CHALLENGER:
@@ -298,17 +465,57 @@ class TestIntensify(unittest.TestCase):
             instances=[1],
             deterministic=True)
 
-        intensifier._add_inc_run(incumbent=self.config1, run_history=self.rh)
+        inc, instance, seed, cutoff = intensifier._add_inc_run(
+            incumbent=self.config1,
+            run_history=self.rh
+        )
+        status, cost, dur, res = intensifier.eval_challenger(
+            RunInfo(
+                config=self.config1,
+                new=False,
+                instance=instance,
+                seed=seed,
+                cutoff=cutoff,
+                budget=0.0,
+            )
+        )
+        inc, perf = intensifier.process_results(
+            challenger=self.config1,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(len(self.rh.data), 1, self.rh.data)
 
         # since we assume deterministic=1,
         # the second call should not add any more runs
         # given only one instance
-        intensifier._add_inc_run(incumbent=self.config1, run_history=self.rh)
-        self.assertEqual(len(self.rh.data), 1, self.rh.data)
+        # So the returned seed/instance is None so that a new
+        # run to be triggered is not launched
+        inc, instance, seed, cutoff = intensifier._add_inc_run(
+            incumbent=self.config1,
+            run_history=self.rh
+        )
+        self.assertEqual(None, instance)
+        self.assertEqual(None, seed)
 
         # The following two tests evaluate to zero because _next_iteration is triggered by _add_inc_run
         # as it is the first evaluation of this intensifier
+        # After the above incumbent run, the stage is
+        # IntensifierStage.RUN_CHALLENGER. Change it to test next iteration
+        intensifier.stage = IntensifierStage.RUN_FIRST_CONFIG
+        inc, perf = intensifier.process_results(
+            challenger=self.config1,
+            incumbent=None,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(intensifier.num_run, 0)
         self.assertEqual(intensifier.num_chall_run, 0)
 
@@ -328,20 +535,88 @@ class TestIntensify(unittest.TestCase):
             instances=[1, 2],
             deterministic=False)
 
-        intensifier._add_inc_run(incumbent=self.config1, run_history=self.rh)
+        inc, instance, seed, cutoff = intensifier._add_inc_run(
+            incumbent=self.config1,
+            run_history=self.rh
+        )
+        status, cost, dur, res = intensifier.eval_challenger(
+            RunInfo(
+                config=self.config1,
+                new=False,
+                instance=instance,
+                seed=seed,
+                cutoff=cutoff,
+                budget=0.0,
+            )
+        )
+        inc, perf = intensifier.process_results(
+            challenger=self.config1,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(len(self.rh.data), 1, self.rh.data)
 
-        intensifier._add_inc_run(incumbent=self.config1, run_history=self.rh)
+        inc, instance, seed, cutoff = intensifier._add_inc_run(
+            incumbent=self.config1,
+            run_history=self.rh
+        )
+        status, cost, dur, res = intensifier.eval_challenger(
+            RunInfo(
+                config=self.config1,
+                new=False,
+                instance=instance,
+                seed=seed,
+                cutoff=cutoff,
+                budget=0.0,
+            )
+        )
+        inc, perf = intensifier.process_results(
+            challenger=self.config1,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(len(self.rh.data), 2, self.rh.data)
         runs = self.rh.get_runs_for_config(config=self.config1, only_max_observed_budget=True)
         # exactly one run on each instance
         self.assertIn(1, [runs[0].instance, runs[1].instance])
         self.assertIn(2, [runs[0].instance, runs[1].instance])
 
-        intensifier._add_inc_run(incumbent=self.config1, run_history=self.rh)
+        inc, instance, seed, cutoff = intensifier._add_inc_run(
+            incumbent=self.config1,
+            run_history=self.rh
+        )
+        status, cost, dur, res = intensifier.eval_challenger(
+            RunInfo(
+                config=self.config1,
+                new=False,
+                instance=instance,
+                seed=seed,
+                cutoff=cutoff,
+                budget=0.0,
+            )
+        )
+        inc, perf = intensifier.process_results(
+            challenger=self.config1,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(len(self.rh.data), 3, self.rh.data)
 
-        self.assertEqual(intensifier.num_run, 2)
+        # The number of runs performed should be 3
+        # No Next iteration call as an incumbent is provided
+        self.assertEqual(intensifier.num_run, 3)
         self.assertEqual(intensifier.num_chall_run, 0)
 
     def test_get_next_challenger(self):
@@ -353,24 +628,41 @@ class TestIntensify(unittest.TestCase):
             traj_logger=TrajLogger(output_dir=None, stats=self.stats),
             rng=np.random.RandomState(12345),
             instances=[1],
-            deterministic=True)
+            deterministic=True,
+            run_obj_time=False,
+        )
 
         intensifier.stage = IntensifierStage.RUN_CHALLENGER
 
         # get a new challenger to evaluate
-        config, new = intensifier.get_next_challenger(challengers=[self.config1, self.config2], chooser=None)
+        run_info = intensifier.get_next_challenger(
+            challengers=[self.config1, self.config2],
+            run_history=self.rh,
+            incumbent=self.config2,
+            chooser=None
+        )
 
-        self.assertEqual(config, self.config1, intensifier.current_challenger)
+        self.assertEqual(run_info.config, self.config1, intensifier.current_challenger)
         self.assertEqual(intensifier._chall_indx, 1)
         self.assertEqual(intensifier.N, 1)
-        self.assertTrue(new)
+        self.assertTrue(run_info.new)
 
         # when already evaluating a challenger, return the same challenger
         intensifier.to_run = [(1, 1, 0)]
-        config, new = intensifier.get_next_challenger(challengers=[self.config2], chooser=None)
-        self.assertEqual(config, self.config1, intensifier.current_challenger)
+        run_info = intensifier.get_next_challenger(
+            challengers=[self.config2],
+            run_history=self.rh,
+            incumbent=self.config1,
+            chooser=None,
+        )
+        self.assertEqual(self.config1, intensifier.current_challenger)
+
+        # During evaluation, if the challenger is the same as the
+        # Incumbent, the challenger is skipped, if the stage is
+        # Running challenger. In this case None is returned as next config
+        self.assertEqual(run_info.config, None)
         self.assertEqual(intensifier._chall_indx, 1)
-        self.assertFalse(new)
+        self.assertFalse(run_info.new)
 
     def test_generate_challenger(self):
         """
@@ -428,12 +720,26 @@ class TestIntensify(unittest.TestCase):
 
         # intensification iteration #1
         # run first config as incumbent if incumbent is None
-        config, _ = intensifier.get_next_challenger(challengers=[self.config2],
-                                                    chooser=None)
-        self.assertEqual(config, self.config2)
+        run_info = intensifier.get_next_challenger(
+            incumbent=None,
+            run_history=self.rh,
+            challengers=[self.config2],
+            chooser=None
+        )
+        self.assertEqual(run_info.config, self.config2)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
         # eval config 2 (=first run)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=None, run_history=self.rh, )
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=None,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
+
         self.assertEqual(inc, self.config2)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
         self.assertEqual(self.stats.inc_changed, 1)
@@ -441,21 +747,43 @@ class TestIntensify(unittest.TestCase):
 
         # intensification iteration #2
         # regular intensification begins - run incumbent first
-        config, _ = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
-                                                    chooser=None)
-        self.assertEqual(config, inc)
+        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        self.assertEqual(run_info.config, inc)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(self.stats.ta_runs, 2)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(self.stats.inc_changed, 1)
 
         # run challenger now that the incumbent has been executed
-        config, _ = intensifier.get_next_challenger(challengers=[self.config1],
-                                                    chooser=None)
+        run_info = intensifier.get_next_challenger(challengers=[self.config1],
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
-        self.assertEqual(config, self.config1)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        self.assertEqual(run_info.config, self.config1)
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         # challenger has a better performance, but not run on all instances yet. so incumbent stays the same
         self.assertEqual(inc, self.config2)
@@ -463,11 +791,22 @@ class TestIntensify(unittest.TestCase):
         self.assertTrue(intensifier.continue_challenger)
 
         # run challenger again on the other instance
-        config, _ = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
-                                                    chooser=None)
+        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
-        self.assertEqual(config, self.config1)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        self.assertEqual(run_info.config, self.config1)
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         # challenger better than incumbent in both instances. so incumbent changed
         self.assertEqual(inc, self.config1)
@@ -476,11 +815,22 @@ class TestIntensify(unittest.TestCase):
         self.assertFalse(intensifier.continue_challenger)
 
         # run basis configuration (`always_race_against`)
-        config, _ = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
-                                                    chooser=None)
-        self.assertEqual(config, self.config3)
+        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        self.assertEqual(run_info.config, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_BASIS)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         # the basis configuration (config3) not better than incumbent, so can move on
         self.assertEqual(inc, self.config1)
@@ -495,10 +845,21 @@ class TestIntensify(unittest.TestCase):
             next(intensifier.configs_to_run)
 
         # intensification continues running incumbent again in same iteration...
-        config, _ = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
-                                                    chooser=None)
+        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         self.assertEqual(inc, self.config1)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
@@ -529,23 +890,55 @@ class TestIntensify(unittest.TestCase):
 
         # intensification iteration #1
         # run first config as incumbent if incumbent is None
-        config, _ = intensifier.get_next_challenger(challengers=[self.config3],
-                                                    chooser=None)
-        self.assertEqual(config, self.config3)
+        run_info = intensifier.get_next_challenger(challengers=[self.config3],
+                                                   incumbent=None,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        self.assertEqual(run_info.config, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
         # eval config 2 (=first run)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=None, run_history=self.rh, )
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=None,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(inc, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
         self.assertEqual(self.stats.inc_changed, 1)
         self.assertEqual(intensifier.n_iters, 1)  # 1 intensification run complete!
 
         # regular intensification begins - run incumbent
-        config, _ = intensifier.get_next_challenger(challengers=None,  # since incumbent is run, no configs required
-                                                    chooser=None)
-        self.assertEqual(config, inc)
-        self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        run_info = intensifier.get_next_challenger(challengers=None,  # since incumbent is run, no configs required
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        self.assertEqual(run_info.config, inc)
+
+        # There is a transition from:
+        # IntensifierStage.RUN_FIRST_CONFIG-> IntensifierStage.RUN_INCUMBENT
+        # Because after the first run, incumbent is run.
+        # Nevertheless, there is now a transition:
+        # IntensifierStage.RUN_INCUMBENT->IntensifierStage.RUN_CHALLENGER
+        # because in add_inc_run, there are more available instance pairs
+        self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
+        if run_info.config and (run_info.instance is not None or run_info.seed is not None):
+            status, cost, dur, res = intensifier.eval_challenger(run_info)
+        else:
+            status, cost, dur, res = None, None, None, None
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         # no new TA runs as there are no more instances to run
         self.assertEqual(inc, self.config3)
@@ -555,11 +948,22 @@ class TestIntensify(unittest.TestCase):
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
 
         # run challenger now that the incumbent has been executed
-        config, _ = intensifier.get_next_challenger(challengers=[self.config2, self.config1],
-                                                    chooser=None)
+        run_info = intensifier.get_next_challenger(challengers=[self.config2, self.config1],
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
-        self.assertEqual(config, self.config2)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        self.assertEqual(run_info.config, self.config2)
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         # challenger has a better performance, so incumbent has changed
         self.assertEqual(inc, self.config2)
@@ -570,18 +974,51 @@ class TestIntensify(unittest.TestCase):
 
         # intensification continues running incumbent again in same iteration...
         # run incumbent
-        config, _ = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
-                                                    chooser=None)
-        self.assertEqual(config, self.config2)
-        self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        self.assertEqual(run_info.config, self.config2)
+
+        # There is a transition from:
+        # IntensifierStage.RUN_FIRST_CONFIG-> IntensifierStage.RUN_INCUMBENT
+        # Because after the first run, incumbent is run.
+        # Nevertheless, there is now a transition:
+        # IntensifierStage.RUN_INCUMBENT->IntensifierStage.RUN_CHALLENGER
+        # because in add_inc_run, there are more available instance pairs
+        self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
+
+        if run_info.config and (run_info.instance is not None or run_info.seed is not None):
+            status, cost, dur, res = intensifier.eval_challenger(run_info)
+        else:
+            status, cost, dur, res = None, None, None, None
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         # run challenger
-        config, _ = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
-                                                    chooser=None)
-        self.assertEqual(config, self.config1)
+        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        self.assertEqual(run_info.config, self.config1)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         self.assertEqual(inc, self.config1)
         self.assertEqual(self.stats.inc_changed, 3)
@@ -619,8 +1056,20 @@ class TestIntensify(unittest.TestCase):
                     instance_id=1, seed=None, additional_info=None)
 
         # intensification - incumbent will be run, but not as RUN_FIRST_CONFIG stage
-        config, _ = intensifier.get_next_challenger(challengers=[self.config2], chooser=None)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=self.config1, run_history=self.rh, )
+        run_info = intensifier.get_next_challenger(challengers=[self.config2],
+                                                   incumbent=self.config1,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        status, cost, dur, res = intensifier.eval_challenger(run_info)
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=self.config1,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
 
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(len(self.rh.get_runs_for_config(self.config1, only_max_observed_budget=True)), 2)
@@ -647,28 +1096,76 @@ class TestIntensify(unittest.TestCase):
         self.assertEqual(intensifier.n_iters, 0)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
 
-        config, _ = intensifier.get_next_challenger(challengers=[self.config3],
-                                                    chooser=None)
-        self.assertEqual(config, self.config3)
+        run_info = intensifier.get_next_challenger(challengers=[self.config3],
+                                                   incumbent=None,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        self.assertEqual(run_info.config, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=None, run_history=self.rh, )
+        if run_info.config and (run_info.instance is not None or run_info.seed is not None):
+            status, cost, dur, res = intensifier.eval_challenger(run_info)
+        else:
+            status, cost, dur, res = None, None, None, None
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=None,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(inc, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
         self.assertEqual(intensifier.n_iters, 1)  # 1 intensification run complete!
 
         # regular intensification begins - run incumbent
-        config, _ = intensifier.get_next_challenger(challengers=None,  # since incumbent is run, no configs required
-                                                    chooser=None)
-        self.assertEqual(config, inc)
-        self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        run_info = intensifier.get_next_challenger(challengers=None,  # since incumbent is run, no configs required
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        self.assertEqual(run_info.config, inc)
+        # There is a transition from:
+        # IntensifierStage.RUN_FIRST_CONFIG-> IntensifierStage.RUN_INCUMBENT
+        # Because after the first run, incumbent is run.
+        # Nevertheless, there is now a transition:
+        # IntensifierStage.RUN_INCUMBENT->IntensifierStage.RUN_CHALLENGER
+        # because in add_inc_run, there are more available instance pairs
+        self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
+        if run_info.config and (run_info.instance is not None or run_info.seed is not None):
+            status, cost, dur, res = intensifier.eval_challenger(run_info)
+        else:
+            status, cost, dur, res = None, None, None, None
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(intensifier.n_iters, 1)
 
         # Check that we don't walk into the next iteration if the challenger is passed again
-        config, _ = intensifier.get_next_challenger(challengers=[self.config3],
-                                                    chooser=None)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        run_info = intensifier.get_next_challenger(challengers=[self.config3],
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        if run_info.config and (run_info.instance is not None or run_info.seed is not None):
+            status, cost, dur, res = intensifier.eval_challenger(run_info)
+        else:
+            status, cost, dur, res = None, None, None, None
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(intensifier.n_iters, 1)
 
@@ -679,21 +1176,67 @@ class TestIntensify(unittest.TestCase):
         self.rh.add(config=self.config1, cost=1, time=1, status=StatusType.SUCCESS,
                     instance_id=1, seed=0, additional_info=None)
         intensifier.stage = IntensifierStage.RUN_CHALLENGER
-        config, _ = intensifier.get_next_challenger(challengers=[self.config1],
-                                                    chooser=None)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        run_info = intensifier.get_next_challenger(challengers=[self.config1],
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        if run_info.config and (run_info.instance is not None or run_info.seed is not None):
+            status, cost, dur, res = intensifier.eval_challenger(run_info)
+        else:
+            status, cost, dur, res = None, None, None, None
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(intensifier.n_iters, 2)
         self.assertEqual(intensifier.num_chall_run, 0)
 
         # This returns the config evaluating the incumbent again
-        config, _ = intensifier.get_next_challenger(challengers=None, chooser=None)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        run_info = intensifier.get_next_challenger(challengers=None,
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        if run_info.config and (run_info.instance is not None or run_info.seed is not None):
+            status, cost, dur, res = intensifier.eval_challenger(run_info)
+        else:
+            status, cost, dur, res = None, None, None, None
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         # This doesn't return a config because the array of configs is exhausted
-        config, _ = intensifier.get_next_challenger(challengers=None, chooser=None)
-        self.assertIsNone(config)
+        run_info = intensifier.get_next_challenger(challengers=None,
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        self.assertIsNone(run_info.config)
         # This finally gives a runable configuration
-        config, _ = intensifier.get_next_challenger(challengers=[self.config2],
-                                                    chooser=None)
-        inc, _ = intensifier.eval_challenger(challenger=config, incumbent=inc, run_history=self.rh, )
+        run_info = intensifier.get_next_challenger(challengers=[self.config2],
+                                                   incumbent=inc,
+                                                   run_history=self.rh,
+                                                   chooser=None)
+        if run_info.config and (run_info.instance is not None or run_info.seed is not None):
+            status, cost, dur, res = intensifier.eval_challenger(run_info)  # noqa: F841
+        else:
+            status, cost, dur, res = None, None, None, None  # noqa: F841
+        inc, perf = intensifier.process_results(
+            challenger=run_info.config,
+            incumbent=inc,
+            run_history=self.rh,
+            time_bound=np.inf,
+            status=status,
+            runtime=dur,
+            elapsed_time=dur,
+        )
         self.assertEqual(intensifier.n_iters, 3)
         self.assertEqual(intensifier.num_chall_run, 1)

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -454,7 +454,7 @@ class TestIntensify(unittest.TestCase):
             instances=[1],
             deterministic=True)
 
-        instance, seed, cutoff = intensifier._get_next_inc_config(
+        instance, seed, cutoff = intensifier._get_next_inc_run(
             available_insts=intensifier._get_inc_available_inst(
                 incumbent=self.config1,
                 run_history=self.rh
@@ -524,7 +524,7 @@ class TestIntensify(unittest.TestCase):
             instances=[1, 2],
             deterministic=False)
 
-        instance, seed, cutoff = intensifier._get_next_inc_config(
+        instance, seed, cutoff = intensifier._get_next_inc_run(
             available_insts=intensifier._get_inc_available_inst(
                 incumbent=self.config1,
                 run_history=self.rh
@@ -549,7 +549,7 @@ class TestIntensify(unittest.TestCase):
         )
         self.assertEqual(len(self.rh.data), 1, self.rh.data)
 
-        instance, seed, cutoff = intensifier._get_next_inc_config(
+        instance, seed, cutoff = intensifier._get_next_inc_run(
             available_insts=intensifier._get_inc_available_inst(
                 incumbent=self.config1,
                 run_history=self.rh
@@ -578,7 +578,7 @@ class TestIntensify(unittest.TestCase):
         self.assertIn(1, [runs[0].instance, runs[1].instance])
         self.assertIn(2, [runs[0].instance, runs[1].instance])
 
-        instance, seed, cutoff = intensifier._get_next_inc_config(
+        instance, seed, cutoff = intensifier._get_next_inc_run(
             available_insts=intensifier._get_inc_available_inst(
                 incumbent=self.config1,
                 run_history=self.rh
@@ -1090,12 +1090,11 @@ class TestIntensify(unittest.TestCase):
         intensifier.stage = IntensifierStage.RUN_CHALLENGER
 
         # In the upcoming get next run, the stage is RUN_CHALLENGER
-        # So config1 is tried to be run. Nevertheless, there are no further
-        # runs for this challenger available, that is, race challenger
-        # can do nothing. Instead for returning None, the code tries
-        # to grab a new iteration, but all of them are exhausted
-        # In this particular unit testing, no further new configurations
-        # nor a chooser is provided, so we run into a value error
+        # so the intensifier tries to run config1. Nevertheless,
+        # there are no further instances for this configuration available.
+        # In this scenario, the intensifier produces a SKIP intent as an indication
+        # that a new iteration must be initiated, and for code simplicity,
+        # relies on a new call to get_next_run to yield more configurations
         intent, run_info = intensifier.get_next_run(
             challengers=[self.config1],
             incumbent=inc,

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -739,9 +739,9 @@ class TestIntensify(unittest.TestCase):
         # intensification iteration #2
         # regular intensification begins - run incumbent first
         run_info = intensifier.get_next_run(challengers=None,  # don't need a new list here as old one is cont'd
-                                                   incumbent=inc,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=inc,
+                                            run_history=self.rh,
+                                            chooser=None)
         self.assertEqual(run_info.config, inc)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
         status, cost, dur, res = eval_challenger(run_info, taf)
@@ -760,9 +760,9 @@ class TestIntensify(unittest.TestCase):
 
         # run challenger now that the incumbent has been executed
         run_info = intensifier.get_next_run(challengers=[self.config1],
-                                                   incumbent=inc,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=inc,
+                                            run_history=self.rh,
+                                            chooser=None)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(run_info.config, self.config1)
         status, cost, dur, res = eval_challenger(run_info, taf)
@@ -783,9 +783,9 @@ class TestIntensify(unittest.TestCase):
 
         # run challenger again on the other instance
         run_info = intensifier.get_next_run(challengers=None,  # don't need a new list here as old one is cont'd
-                                                   incumbent=inc,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=inc,
+                                            run_history=self.rh,
+                                            chooser=None)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(run_info.config, self.config1)
         status, cost, dur, res = eval_challenger(run_info, taf)
@@ -807,9 +807,9 @@ class TestIntensify(unittest.TestCase):
 
         # run basis configuration (`always_race_against`)
         run_info = intensifier.get_next_run(challengers=None,  # don't need a new list here as old one is cont'd
-                                                   incumbent=inc,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=inc,
+                                            run_history=self.rh,
+                                            chooser=None)
         self.assertEqual(run_info.config, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_BASIS)
         status, cost, dur, res = eval_challenger(run_info, taf)
@@ -837,9 +837,9 @@ class TestIntensify(unittest.TestCase):
 
         # intensification continues running incumbent again in same iteration...
         run_info = intensifier.get_next_run(challengers=None,  # don't need a new list here as old one is cont'd
-                                                   incumbent=inc,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=inc,
+                                            run_history=self.rh,
+                                            chooser=None)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
         status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
@@ -882,9 +882,9 @@ class TestIntensify(unittest.TestCase):
         # intensification iteration #1
         # run first config as incumbent if incumbent is None
         run_info = intensifier.get_next_run(challengers=[self.config3],
-                                                   incumbent=None,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=None,
+                                            run_history=self.rh,
+                                            chooser=None)
         self.assertEqual(run_info.config, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
         # eval config 2 (=first run)
@@ -973,9 +973,9 @@ class TestIntensify(unittest.TestCase):
 
         # run challenger
         run_info = intensifier.get_next_run(challengers=None,  # don't need a new list here as old one is cont'd
-                                                   incumbent=inc,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=inc,
+                                            run_history=self.rh,
+                                            chooser=None)
         self.assertEqual(run_info.config, self.config1)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         status, cost, dur, res = eval_challenger(run_info, taf)
@@ -1026,9 +1026,9 @@ class TestIntensify(unittest.TestCase):
 
         # intensification - incumbent will be run, but not as RUN_FIRST_CONFIG stage
         run_info = intensifier.get_next_run(challengers=[self.config2],
-                                                   incumbent=self.config1,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=self.config1,
+                                            run_history=self.rh,
+                                            chooser=None)
         status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
@@ -1066,9 +1066,9 @@ class TestIntensify(unittest.TestCase):
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
 
         run_info = intensifier.get_next_run(challengers=[self.config3],
-                                                   incumbent=None,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=None,
+                                            run_history=self.rh,
+                                            chooser=None)
         self.assertEqual(run_info.config, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
         status, cost, dur, res = eval_challenger(run_info, taf)
@@ -1115,9 +1115,9 @@ class TestIntensify(unittest.TestCase):
                     instance_id=1, seed=0, additional_info=None)
         intensifier.stage = IntensifierStage.RUN_CHALLENGER
         run_info = intensifier.get_next_run(challengers=[self.config1],
-                                                   incumbent=inc,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=inc,
+                                            run_history=self.rh,
+                                            chooser=None)
 
         # In the above get next challenger, the stage is RUN_CHALLENGER
         # So config1 is tried to be run. Nevertheless, there are no further
@@ -1141,9 +1141,9 @@ class TestIntensify(unittest.TestCase):
         self.assertIsNone(config)
         # This finally gives a runable configuration
         run_info = intensifier.get_next_run(challengers=[self.config2],
-                                                   incumbent=inc,
-                                                   run_history=self.rh,
-                                                   chooser=None)
+                                            incumbent=inc,
+                                            run_history=self.rh,
+                                            chooser=None)
         status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         inc, perf = intensifier.process_results(
             challenger=run_info.config,

--- a/test/test_intensify/test_intensify.py
+++ b/test/test_intensify/test_intensify.py
@@ -16,7 +16,7 @@ from smac.intensification.intensification import Intensifier, IntensifierStage
 from smac.facade.smac_ac_facade import SMAC4AC
 from smac.tae.execute_ta_run import StatusType
 from smac.utils.io.traj_logging import TrajLogger
-from smac.optimizer.smbo import SMBO
+from smac.optimizer.smbo import eval_challenger
 
 
 def get_config_space():
@@ -81,7 +81,7 @@ class TestIntensify(unittest.TestCase):
             incumbent=self.config1,
             run_history=self.rh
         )
-        status, cost, dur, res = SMBO.eval_challenger(
+        status, cost, dur, res = eval_challenger(
             RunInfo(
                 config=self.config2,
                 instance=instance,
@@ -137,7 +137,7 @@ class TestIntensify(unittest.TestCase):
             incumbent=self.config1,
             run_history=self.rh
         )
-        status, cost, dur, res = SMBO.eval_challenger(
+        status, cost, dur, res = eval_challenger(
             RunInfo(
                 config=self.config2,
                 instance=instance,
@@ -210,7 +210,7 @@ class TestIntensify(unittest.TestCase):
             capped=True,
             budget=0.0,
         )
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=config,
             incumbent=self.config1,
@@ -247,7 +247,7 @@ class TestIntensify(unittest.TestCase):
             capped=False,
             budget=0.0,
         )
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=config,
             incumbent=self.config1,
@@ -278,7 +278,7 @@ class TestIntensify(unittest.TestCase):
             budget=0.0,
         )
 
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=config,
             incumbent=self.config1,
@@ -348,7 +348,7 @@ class TestIntensify(unittest.TestCase):
                 budget=0.0,
             )
 
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+            status, cost, dur, res = eval_challenger(run_info, taf)
             inc, perf = intensifier.process_results(
                 challenger=config,
                 incumbent=self.config1,
@@ -420,7 +420,7 @@ class TestIntensify(unittest.TestCase):
                 capped=False,
                 budget=0.0,
             )
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+            status, cost, dur, res = eval_challenger(run_info, taf)
             inc, perf = intensifier.process_results(
                 challenger=run_info.config,
                 incumbent=self.config1,
@@ -469,7 +469,7 @@ class TestIntensify(unittest.TestCase):
             incumbent=self.config1,
             run_history=self.rh
         )
-        status, cost, dur, res = SMBO.eval_challenger(
+        status, cost, dur, res = eval_challenger(
             RunInfo(
                 config=self.config1,
                 instance=instance,
@@ -541,7 +541,7 @@ class TestIntensify(unittest.TestCase):
             incumbent=self.config1,
             run_history=self.rh
         )
-        status, cost, dur, res = SMBO.eval_challenger(
+        status, cost, dur, res = eval_challenger(
             RunInfo(
                 config=self.config1,
                 instance=instance,
@@ -568,7 +568,7 @@ class TestIntensify(unittest.TestCase):
             incumbent=self.config1,
             run_history=self.rh
         )
-        status, cost, dur, res = SMBO.eval_challenger(
+        status, cost, dur, res = eval_challenger(
             RunInfo(
                 config=self.config1,
                 instance=instance,
@@ -599,7 +599,7 @@ class TestIntensify(unittest.TestCase):
             incumbent=self.config1,
             run_history=self.rh
         )
-        status, cost, dur, res = SMBO.eval_challenger(
+        status, cost, dur, res = eval_challenger(
             RunInfo(
                 config=self.config1,
                 instance=instance,
@@ -629,7 +629,7 @@ class TestIntensify(unittest.TestCase):
 
     def test_query_next_challenger(self):
         """
-            test get_next_challenger()
+            test _query_next_challenger()
         """
         intensifier = Intensifier(
             stats=self.stats,
@@ -711,7 +711,7 @@ class TestIntensify(unittest.TestCase):
 
         # intensification iteration #1
         # run first config as incumbent if incumbent is None
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             incumbent=None,
             run_history=self.rh,
             challengers=[self.config2],
@@ -720,7 +720,7 @@ class TestIntensify(unittest.TestCase):
         self.assertEqual(run_info.config, self.config2)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
         # eval config 2 (=first run)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=None,
@@ -738,13 +738,13 @@ class TestIntensify(unittest.TestCase):
 
         # intensification iteration #2
         # regular intensification begins - run incumbent first
-        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+        run_info = intensifier.get_next_run(challengers=None,  # don't need a new list here as old one is cont'd
                                                    incumbent=inc,
                                                    run_history=self.rh,
                                                    chooser=None)
         self.assertEqual(run_info.config, inc)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=inc,
@@ -759,13 +759,13 @@ class TestIntensify(unittest.TestCase):
         self.assertEqual(self.stats.inc_changed, 1)
 
         # run challenger now that the incumbent has been executed
-        run_info = intensifier.get_next_challenger(challengers=[self.config1],
+        run_info = intensifier.get_next_run(challengers=[self.config1],
                                                    incumbent=inc,
                                                    run_history=self.rh,
                                                    chooser=None)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(run_info.config, self.config1)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=inc,
@@ -782,13 +782,13 @@ class TestIntensify(unittest.TestCase):
         self.assertTrue(intensifier.continue_challenger)
 
         # run challenger again on the other instance
-        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+        run_info = intensifier.get_next_run(challengers=None,  # don't need a new list here as old one is cont'd
                                                    incumbent=inc,
                                                    run_history=self.rh,
                                                    chooser=None)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(run_info.config, self.config1)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=inc,
@@ -806,13 +806,13 @@ class TestIntensify(unittest.TestCase):
         self.assertFalse(intensifier.continue_challenger)
 
         # run basis configuration (`always_race_against`)
-        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+        run_info = intensifier.get_next_run(challengers=None,  # don't need a new list here as old one is cont'd
                                                    incumbent=inc,
                                                    run_history=self.rh,
                                                    chooser=None)
         self.assertEqual(run_info.config, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_BASIS)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=inc,
@@ -836,12 +836,12 @@ class TestIntensify(unittest.TestCase):
             next(intensifier.configs_to_run)
 
         # intensification continues running incumbent again in same iteration...
-        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+        run_info = intensifier.get_next_run(challengers=None,  # don't need a new list here as old one is cont'd
                                                    incumbent=inc,
                                                    run_history=self.rh,
                                                    chooser=None)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=inc,
@@ -881,14 +881,14 @@ class TestIntensify(unittest.TestCase):
 
         # intensification iteration #1
         # run first config as incumbent if incumbent is None
-        run_info = intensifier.get_next_challenger(challengers=[self.config3],
+        run_info = intensifier.get_next_run(challengers=[self.config3],
                                                    incumbent=None,
                                                    run_history=self.rh,
                                                    chooser=None)
         self.assertEqual(run_info.config, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
         # eval config 2 (=first run)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=None,
@@ -907,7 +907,7 @@ class TestIntensify(unittest.TestCase):
         # Normally a challenger will be given, which in this case is the incumbent
         # But no more instances are available. So to prevent cicles
         # where No iteration happens, provide the challengers
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config2, self.config1],  # since incumbent is run, no configs required
             incumbent=inc,
             run_history=self.rh,
@@ -925,7 +925,7 @@ class TestIntensify(unittest.TestCase):
         # So this call happen above, to save one iteration
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(run_info.config, self.config2)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=inc,
@@ -960,7 +960,7 @@ class TestIntensify(unittest.TestCase):
         # self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_INCUMBENT)
 
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=inc,
@@ -972,13 +972,13 @@ class TestIntensify(unittest.TestCase):
         )
 
         # run challenger
-        run_info = intensifier.get_next_challenger(challengers=None,  # don't need a new list here as old one is cont'd
+        run_info = intensifier.get_next_run(challengers=None,  # don't need a new list here as old one is cont'd
                                                    incumbent=inc,
                                                    run_history=self.rh,
                                                    chooser=None)
         self.assertEqual(run_info.config, self.config1)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_CHALLENGER)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=inc,
@@ -1025,11 +1025,11 @@ class TestIntensify(unittest.TestCase):
                     instance_id=1, seed=None, additional_info=None)
 
         # intensification - incumbent will be run, but not as RUN_FIRST_CONFIG stage
-        run_info = intensifier.get_next_challenger(challengers=[self.config2],
+        run_info = intensifier.get_next_run(challengers=[self.config2],
                                                    incumbent=self.config1,
                                                    run_history=self.rh,
                                                    chooser=None)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=self.config1,
@@ -1065,13 +1065,13 @@ class TestIntensify(unittest.TestCase):
         self.assertEqual(intensifier.n_iters, 0)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
 
-        run_info = intensifier.get_next_challenger(challengers=[self.config3],
+        run_info = intensifier.get_next_run(challengers=[self.config3],
                                                    incumbent=None,
                                                    run_history=self.rh,
                                                    chooser=None)
         self.assertEqual(run_info.config, self.config3)
         self.assertEqual(intensifier.stage, IntensifierStage.RUN_FIRST_CONFIG)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)
+        status, cost, dur, res = eval_challenger(run_info, taf)
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=None,
@@ -1095,7 +1095,7 @@ class TestIntensify(unittest.TestCase):
         # Challenger was the same as the current incumbent; Skipping challenger
         # Then, we try to get more challengers, but below all challengers
         # Provided are config3, the incumbent which means nothing more to run
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config3],  # since incumbent is run, no configs required
             incumbent=inc,
             run_history=self.rh,
@@ -1114,7 +1114,7 @@ class TestIntensify(unittest.TestCase):
         self.rh.add(config=self.config1, cost=1, time=1, status=StatusType.SUCCESS,
                     instance_id=1, seed=0, additional_info=None)
         intensifier.stage = IntensifierStage.RUN_CHALLENGER
-        run_info = intensifier.get_next_challenger(challengers=[self.config1],
+        run_info = intensifier.get_next_run(challengers=[self.config1],
                                                    incumbent=inc,
                                                    run_history=self.rh,
                                                    chooser=None)
@@ -1140,11 +1140,11 @@ class TestIntensify(unittest.TestCase):
                                                        chooser=None)
         self.assertIsNone(config)
         # This finally gives a runable configuration
-        run_info = intensifier.get_next_challenger(challengers=[self.config2],
+        run_info = intensifier.get_next_run(challengers=[self.config2],
                                                    incumbent=inc,
                                                    run_history=self.rh,
                                                    chooser=None)
-        status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+        status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         inc, perf = intensifier.process_results(
             challenger=run_info.config,
             incumbent=inc,

--- a/test/test_intensify/test_successive_halving.py
+++ b/test/test_intensify/test_successive_halving.py
@@ -269,7 +269,7 @@ class TestSuccessiveHalving(unittest.TestCase):
             cutoff=1, instances=[1, 2], initial_budget=1, max_budget=2, eta=2)
 
         # next challenger from a list
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config1],
             chooser=None,
             run_history=self.rh,
@@ -279,7 +279,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertTrue(intensifier.new_challenger)
 
         # until evaluated, does not pick new challenger
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             run_history=self.rh,
@@ -300,7 +300,7 @@ class TestSuccessiveHalving(unittest.TestCase):
             result=result,
             log_traj=False,
         )
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             incumbent=inc,
@@ -324,7 +324,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         intensifier.configs_to_run = [self.config1]
 
         # next challenger should come from configs to run
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=None,
             chooser=None,
             run_history=self.rh,
@@ -454,7 +454,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         intensifier.success_challengers = {self.config2, self.config3}
         intensifier._update_stage(run_history=self.rh)
 
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config1],
             chooser=None,
             incumbent=self.config1,
@@ -495,7 +495,7 @@ class TestSuccessiveHalving(unittest.TestCase):
             instances=[1, 2], initial_budget=1, max_budget=2, eta=2, instance_order=None)
 
         # config1 should be executed successfully and selected as incumbent
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config1],
             chooser=None,
             incumbent=None,
@@ -515,7 +515,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         # config2 should be capped and config1 should still be the incumbent
 
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             incumbent=inc,
@@ -535,7 +535,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(list(self.rh.data.values())[1][2], StatusType.CAPPED)
 
         # config1 is selected for the next stage and allowed to timeout since this is the 1st run for this instance
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[],
             chooser=None,
             incumbent=inc,
@@ -582,7 +582,7 @@ class TestSuccessiveHalving(unittest.TestCase):
                         additional_info=None)
 
         # provide configurations
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             incumbent=self.config1,
@@ -602,7 +602,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(len(intensifier.success_challengers), 0)
 
         # provide configurations
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config3],
             chooser=None,
             incumbent=self.config1,
@@ -630,7 +630,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         # should raise an error as this is a new iteration but no configs were provided
         with self.assertRaisesRegex(ValueError, 'No configurations/chooser provided.'):
-            behest, run_info = intensifier.get_next_run(
+            intent, run_info = intensifier.get_next_run(
                 challengers=None,
                 chooser=None,
                 incumbent=self.config1,
@@ -656,7 +656,7 @@ class TestSuccessiveHalving(unittest.TestCase):
             instances=[1, 2], n_seeds=2, initial_budget=1, max_budget=4, eta=2, instance_order=None)
 
         # first configuration run
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config4],
             chooser=None,
             incumbent=None,
@@ -674,7 +674,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         # remaining 3 runs should be capped
         for i in [self.config1, self.config2, self.config3]:
-            behest, run_info = intensifier.get_next_run(
+            intent, run_info = intensifier.get_next_run(
                 challengers=[i],
                 chooser=None,
                 incumbent=inc,
@@ -698,7 +698,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         # run next stage - should run only 1 configuration since other 3 were capped
         # 1 runs for config1
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[],
             chooser=None,
             incumbent=inc,
@@ -718,7 +718,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         # run next stage with only config1
         # should go to next iteration since no more configurations left
         for _ in range(2):
-            behest, run_info = intensifier.get_next_run(
+            intent, run_info = intensifier.get_next_run(
                 challengers=[],
                 chooser=None,
                 incumbent=inc,
@@ -769,7 +769,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         self.assertEqual(intensifier.inst_seed_pairs, [(0, 0), (1, 0)])
 
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config1],
             chooser=None,
             incumbent=None,
@@ -789,7 +789,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(intensifier.configs_to_run, [])
         self.assertEqual(intensifier.stage, 0)
 
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             incumbent=inc,
@@ -809,7 +809,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(intensifier.configs_to_run, [self.config1])  # Incumbent is promoted to the next stage
         self.assertEqual(intensifier.stage, 1)
 
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config3],
             chooser=None,
             incumbent=inc,
@@ -835,7 +835,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         self.assertEqual(intensifier.inst_seed_pairs, [(1, 0), (0, 0)])
 
-        behest, run_info = intensifier.get_next_run(
+        intent, run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             incumbent=inc,

--- a/test/test_intensify/test_successive_halving.py
+++ b/test/test_intensify/test_successive_halving.py
@@ -15,7 +15,7 @@ from smac.runhistory.runhistory import RunHistory
 from smac.tae.execute_ta_run import StatusType
 from smac.stats.stats import Stats
 from smac.utils.io.traj_logging import TrajLogger
-from smac.optimizer.smbo import SMBO
+from smac.optimizer.smbo import eval_challenger
 
 
 def get_config_space():
@@ -251,9 +251,9 @@ class TestSuccessiveHalving(unittest.TestCase):
         intensifier._update_stage(self.rh)
         self.assertEqual(intensifier.stage, 0)  # going back, since there are not enough to advance
 
-    def test_get_next_challenger_1(self):
+    def test_get_next_run_1(self):
         """
-            test get_next_challenger for a presently running configuration
+            test get_next_run for a presently running configuration
         """
         def target(x):
             return 1
@@ -268,7 +268,7 @@ class TestSuccessiveHalving(unittest.TestCase):
             cutoff=1, instances=[1, 2], initial_budget=1, max_budget=2, eta=2)
 
         # next challenger from a list
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config1],
             chooser=None,
             run_history=self.rh,
@@ -278,7 +278,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertTrue(intensifier.new_challenger)
 
         # until evaluated, does not pick new challenger
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             run_history=self.rh,
@@ -290,7 +290,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         # evaluating configuration
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -303,7 +303,7 @@ class TestSuccessiveHalving(unittest.TestCase):
             elapsed_time=dur,
             log_traj=False,
         )
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             incumbent=inc,
@@ -313,9 +313,9 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(len(intensifier.success_challengers), 1)
         self.assertTrue(intensifier.new_challenger)
 
-    def test_get_next_challenger_2(self):
+    def test_get_next_run_2(self):
         """
-            test get_next_challenger for higher stages of SH iteration
+            test get_next_run for higher stages of SH iteration
         """
         intensifier = SuccessiveHalving(
             stats=self.stats, traj_logger=None,
@@ -327,7 +327,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         intensifier.configs_to_run = [self.config1]
 
         # next challenger should come from configs to run
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=None,
             chooser=None,
             run_history=self.rh,
@@ -457,14 +457,14 @@ class TestSuccessiveHalving(unittest.TestCase):
         intensifier.success_challengers = {self.config2, self.config3}
         intensifier._update_stage(run_history=self.rh)
 
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config1],
             chooser=None,
             incumbent=self.config1,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -503,14 +503,14 @@ class TestSuccessiveHalving(unittest.TestCase):
             instances=[1, 2], initial_budget=1, max_budget=2, eta=2, instance_order=None)
 
         # config1 should be executed successfully and selected as incumbent
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config1],
             chooser=None,
             incumbent=None,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -528,14 +528,14 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         # config2 should be capped and config1 should still be the incumbent
 
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             incumbent=inc,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -553,14 +553,14 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(list(self.rh.data.values())[1][2], StatusType.CAPPED)
 
         # config1 is selected for the next stage and allowed to timeout since this is the 1st run for this instance
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[],
             chooser=None,
             incumbent=inc,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -605,14 +605,14 @@ class TestSuccessiveHalving(unittest.TestCase):
                         additional_info=None)
 
         # provide configurations
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             incumbent=self.config1,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -630,14 +630,14 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(len(intensifier.success_challengers), 0)
 
         # provide configurations
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config3],
             chooser=None,
             incumbent=self.config1,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -663,7 +663,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         # should raise an error as this is a new iteration but no configs were provided
         with self.assertRaisesRegex(ValueError, 'No configurations/chooser provided.'):
-            run_info = intensifier.get_next_challenger(
+            run_info = intensifier.get_next_run(
                 challengers=None,
                 chooser=None,
                 incumbent=self.config1,
@@ -689,14 +689,14 @@ class TestSuccessiveHalving(unittest.TestCase):
             instances=[1, 2], n_seeds=2, initial_budget=1, max_budget=4, eta=2, instance_order=None)
 
         # first configuration run
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config4],
             chooser=None,
             incumbent=None,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -712,14 +712,14 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         # remaining 3 runs should be capped
         for i in [self.config1, self.config2, self.config3]:
-            run_info = intensifier.get_next_challenger(
+            run_info = intensifier.get_next_run(
                 challengers=[i],
                 chooser=None,
                 incumbent=inc,
                 run_history=self.rh
             )
             if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-                status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+                status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
             else:
                 status, cost, dur, res = None, None, None, None  # noqa: F841
             inc, inc_value = intensifier.process_results(
@@ -741,7 +741,7 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         # run next stage - should run only 1 configuration since other 3 were capped
         # 1 runs for config1
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[],
             chooser=None,
             incumbent=inc,
@@ -749,7 +749,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         )
         self.assertEqual(run_info.config, self.config4)
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -766,7 +766,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         # run next stage with only config1
         # should go to next iteration since no more configurations left
         for _ in range(2):
-            run_info = intensifier.get_next_challenger(
+            run_info = intensifier.get_next_run(
                 challengers=[],
                 chooser=None,
                 incumbent=inc,
@@ -774,7 +774,7 @@ class TestSuccessiveHalving(unittest.TestCase):
             )
             self.assertEqual(run_info.config, self.config4)
             if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-                status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+                status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
             else:
                 status, cost, dur, res = None, None, None, None  # noqa: F841
             inc, inc_value = intensifier.process_results(
@@ -793,7 +793,7 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(intensifier.stage, 0)
 
         with self.assertRaisesRegex(ValueError, 'No configurations/chooser provided.'):
-            intensifier.get_next_challenger(
+            intensifier.get_next_run(
                 challengers=[],
                 chooser=None,
                 incumbent=inc,
@@ -822,14 +822,14 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         self.assertEqual(intensifier.inst_seed_pairs, [(0, 0), (1, 0)])
 
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config1],
             chooser=None,
             incumbent=None,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -847,14 +847,14 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(intensifier.configs_to_run, [])
         self.assertEqual(intensifier.stage, 0)
 
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             incumbent=inc,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -872,14 +872,14 @@ class TestSuccessiveHalving(unittest.TestCase):
         self.assertEqual(intensifier.configs_to_run, [self.config1])  # Incumbent is promoted to the next stage
         self.assertEqual(intensifier.stage, 1)
 
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config3],
             chooser=None,
             incumbent=inc,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(
@@ -903,14 +903,14 @@ class TestSuccessiveHalving(unittest.TestCase):
 
         self.assertEqual(intensifier.inst_seed_pairs, [(1, 0), (0, 0)])
 
-        run_info = intensifier.get_next_challenger(
+        run_info = intensifier.get_next_run(
             challengers=[self.config2],
             chooser=None,
             incumbent=inc,
             run_history=self.rh
         )
         if run_info.config and (run_info.instance is not None or run_info.seed is not None):
-            status, cost, dur, res = SMBO.eval_challenger(run_info, taf)  # noqa: F841
+            status, cost, dur, res = eval_challenger(run_info, taf)  # noqa: F841
         else:
             status, cost, dur, res = None, None, None, None  # noqa: F841
         inc, inc_value = intensifier.process_results(

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from smac.epm.rf_with_instances import RandomForestWithInstances
 from smac.facade.smac_ac_facade import SMAC4AC
-from smac.intensification.intensification import Intensifier
 from smac.optimizer.acquisition import EI, LogEI
 from smac.runhistory.runhistory2epm import RunHistory2EPM4Cost, RunHistory2EPM4LogCost
 from smac.scenario.scenario import Scenario
@@ -14,7 +13,6 @@ from smac.tae.execute_ta_run import FirstRunCrashedException
 from smac.utils import test_helpers
 from smac.utils.io.traj_logging import TrajLogger
 from smac.utils.validate import Validator
-from smac.optimizer.smbo import eval_challenger
 
 
 class ConfigurationMock(object):

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -14,6 +14,7 @@ from smac.tae.execute_ta_run import FirstRunCrashedException
 from smac.utils import test_helpers
 from smac.utils.io.traj_logging import TrajLogger
 from smac.utils.validate import Validator
+from smac.optimizer.smbo import SMBO
 
 
 class ConfigurationMock(object):
@@ -79,7 +80,7 @@ class TestSMBO(unittest.TestCase):
             rng='BLA',
         )
 
-    @mock.patch.object(Intensifier, 'eval_challenger')
+    @mock.patch.object(SMBO, 'eval_challenger')
     def test_abort_on_initial_design(self, patch):
         def target(x):
             return 5

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -14,7 +14,7 @@ from smac.tae.execute_ta_run import FirstRunCrashedException
 from smac.utils import test_helpers
 from smac.utils.io.traj_logging import TrajLogger
 from smac.utils.validate import Validator
-from smac.optimizer.smbo import SMBO
+from smac.optimizer.smbo import eval_challenger
 
 
 class ConfigurationMock(object):
@@ -80,7 +80,7 @@ class TestSMBO(unittest.TestCase):
             rng='BLA',
         )
 
-    @mock.patch.object(SMBO, 'eval_challenger')
+    @mock.patch('smac.optimizer.smbo.eval_challenger')
     def test_abort_on_initial_design(self, patch):
         def target(x):
             return 5
@@ -139,7 +139,7 @@ class TestSMBO(unittest.TestCase):
 
     def test_update_intensification_percentage(self):
         """
-        This test checks the insification time bound is updated in subsequent iterations as long as
+        This test checks the intensification time bound is updated in subsequent iterations as long as
         num_runs of the intensifier is not reset to zero.
         """
 
@@ -157,19 +157,19 @@ class TestSMBO(unittest.TestCase):
         solver._get_timebound_for_intensification = unittest.mock.Mock(wraps=solver._get_timebound_for_intensification)
 
         class SideEffect:
-            def __init__(self, intensifier, get_next_challenger):
+            def __init__(self, intensifier, get_next_run):
                 self.intensifier = intensifier
-                self.get_next_challenger = get_next_challenger
+                self.get_next_run = get_next_run
                 self.counter = 0
 
             def __call__(self, *args, **kwargs):
                 self.counter += 1
                 if self.counter % 4 == 0:
                     self.intensifier.num_run = 0
-                return self.get_next_challenger(*args, **kwargs)
+                return self.get_next_run(*args, **kwargs)
 
-        solver.intensifier.get_next_challenger = unittest.mock.Mock(
-            side_effect=SideEffect(solver.intensifier, solver.intensifier.get_next_challenger))
+        solver.intensifier.get_next_run = unittest.mock.Mock(
+            side_effect=SideEffect(solver.intensifier, solver.intensifier.get_next_run))
 
         solver.run()
 

--- a/test/test_tae/test_exec_tae_run.py
+++ b/test/test_tae/test_exec_tae_run.py
@@ -18,6 +18,8 @@ from smac.tae.execute_ta_run import BudgetExhaustedException, TAEAbortException
 from smac.tae.execute_ta_run import FirstRunCrashedException
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
+from smac.tae.execute_ta_run_wrapper import execute_ta_run_wrapper
+from smac.runhistory.runhistory import RunInfo
 
 if sys.version_info[0] == 2:
     import mock
@@ -49,8 +51,14 @@ class TaeTest(unittest.TestCase):
         eta = ExecuteTARun(ta=lambda *args: None,  # Dummy-function
                            stats=stats)
 
-        self.assertRaises(
-            BudgetExhaustedException, eta.start, config={}, instance=1)
+        # Dummy run. When on budget exhausted, the smbo
+        # loop is notified via the result status
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config=None, instance=None, instance_specific=None,
+            cutoff=None, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(result.status, StatusType.BUDGETEXHAUSTED)
+
 
     @mock.patch.object(ExecuteTARun, 'run')
     def test_start_tae_return_abort(self, test_run):
@@ -72,27 +80,12 @@ class TaeTest(unittest.TestCase):
         stats.start_timing()
         eta = ExecuteTARun(ta=lambda *args: None, stats=stats)
 
-        self.assertRaises(
-            TAEAbortException, eta.start, config={}, instance=1, cutoff=30)
-
-    @mock.patch.object(ExecuteTARun, 'run')
-    def test_start_crash_first_run(self, test_run):
-        '''
-            testing crash-on-first-run
-        '''
-        # Patch run-function for custom-return
-        test_run.return_value = StatusType.CRASHED, 12345.0, 1.2345, {}
-
-        scen = Scenario(scenario={'cs': ConfigurationSpace(),
-                                  'run_obj': 'quality',
-                                  'output_dir': ''}, cmd_options=None)
-        stats = Stats(scen)
-        stats.start_timing()
-        eta = ExecuteTARun(ta=lambda *args: None, stats=stats,
-                           run_obj="quality", abort_on_first_run_crash=True)
-
-        self.assertRaises(
-            FirstRunCrashedException, eta.start, config={}, instance=1)
+        with self.assertRaises(TAEAbortException):
+            execute_ta_run_wrapper(eta, RunInfo(
+                config=None, instance=1, instance_specific=None,
+                cutoff=30, seed=None, capped=False, budget=0.0
+                )
+            )
 
     @mock.patch.object(ExecuteTARun, 'run')
     def test_start_tae_return_nan_inf(self, test_run):
@@ -115,35 +108,67 @@ class TaeTest(unittest.TestCase):
         eta = get_tae('runtime')
         # Patch run-function for custom-return (obj = runtime, cost = nan)
         test_run.return_value = StatusType.SUCCESS, np.nan, 1, {}
-        self.assertEqual(eta.start(config={}, cutoff=10, instance=1)[0], StatusType.SUCCESS)
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config={}, instance=1, instance_specific="0",
+            cutoff=10, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(result.status, StatusType.SUCCESS)
         #                                      (obj = runtime, runtime = nan)
         test_run.return_value = StatusType.SUCCESS, 1, np.nan, {}
-        self.assertEqual(eta.start(config={}, cutoff=10, instance=1)[0], StatusType.CRASHED)
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config={}, instance=1, instance_specific="0",
+            cutoff=10, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(result.status, StatusType.CRASHED)
 
         eta = get_tae('quality')
         # Patch run-function for custom-return (obj = quality, cost = nan)
         test_run.return_value = StatusType.SUCCESS, np.nan, 1, {}
-        self.assertEqual(eta.start(config={}, instance=1)[0], StatusType.CRASHED)
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config={}, instance=1, instance_specific="0",
+            cutoff=10, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(result.status, StatusType.CRASHED)
         #                                      (obj = quality, runtime = nan)
         test_run.return_value = StatusType.SUCCESS, 1, np.nan, {}
-        self.assertEqual(eta.start(config={}, instance=1)[0], StatusType.SUCCESS)
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config={}, instance=1, instance_specific="0",
+            cutoff=10, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(result.status, StatusType.SUCCESS)
 
         # TEST INF
         eta = get_tae('runtime')
         # Patch run-function for custom-return (obj = runtime, cost = inf)
         test_run.return_value = StatusType.SUCCESS, np.inf, 1, {}
-        self.assertEqual(eta.start(config={}, cutoff=10, instance=1)[0], StatusType.SUCCESS)
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config={}, instance=1, instance_specific="0",
+            cutoff=10, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(result.status, StatusType.SUCCESS)
         #                                      (obj = runtime, runtime = inf)
         test_run.return_value = StatusType.SUCCESS, 1, np.inf, {}
-        self.assertEqual(eta.start(config={}, cutoff=10, instance=1)[0], StatusType.TIMEOUT)
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config={}, instance=1, instance_specific="0",
+            cutoff=10, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(result.status, StatusType.TIMEOUT)
 
         eta = get_tae('quality')
         # Patch run-function for custom-return (obj = quality, cost = inf)
         test_run.return_value = StatusType.SUCCESS, np.inf, 1, {}
-        self.assertEqual(eta.start(config={}, instance=1)[0], StatusType.CRASHED)
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config={}, instance=1, instance_specific="0",
+            cutoff=10, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(result.status, StatusType.CRASHED)
         #                                      (obj = quality, runtime = inf)
         test_run.return_value = StatusType.SUCCESS, 1, np.inf, {}
-        self.assertEqual(eta.start(config={}, instance=1)[0], StatusType.SUCCESS)
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config={}, instance=1, instance_specific="0",
+            cutoff=10, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(result.status, StatusType.SUCCESS)
 
     @mock.patch.object(ExecuteTARun, 'run')
     def test_crashed_cost_value(self, test_run):
@@ -161,12 +186,20 @@ class TaeTest(unittest.TestCase):
         test_run.return_value = StatusType.CRASHED, np.nan, np.nan, {}
         eta = ExecuteTARun(ta=lambda *args: None, stats=stats,
                            run_obj='quality', cost_for_crash=100)
-        self.assertEqual(100, eta.start(config={}, instance=1)[1])
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config={}, instance=1, instance_specific="0",
+            cutoff=None, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(100, result.cost)
 
         # Check runtime
         eta = ExecuteTARun(ta=lambda *args: None, stats=stats,
                            run_obj='runtime', cost_for_crash=10.7)
-        self.assertEqual(20.0, eta.start(config={}, instance=1, cutoff=20)[1])
+        result = execute_ta_run_wrapper(eta, RunInfo(
+            config={}, instance=1, instance_specific="0",
+            cutoff=20, seed=None, capped=False, budget=0.0
+        ))
+        self.assertEqual(20.0, result.cost)
 
 
 if __name__ == "__main__":

--- a/test/test_tae/test_exec_tae_run.py
+++ b/test/test_tae/test_exec_tae_run.py
@@ -14,8 +14,7 @@ import numpy as np
 
 from smac.configspace import ConfigurationSpace
 from smac.tae.execute_ta_run import ExecuteTARun, StatusType
-from smac.tae.execute_ta_run import BudgetExhaustedException, TAEAbortException
-from smac.tae.execute_ta_run import FirstRunCrashedException
+from smac.tae.execute_ta_run import TAEAbortException
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
 from smac.tae.execute_ta_run_wrapper import execute_ta_run_wrapper
@@ -59,7 +58,6 @@ class TaeTest(unittest.TestCase):
         ))
         self.assertEqual(result.status, StatusType.BUDGETEXHAUSTED)
 
-
     @mock.patch.object(ExecuteTARun, 'run')
     def test_start_tae_return_abort(self, test_run):
         '''
@@ -81,9 +79,10 @@ class TaeTest(unittest.TestCase):
         eta = ExecuteTARun(ta=lambda *args: None, stats=stats)
 
         with self.assertRaises(TAEAbortException):
-            execute_ta_run_wrapper(eta, RunInfo(
-                config=None, instance=1, instance_specific=None,
-                cutoff=30, seed=None, capped=False, budget=0.0
+            execute_ta_run_wrapper(
+                eta, RunInfo(
+                    config=None, instance=1, instance_specific=None,
+                    cutoff=30, seed=None, capped=False, budget=0.0
                 )
             )
 


### PR DESCRIPTION
Separated evaluation from get next challengers in intensification.

Created an object called runinfo that contains the necessary information for an isolated run.

The intensifier is now a state machine with the main stages given by (also in old code):
    RUN_FIRST_CONFIG = 0  # to replicate the old initial design
     RUN_INCUMBENT = 1  # Lines 3-7
     RUN_CHALLENGER = 2  # Lines 8-17
     RUN_BASIS = 3
and substrates given by (new):
         self.challenger_same_as_incumbent = False
         self.no_available_insts = False
        self.to_run_empty = False

Readjusted the test to have the same functionality. Verified also via examples executing the same line of code using a profiler. Fundamentally, this change can be seen as a reordering such that:

- Eval challenger code was mostly moved to get challengers to be able to obtain the seed/instance
- Added a new function called process results to update the state machine before next iteration
