### PR TITLE
Fix issue #665; BO facade and GPMCMC samples

### DIFF
--- a/smac/epm/gaussian_process_mcmc.py
+++ b/smac/epm/gaussian_process_mcmc.py
@@ -184,7 +184,7 @@ class GaussianProcessMCMC(BaseModel):
                     self.p0, _, _ = sampler.run_mcmc(self.p0, self.chain_length)
 
                 # Take the last samples from each walker
-                self.hypers = sampler.get_chain()[:, -1]
+                self.hypers = sampler.get_chain()[-1]
             elif self.mcmc_sampler == 'nuts':
                 # Originally published as:
                 # http://www.stat.columbia.edu/~gelman/research/published/nuts.pdf

--- a/smac/facade/smac_bo_facade.py
+++ b/smac/facade/smac_bo_facade.py
@@ -104,7 +104,7 @@ class SMAC4BO(SMAC4AC):
                     operate_on=cat_dims,
                 )
 
-            assert len(cont_dims + len(cat_dims)) == len(scenario.cs.get_hyperparameters())
+            assert (len(cont_dims) + len(cat_dims)) == len(scenario.cs.get_hyperparameters())
 
             noise_kernel = WhiteKernel(
                 noise_level=1e-8,

--- a/test/test_epm/test_gp_mcmc.py
+++ b/test/test_epm/test_gp_mcmc.py
@@ -87,6 +87,7 @@ class TestGPMCMC(unittest.TestCase):
         model = get_gp(10, rs)
         np.testing.assert_array_almost_equal(model.kernel.theta, fixture)
         model.train(X[:10], Y[:10])
+        self.assertEqual(len(model.models), 36)
 
         for base_model in model.models:
             theta = base_model.gp.kernel.theta
@@ -185,7 +186,7 @@ class TestGPMCMC(unittest.TestCase):
         model = get_gp(X.shape[1], rs, noise=1e-10, normalize_y=True)
         cv = sklearn.model_selection.KFold(shuffle=True, random_state=rs, n_splits=2)
 
-        maes = [7.8774231707672667164, 8.645038495119097796]
+        maes = [6.841565457149357281, 7.4943401900804902144]
 
         for i, (train_split, test_split) in enumerate(cv.split(X, y)):
             X_train = X[train_split]


### PR DESCRIPTION
This PR fixes issue #665. More specifically, it:

* fixes a wrong assertion in the BOFacade
* uses the final result of the walker ensemble from emcee instead of a single chain (this mistake happened while updating the code to the latest version of emcee).
* adds an additional check that the number of walkers is correct