### PR TITLE
fix_695

### DIFF
--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -213,7 +213,7 @@ class _SuccessiveHalving(AbstractRacer):
         # run history, does not have this information and so we track locally. That way,
         # when we access the complete list of configs from the run history, we filter
         # the ones launched by the current succesive halver using self.run_tracker
-        self.run_tracker = []  # type: typing.List[typing.Tuple[Configuration, str, int]]
+        self.run_tracker = {}  # type: typing.Dict[typing.Tuple[Configuration, str, int, float], bool]
 
     def _init_sh_params(self,
                         initial_budget: typing.Optional[float],
@@ -328,6 +328,15 @@ class _SuccessiveHalving(AbstractRacer):
             empirical performance of incumbent configuration
         """
 
+        # Mark the fact that we processed this configuration
+        self.run_tracker[(run_info.config, run_info.instance, run_info.seed, run_info.budget)] = True
+
+        # We need to update the incumbent if this config we are processing
+        # completes the instance seed pair. Here, a config/seed/instance is seen for the first time
+        # so if all configurations runs are marked as RAN it means that this new config
+        # was the missing piece to have everything needed to compare against the incumbent
+        update_incumbent = all([v for k, v in self.run_tracker.items() if k[0] == run_info.config])
+
         # If The incumbent is None and it is the first run, we use the challenger
         if not incumbent and self.first_run:
             self.logger.info(
@@ -336,14 +345,9 @@ class _SuccessiveHalving(AbstractRacer):
             incumbent = run_info.config
             self.first_run = False
 
-        # selecting instance-seed subset for this budget, depending on the kind of budget
-        curr_budget = self.all_budgets[self.stage]
-        if self.instance_as_budget:
-            prev_budget = int(self.all_budgets[self.stage - 1]) if self.stage > 0 else 0
-            curr_insts = self.inst_seed_pairs[int(prev_budget):int(curr_budget)]
-        else:
-            curr_insts = self.inst_seed_pairs
-        n_insts_remaining = len(curr_insts) - self.curr_inst_idx - 1
+        # Account for running instances across configurations, not only on the
+        # running configuration
+        n_insts_remaining = self._get_pending_instances_for_stage(run_history)
 
         # Make sure that there is no Budget exhausted
         if result.status == StatusType.CAPPED:
@@ -368,7 +372,7 @@ class _SuccessiveHalving(AbstractRacer):
             self.fail_challengers.add(run_info.config)  # capped/crashed/do not advance configs
 
         # get incumbent if all instances have been evaluated
-        if n_insts_remaining <= 0:
+        if n_insts_remaining <= 0 or update_incumbent:
             incumbent = self._compare_configs(challenger=run_info.config,
                                               incumbent=incumbent,
                                               run_history=run_history,
@@ -582,7 +586,9 @@ class _SuccessiveHalving(AbstractRacer):
         if (self.cutoff is not None) and (cutoff < self.cutoff):  # type: ignore[operator] # noqa F821
             capped = True
 
-        self.run_tracker.append((challenger, instance, seed))
+        budget = 0.0 if self.instance_as_budget else curr_budget
+
+        self.run_tracker[(challenger, instance, seed, budget)] = False
         return RunInfoIntent.RUN, RunInfo(
             config=challenger,
             instance=instance,
@@ -590,7 +596,7 @@ class _SuccessiveHalving(AbstractRacer):
             seed=seed,
             cutoff=cutoff,
             capped=capped,
-            budget=0.0 if self.instance_as_budget else curr_budget,
+            budget=budget,
             source_id=self.identifier,
         )
 
@@ -674,7 +680,7 @@ class _SuccessiveHalving(AbstractRacer):
                 self.iteration_done = True
                 self.sh_iters += 1
                 self.stage = 0
-                self.run_tracker = []
+                self.run_tracker = {}
                 self.configs_to_run = []
                 self.fail_chal_offset = 0
 
@@ -913,6 +919,33 @@ class _SuccessiveHalving(AbstractRacer):
 
         return running_instances
 
+    def _get_pending_instances_for_stage(self, run_history: RunHistory) -> int:
+        """
+        When running SH, M configs might require N instances. Before moving to the
+        next stage, we need to make sure that all MxN jobs are completed
+
+        We use the run tracker to make sure we processed all configurations.
+
+        Parameters
+        ----------
+        run_history : RunHistory
+            stores all runs we ran so far
+
+        Returns
+        -------
+            int: All the instances that have not yet been processed
+        """
+        curr_budget = self.all_budgets[self.stage]
+        if self.instance_as_budget:
+            prev_budget = int(self.all_budgets[self.stage - 1]) if self.stage > 0 else 0
+            curr_insts = self.inst_seed_pairs[int(prev_budget):int(curr_budget)]
+        else:
+            curr_insts = self.inst_seed_pairs
+        n_insts_remaining = len(curr_insts) - self.curr_inst_idx - 1
+        # If there are pending runs from a past config, wait for them
+        pending_to_process = [k for k, v in self.run_tracker.items() if not v]
+        return n_insts_remaining + len(pending_to_process)
+
     def _launched_all_configs_for_current_stage(self, run_history: RunHistory) -> bool:
         """
         This procedure queries if the addition of currently finished configs
@@ -943,9 +976,17 @@ class _SuccessiveHalving(AbstractRacer):
         n_insts_remaining = len(curr_insts) - (self.curr_inst_idx + running_instances)
 
         # Check which of the current configs is running
-        my_configs = [c for c, i, s in self.run_tracker]
+        my_configs = [c for c, i, s, b in self.run_tracker]
         running_configs = set()
+        tracked_configs = self.success_challengers.union(
+            self.fail_challengers).union(self.do_not_advance_challengers)
         for k, v in run_history.data.items():
+            # Our goal here is to account for number of challengers available
+            # We care if the challenger is running only if is is not tracked in
+            # success/fails/do not advance
+            if run_history.ids_config[k.config_id] in tracked_configs:
+                continue
+
             if v.status == StatusType.RUNNING:
                 if run_history.ids_config[k.config_id] in my_configs:
                     running_configs.add(k.config_id)

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -331,16 +331,6 @@ class _SuccessiveHalving(AbstractRacer):
         # Mark the fact that we processed this configuration
         self.run_tracker[(run_info.config, run_info.instance, run_info.seed, run_info.budget)] = True
 
-        # We need to update the incumbent if this config we are processing
-        # completes all scheduled instance-seed pairs.
-        # Here, a config/seed/instance is going to be processed for the first time
-        # (it has been previously scheduled by get_next_run and marked False, indicating
-        # that it has not been processed yet. Entering process_results() this config/seed/instance
-        # is marked as TRUE as an indication that it has finished and should be processed)
-        # so if all configurations runs are marked as TRUE it means that this new config
-        # was the missing piece to have everything needed to compare against the incumbent
-        update_incumbent = all([v for k, v in self.run_tracker.items() if k[0] == run_info.config])
-
         # If The incumbent is None and it is the first run, we use the challenger
         if not incumbent and self.first_run:
             self.logger.info(
@@ -374,6 +364,16 @@ class _SuccessiveHalving(AbstractRacer):
             self.do_not_advance_challengers.add(run_info.config)
         else:
             self.fail_challengers.add(run_info.config)  # capped/crashed/do not advance configs
+
+        # We need to update the incumbent if this config we are processing
+        # completes all scheduled instance-seed pairs.
+        # Here, a config/seed/instance is going to be processed for the first time
+        # (it has been previously scheduled by get_next_run and marked False, indicating
+        # that it has not been processed yet. Entering process_results() this config/seed/instance
+        # is marked as TRUE as an indication that it has finished and should be processed)
+        # so if all configurations runs are marked as TRUE it means that this new config
+        # was the missing piece to have everything needed to compare against the incumbent
+        update_incumbent = all([v for k, v in self.run_tracker.items() if k[0] == run_info.config])
 
         # get incumbent if all instances have been evaluated
         if n_insts_remaining <= 0 or update_incumbent:
@@ -902,7 +902,7 @@ class _SuccessiveHalving(AbstractRacer):
                 )
             config_costs[c] = run_history.get_cost(c)
 
-        configs_sorted = sorted(config_costs, key=config_costs.get)
+        configs_sorted = [k for k, v in sorted(config_costs.items(), key=lambda item: item[1])]
         # select top configurations only
         top_configs = configs_sorted[:k]
         return top_configs

--- a/smac/utils/validate.py
+++ b/smac/utils/validate.py
@@ -445,9 +445,9 @@ class Validator(object):
         if isinstance(configs, str):
             configs = self._get_configs(configs)
         if isinstance(insts, str):
-            instances = self._get_instances(insts)  # type: typing.Sequence[typing.Union[str, None]]
+            instances = sorted(self._get_instances(insts))  # type: typing.Sequence[typing.Union[str, None]]
         elif insts is not None:
-            instances = insts
+            instances = sorted(insts)
         else:
             instances = [None]
         # If no instances are given, fix the instances to one "None" instance
@@ -470,7 +470,7 @@ class Validator(object):
         # If we reuse runs, we want to return them as well
         new_rh = RunHistory()
 
-        for i in sorted(instances):
+        for i in instances:
             for rep in range(repetitions):
                 # First, find a seed and add all the data we can take from the
                 # given runhistory to "our" validation runhistory.

--- a/test/test_intensify/test_eval_utils.py
+++ b/test/test_intensify/test_eval_utils.py
@@ -8,6 +8,7 @@ def eval_challenger(
     taf: ExecuteTAFuncDict,
     stats: Stats,
     runhistory: RunHistory,
+    force_update=False,
 ):
     """
     Wrapper over challenger evaluation
@@ -29,6 +30,7 @@ def eval_challenger(
         instance_id=run_info.instance,
         seed=run_info.seed,
         budget=run_info.budget,
+        force_update=force_update,
     )
     stats.n_configs = len(runhistory.config_ids)
     return result

--- a/test/test_intensify/test_hyperband.py
+++ b/test/test_intensify/test_hyperband.py
@@ -510,12 +510,20 @@ class Test_Hyperband(unittest.TestCase):
         self.assertEqual(intensifier.s, 1)
         self.assertEqual(intensifier.s_max, 1)
 
+        # We assume now that process results was called with below successes.
+        # We track closely run execution through run_tracker, so this also
+        # has to be update -- the fact that the succesive halving inside hyperband
+        # processed the given configurations
         self.rh.add(config=self.config1, cost=1, time=1, status=StatusType.SUCCESS,
                     seed=0, budget=1)
+        intensifier.sh_intensifier.run_tracker[(self.config1, None, 0, 1)] = True
         self.rh.add(config=self.config2, cost=2, time=2, status=StatusType.SUCCESS,
                     seed=0, budget=0.5)
+        intensifier.sh_intensifier.run_tracker[(self.config2, None, 0, 0.5)] = True
         self.rh.add(config=self.config3, cost=3, time=2, status=StatusType.SUCCESS,
                     seed=0, budget=0.5)
+        intensifier.sh_intensifier.run_tracker[(self.config3, None, 0, 0.5)] = True
+
         intensifier.sh_intensifier.success_challengers = {self.config2, self.config3}
         intensifier.sh_intensifier._update_stage(self.rh)
         intent, run_info = intensifier.get_next_run(


### PR DESCRIPTION
This push is to address #695 

The problem statement is that a new intensification was created before all configurations were consumed

I have added a very strict check now to make sure every single configuration is consumed and has the expected value in the successive halving engine.