### PR TITLE
Add config_id to configuration objects prior to execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
   include:
     # Unit tests
     - os: linux
-      env: TESTSUITE=run_unittests.sh PYTHON_VERSION="3.5" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
-    - os: linux
       env: TESTSUITE=run_unittests.sh PYTHON_VERSION="3.6" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
     - os: linux
       env: TESTSUITE=run_unittests.sh PYTHON_VERSION="3.7" COVERAGE="true" DOCPUSH="true" MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ we refer to
     In: Proceedings of the conference on Learning and Intelligent OptimizatioN (LION 5)
 
 
-SMAC v3 is written in Python3 and continuously tested with python3.5 and
+SMAC v3 is written in Python3 and continuously tested with Python 3.6 and
 python3.6. Its [Random Forest](https://github.com/automl/random_forest_run)
 is written in C++.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -55,7 +55,7 @@ Contents:
      |    howpublished={\\url{https://github.com/automl/SMAC3}}
      | }
 
-SMAC3 is mainly written in Python 3 and continuously tested with Python 3.5-3.6.
+SMAC3 is mainly written in Python 3 and continuously tested with Python 3.6-3.8.
 Its `Random Forest <https://github.com/automl/random_forest_run>`_ is written in
 C++11.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.7.1
 scipy>=0.18.1
 psutil
 pynisher>=0.4.1
-ConfigSpace>=0.4.9,<0.5
+ConfigSpace>=0.4.14,<0.5
 scikit-learn>=0.22.0
 pyrfr>=0.8.0
 joblib

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def get_author():
 
 
 setup(
-    python_requires=">=3.5.2",
+    python_requires=">=3.6",
     install_requires=requirements,
     extras_require=extras_require,
     package_data={'smac': ['requirements.txt', 'extras_require.json']},

--- a/smac/__init__.py
+++ b/smac/__init__.py
@@ -28,8 +28,8 @@ for name, requirements in extras_require.items():
             package_name = 'skopt'
         lazy_import.lazy_module(package_name)
 
-if sys.version_info < (3, 5, 2):
-    raise ValueError("SMAC requires Python 3.5.2 or newer.")
+if sys.version_info < (3, 6, 0):
+    raise ValueError("SMAC requires Python 3.6.0 or newer.")
 
 
 if os.name != 'posix':

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -236,6 +236,8 @@ class SMBO(object):
                     budget=run_info.budget,
                 )
 
+                run_info.config.config_id = self.runhistory.config_ids[run_info.config]
+
                 self.tae_runner.submit_run(run_info=run_info)
 
                 # There are 2 criteria that the stats object uses to know

--- a/test/test_smbo/test_epm_configuration_chooser.py
+++ b/test/test_smbo/test_epm_configuration_chooser.py
@@ -1,4 +1,3 @@
-import sys
 import shutil
 import unittest
 from unittest import mock

--- a/test/test_smbo/test_epm_configuration_chooser.py
+++ b/test/test_smbo/test_epm_configuration_chooser.py
@@ -174,7 +174,6 @@ class TestEPMChooser(unittest.TestCase):
         self.assertEqual(num_random_search_sorted, 5000)
         self.assertEqual(num_random_search, 5187)
 
-    @unittest.skipIf(sys.version_info < (3, 6), 'Test not deterministic for Python 3.5 and earlier')
     def test_choose_next_3(self):
         # Test with ten configurations in the runhistory
         def side_effect(X):


### PR DESCRIPTION
I believe the PR name says it all - will be helpful for Auto-sklearn

This PR drop Python 3.5 as the latest ConfigSpace version doesn't support it any more.