### PR TITLE
Logging enhancements and running configs fix

### DIFF
--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -240,7 +240,7 @@ class SMBO(object):
                         self.runhistory.config_ids.get(run_info.config),
                     )
                 )
-                self.runhistory.add(
+                config_id = self.runhistory.add(
                     config=run_info.config,
                     cost=float(MAXINT),
                     time=0.0,
@@ -253,7 +253,7 @@ class SMBO(object):
                 for k, v in self.runhistory.data.items():
                     print(f"RH -- {k}->{v}")
 
-                run_info.config.config_id = self.runhistory.config_ids[run_info.config]
+                run_info.config.config_id = config_id
 
                 self.tae_runner.submit_run(run_info=run_info)
 
@@ -458,13 +458,6 @@ class SMBO(object):
             self._stop = True
             return
 
-        print(
-            "END Going to add config={} config_id_tmp={}".format(
-                run_info.config,
-                self.runhistory.config_ids.get(run_info.config),
-            )
-        )
-
         self.runhistory.add(
             config=run_info.config,
             cost=result.cost,
@@ -475,7 +468,7 @@ class SMBO(object):
             budget=run_info.budget,
             starttime=result.starttime,
             endtime=result.endtime,
-            force_update=True,
+            force_update=run_info.config.config_id,
             additional_info=result.additional_info,
         )
         for k, v in self.runhistory.data.items():

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -282,6 +282,8 @@ class SMBO(object):
             # Check if there is any result, or else continue
             for run_info, result in self.tae_runner.get_finished_runs():
 
+                print(f"Finished_pair run_info={run_info} result={result}")
+
                 # Add the results of the run to the run history
                 # Additionally check for new incumbent
                 self._incorporate_run_results(run_info, result, time_left)

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -216,12 +216,12 @@ class SMBO(object):
             if self.intensifier.num_run == 0:
                 time_spent = time.time() - start_time
                 time_left = self._get_timebound_for_intensification(time_spent, update=False)
-                self.logger.debug('New intensification time bound: %f', time_left)
+                print('New intensification time bound: %f', time_left)
             else:
                 old_time_left = time_left
                 time_spent = time_spent + (time.time() - start_time)
                 time_left = self._get_timebound_for_intensification(time_spent, update=True)
-                self.logger.debug('Updated intensification time bound from %f to %f', old_time_left, time_left)
+                print('Updated intensification time bound from %f to %f', old_time_left, time_left)
 
             # Skip starting new runs if the budget is now exhausted
             if self.stats.is_budget_exhausted():
@@ -234,6 +234,12 @@ class SMBO(object):
                 # Track the fact that a run was launched in the run
                 # history. It's status is tagged as RUNNING, and once
                 # completed and processed, it will be updated accordingly
+                print(
+                    "START Going to add config={} config_id_tmp={}".format(
+                        run_info.config,
+                        self.runhistory.config_ids.get(run_info.config),
+                    )
+                )
                 self.runhistory.add(
                     config=run_info.config,
                     cost=float(MAXINT),
@@ -242,7 +248,10 @@ class SMBO(object):
                     instance_id=run_info.instance,
                     seed=run_info.seed,
                     budget=run_info.budget,
+                    starttime=time.time(),
                 )
+                for k, v in self.runhistory.data.items():
+                    print(f"RH -- {k}->{v}")
 
                 run_info.config.config_id = self.runhistory.config_ids[run_info.config]
 
@@ -283,16 +292,16 @@ class SMBO(object):
                             output_directory=self.scenario.output_dir_for_this_run,  # type: ignore[attr-defined] # noqa F821
                             logger=self.logger)
 
-            self.logger.debug("Remaining budget: %f (wallclock), %f (ta costs), %f (target runs)" % (
+            print("Remaining budget: %f (wallclock), %f (ta costs), %f (target runs)" % (
                 self.stats.get_remaing_time_budget(),
                 self.stats.get_remaining_ta_budget(),
                 self.stats.get_remaining_ta_runs()))
 
             if self.stats.is_budget_exhausted() or self._stop:
                 if self.stats.is_budget_exhausted():
-                    self.logger.debug("Exhausted configuration budget")
+                    print("Exhausted configuration budget")
                 else:
-                    self.logger.debug("Shutting down because a configuration returned status STOP")
+                    print("Shutting down because a configuration returned status STOP")
 
                 # The budget can be exhausted  for 2 reasons: number of ta runs or
                 # time. If the number of ta runs is reached, but there is still budget,
@@ -400,7 +409,7 @@ class SMBO(object):
                              frac_intensify)
         total_time = time_spent / (1 - frac_intensify)
         time_left = frac_intensify * total_time
-        self.logger.debug("Total time: %.4f, time spent on choosing next "
+        print("Total time: %.4f, time spent on choosing next "
                           "configurations: %.4f (%.2f), time left for "
                           "intensification: %.4f (%.2f)" %
                           (total_time, time_spent, (1 - frac_intensify), time_left, frac_intensify))
@@ -433,7 +442,7 @@ class SMBO(object):
         self.stats.ta_time_used += float(result.time)
         self.stats.finished_ta_runs += 1
 
-        self.logger.debug(
+        print(
             "Return: Status: %r, cost: %f, time: %f, additional: %s" % (
                 result.status, result.cost, result.time, str(result.additional_info)
             )
@@ -446,6 +455,13 @@ class SMBO(object):
         elif result.status == StatusType.STOP:
             self._stop = True
             return
+
+        print(
+            "END Going to add config={} config_id_tmp={}".format(
+                run_info.config,
+                self.runhistory.config_ids.get(run_info.config),
+            )
+        )
 
         self.runhistory.add(
             config=run_info.config,
@@ -460,6 +476,8 @@ class SMBO(object):
             force_update=True,
             additional_info=result.additional_info,
         )
+        for k, v in self.runhistory.data.items():
+            print(f"RH -- {k}->{v}")
         self.stats.n_configs = len(self.runhistory.config_ids)
 
         if self.scenario.abort_on_first_run_crash :  # type: ignore[attr-defined] # noqa F821

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -276,9 +276,9 @@ class RunHistory(object):
         # We use the config_id as a hand-shaking mechanism to re-identify the config
         if self.config_ids.get(config) != self.config_ids.get(config, force_update):
             # A new object exists
-            old_config = self.config_ids[self.ids_config[force_update]]
+            old_config = self.ids_config[config_id]
             self.config_ids[config] = self.config_ids.pop(old_config)
-            self.ids_config[force_update] = config
+            self.ids_config[config_id] = config
 
         # Construct keys and values for the data dictionary
         k = RunKey(config_id, instance_id, seed, budget)

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -262,14 +262,6 @@ class RunHistory(object):
         else:
             config_id = typing.cast(int, config_id_tmp)
 
-        print(
-            "Going to add config={} config_id_tmp={} {}".format(
-                config,
-                config_id_tmp,
-                force_update,
-            )
-        )
-
         # Also, in case an object ID changed
         # (that is, when a config is sent to the worker, it will be recreated
         # in the remote object, and the new re-created object will be returned)
@@ -287,7 +279,6 @@ class RunHistory(object):
         # Each runkey is supposed to be used only once. Repeated tries to add
         # the same runkey will be ignored silently if not capped.
         if self.overwrite_existing_runs or force_update or self.data.get(k) is None:
-            print(f"called {force_update} for {k} {v}")
             self._add(k, v, status, origin)
         elif status != StatusType.CAPPED and self.data[k].status == StatusType.CAPPED:
             # overwrite capped runs with uncapped runs

--- a/smac/tae/dask_runner.py
+++ b/smac/tae/dask_runner.py
@@ -161,7 +161,6 @@ class DaskParallelRunner(BaseRunner):
                 run_info
             )
         )
-        print(f"submitted config={run_info} future={self.futures[-1]} so currently self.futures({len(self.futures)})={self.futures}")
 
     def get_finished_runs(self) -> typing.List[typing.Tuple[RunInfo, RunValue]]:
         """This method returns any finished configuration, and returns a list with
@@ -206,11 +205,9 @@ class DaskParallelRunner(BaseRunner):
         # A future is removed to the list of futures as an indication
         # that a worker is available to take in an extra job
         done_futures = [f for f in self.futures if f.done()]
-        print(f"BEFORE Completed runs self.futures({len(self.futures)})={self.futures} and done_futures={done_futures} self.results={self.results}")
         for future in done_futures:
             self.results.append(future.result())
             self.futures.remove(future)
-        print(f"AFTER Completed runs self.futures({len(self.futures)})={self.futures} and done_futures={done_futures} self.results={self.results}")
 
     def wait(self) -> None:
         """SMBO/intensifier might need to wait for runs to finish before making a decision.

--- a/smac/tae/dask_runner.py
+++ b/smac/tae/dask_runner.py
@@ -161,6 +161,7 @@ class DaskParallelRunner(BaseRunner):
                 run_info
             )
         )
+        print(f"submitted config={run_info} future={self.futures[-1]} so currently self.futures({len(self.futures)})={self.futures}")
 
     def get_finished_runs(self) -> typing.List[typing.Tuple[RunInfo, RunValue]]:
         """This method returns any finished configuration, and returns a list with
@@ -205,9 +206,11 @@ class DaskParallelRunner(BaseRunner):
         # A future is removed to the list of futures as an indication
         # that a worker is available to take in an extra job
         done_futures = [f for f in self.futures if f.done()]
+        print(f"BEFORE Completed runs self.futures({len(self.futures)})={self.futures} and done_futures={done_futures} self.results={self.results}")
         for future in done_futures:
             self.results.append(future.result())
             self.futures.remove(future)
+        print(f"AFTER Completed runs self.futures({len(self.futures)})={self.futures} and done_futures={done_futures} self.results={self.results}")
 
     def wait(self) -> None:
         """SMBO/intensifier might need to wait for runs to finish before making a decision.

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -405,8 +405,9 @@ class TestSMBO(unittest.TestCase):
         # Here the run value is the default assumption in
         # case of the run not finishing
         config = cs.sample_configuration()
+        instance = 5
         run_info =  RunInfo(
-            config=config, instance=time.time() % 10,
+            config=config, instance=instance,
             instance_specific={}, seed=0,
             cutoff=None, capped=False, budget=0.0
         )
@@ -458,6 +459,30 @@ class TestSMBO(unittest.TestCase):
             endtime=time.time() + 1,
             additional_info={}
         )
+        smbo._incorporate_run_results(run_info=run_info,
+                                      result=run_value,
+                                      time_left=np.inf)
+        self.assertEqual(smbo.stats.n_configs, 1)
+        self.assertDictEqual(
+            smbo.runhistory.data,
+            {RunKey(
+                config_id=config_id,
+                instance_id=run_info.instance,
+                seed=run_info.seed,
+                budget=run_info.budget
+            ): run_value,
+            }
+        )
+
+        # here drastically change the config, so we rely on the
+        # config id handshaking
+        config = cs.sample_configuration()
+        run_info =  RunInfo(
+            config=config, instance=instance,
+            instance_specific={}, seed=0,
+            cutoff=None, capped=False, budget=0.0
+        )
+        run_info.config.config_id = config_id
         smbo._incorporate_run_results(run_info=run_info,
                                       result=run_value,
                                       time_left=np.inf)

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -406,7 +406,7 @@ class TestSMBO(unittest.TestCase):
         # case of the run not finishing
         config = cs.sample_configuration()
         instance = 5
-        run_info =  RunInfo(
+        run_info = RunInfo(
             config=config, instance=instance,
             instance_specific={}, seed=0,
             cutoff=None, capped=False, budget=0.0
@@ -477,7 +477,7 @@ class TestSMBO(unittest.TestCase):
         # here drastically change the config, so we rely on the
         # config id handshaking
         config = cs.sample_configuration()
-        run_info =  RunInfo(
+        run_info = RunInfo(
             config=config, instance=instance,
             instance_specific={}, seed=0,
             cutoff=None, capped=False, budget=0.0
@@ -497,6 +497,7 @@ class TestSMBO(unittest.TestCase):
             ): run_value,
             }
         )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -293,7 +293,7 @@ class TestSMBO(unittest.TestCase):
             # We create a controlled setting, in which we optimize x^2
             # This will allow us to make sure every component act as expected
 
-            # 16FIRST: config space
+            # FIRST: config space
             cs = ConfigurationSpace()
             cs.add_hyperparameter(UniformFloatHyperparameter('x', -10.0, 10.0))
             smac = SMAC4HPO(


### PR DESCRIPTION
**Problem statement:**
Jobs for a configuration called config are sent to dask and tagged with config_id=1.  It status is then set to RUNNING. It properly completes, but when added back to runhistory through the following question:

```
self.runhistory.config_ids.get(config)
```
Such config no longer is EXACTLY the same, as a worker recreated the object so the ID is different and the above question returns NONE. So that is, when adding the config back to the runhistory, it is added as a whole new configuration.

**My proposed solution:**
Add a better handshaking mechanism that relies on config_id. That is, when runhistory adds the config with config_id=1, we keep adding/tracking/updated based on the config_id, not so much as the object that can change.

BTW, the config is the same, it is just that python re-creates the object with a new id in memory.
