### PR TITLE
Moved to internal registration of instances per config

### DIFF
--- a/test/test_intensify/test_successive_halving.py
+++ b/test/test_intensify/test_successive_halving.py
@@ -1138,7 +1138,17 @@ class Test_SuccessiveHalving(unittest.TestCase):
             incumbent=None,
             run_history=self.rh
         )
-        result = eval_challenger(run_info, taf, self.stats, self.rh)
+
+        # Mark the configuration as launched
+        self.rh.add(config=run_info.config,
+                    instance_id=run_info.instance,
+                    seed=run_info.seed,
+                    budget=run_info.budget,
+                    cost=10,
+                    time=1,
+                    status=StatusType.RUNNING,
+                    additional_info=None)
+        result = eval_challenger(run_info, taf, self.stats, self.rh, force_update=True)
         inc, inc_value = intensifier.process_results(
             run_info=run_info,
             incumbent=None,
@@ -1158,7 +1168,15 @@ class Test_SuccessiveHalving(unittest.TestCase):
             incumbent=inc,
             run_history=self.rh
         )
-        result = eval_challenger(run_info, taf, self.stats, self.rh)
+        self.rh.add(config=run_info.config,
+                    instance_id=run_info.instance,
+                    seed=run_info.seed,
+                    budget=run_info.budget,
+                    cost=10,
+                    time=1,
+                    status=StatusType.RUNNING,
+                    additional_info=None)
+        result = eval_challenger(run_info, taf, self.stats, self.rh, force_update=True)
         inc, inc_value = intensifier.process_results(
             run_info=run_info,
             incumbent=inc,
@@ -1178,7 +1196,15 @@ class Test_SuccessiveHalving(unittest.TestCase):
             incumbent=inc,
             run_history=self.rh
         )
-        result = eval_challenger(run_info, taf, self.stats, self.rh)
+        self.rh.add(config=run_info.config,
+                    instance_id=run_info.instance,
+                    seed=run_info.seed,
+                    budget=run_info.budget,
+                    cost=10,
+                    time=1,
+                    status=StatusType.RUNNING,
+                    additional_info=None)
+        result = eval_challenger(run_info, taf, self.stats, self.rh, force_update=True)
         inc, inc_value = intensifier.process_results(
             run_info=run_info,
             incumbent=inc,
@@ -1204,7 +1230,15 @@ class Test_SuccessiveHalving(unittest.TestCase):
             incumbent=inc,
             run_history=self.rh
         )
-        result = eval_challenger(run_info, taf, self.stats, self.rh)
+        self.rh.add(config=run_info.config,
+                    instance_id=run_info.instance,
+                    seed=run_info.seed,
+                    budget=run_info.budget,
+                    cost=10,
+                    time=1,
+                    status=StatusType.RUNNING,
+                    additional_info=None)
+        result = eval_challenger(run_info, taf, self.stats, self.rh, force_update=True)
         inc, inc_value = intensifier.process_results(
             run_info=run_info,
             incumbent=inc,


### PR DESCRIPTION
Problem Statement:
When running in parallel, the current development code has problem tracking the number of instances per configuration. That is, there is no real per-config tracking of what instances have been launched and which one finished -- per configuration.

This causes an error of the form:
```
ValueError: Cannot compare configs that were run on different instances-seeds-budgets: [InstSeedBudgetKey(instance='75193_10MIN_logloss', seed=0, budget=0.0), InstSeedBudgetKey(instance='189909_10MIN_logloss', seed=0, budget=0.0)] vs [InstSeedBudgetKey(instance='189909_10MIN_logloss', seed=0, budget=0.0)]
```

Where an instance 75193_10MIN_logloss was never launched, because the code failed to notice this run was not launched for this config. 

Solution:
Track per configuration what instances have been launched.