### PR TITLE
Only suggest jobs if workers available

### DIFF
--- a/smac/intensification/simple_intensifier.py
+++ b/smac/intensification/simple_intensifier.py
@@ -2,12 +2,12 @@ import typing
 
 import numpy as np
 
+from smac.configspace import Configuration
 from smac.intensification.abstract_racer import AbstractRacer, RunInfoIntent
 from smac.optimizer.epm_configuration_chooser import EPMChooser
+from smac.runhistory.runhistory import RunHistory, RunInfo, RunValue
 from smac.stats.stats import Stats
 from smac.utils.constants import MAXINT
-from smac.configspace import Configuration
-from smac.runhistory.runhistory import RunHistory, RunInfo, RunValue
 from smac.utils.io.traj_logging import TrajLogger
 
 
@@ -174,14 +174,14 @@ class SimpleIntensifier(AbstractRacer):
         if total_active_runs >= num_workers:
             # We only submit jobs if there is an idle worker
             return RunInfoIntent.WAIT, RunInfo(
-                 config=None,
-                 instance=None,
-                 instance_specific="0",
-                 seed=0,
-                 cutoff=self.cutoff,
-                 capped=False,
-                 budget=0.0,
-             )
+                config=None,
+                instance=None,
+                instance_specific="0",
+                seed=0,
+                cutoff=self.cutoff,
+                capped=False,
+                budget=0.0,
+            )
 
         run_info = RunInfo(
             config=challenger,

--- a/smac/intensification/simple_intensifier.py
+++ b/smac/intensification/simple_intensifier.py
@@ -59,6 +59,12 @@ class SimpleIntensifier(AbstractRacer):
                          min_chall=1,
                          )
 
+        # We want to control the number of runs that are sent to
+        # the workers. At any time, we want to make sure that if there
+        # are just W workers, there should be at max W active runs
+        # Below variable tracks active runs not processed
+        self.run_tracker = {}  # type: typing.Dict[typing.Tuple[Configuration, str, int, float], bool]
+
     def process_results(self,
                         run_info: RunInfo,
                         incumbent: typing.Optional[Configuration],
@@ -97,6 +103,8 @@ class SimpleIntensifier(AbstractRacer):
         inc_perf: float
             empirical performance of incumbent configuration
         """
+        # Mark the fact that we processed this configuration
+        self.run_tracker[(run_info.config, run_info.instance, run_info.seed, run_info.budget)] = True
 
         # If The incumbent is None we use the challenger
         if not incumbent:
@@ -159,7 +167,23 @@ class SimpleIntensifier(AbstractRacer):
                                            run_history=run_history,
                                            repeat_configs=repeat_configs)
 
-        return RunInfoIntent.RUN, RunInfo(
+        # Run tracker is a dictionary whose values indicate if a run has been
+        # processed. If a value in this dict is false, it means that a worker
+        # should still be processing this configuration.
+        total_active_runs = len([v for v in self.run_tracker.values() if not v])
+        if total_active_runs >= num_workers:
+            # We only submit jobs if there is an idle worker
+            return RunInfoIntent.WAIT, RunInfo(
+                 config=None,
+                 instance=None,
+                 instance_specific="0",
+                 seed=0,
+                 cutoff=self.cutoff,
+                 capped=False,
+                 budget=0.0,
+             )
+
+        run_info = RunInfo(
             config=challenger,
             instance=self.instances[-1],
             instance_specific="0",
@@ -168,3 +192,6 @@ class SimpleIntensifier(AbstractRacer):
             capped=False,
             budget=0.0,
         )
+
+        self.run_tracker[(run_info.config, run_info.instance, run_info.seed, run_info.budget)] = False
+        return RunInfoIntent.RUN, run_info

--- a/smac/optimizer/smbo.py
+++ b/smac/optimizer/smbo.py
@@ -449,14 +449,6 @@ class SMBO(object):
             )
         )
 
-        if result.status == StatusType.ABORT:
-            raise TAEAbortException("Target algorithm status ABORT - SMAC will "
-                                    "exit. The last incumbent can be found "
-                                    "in the trajectory-file.")
-        elif result.status == StatusType.STOP:
-            self._stop = True
-            return
-
         self.runhistory.add(
             config=run_info.config,
             cost=result.cost,
@@ -471,6 +463,14 @@ class SMBO(object):
             additional_info=result.additional_info,
         )
         self.stats.n_configs = len(self.runhistory.config_ids)
+
+        if result.status == StatusType.ABORT:
+            raise TAEAbortException("Target algorithm status ABORT - SMAC will "
+                                    "exit. The last incumbent can be found "
+                                    "in the trajectory-file.")
+        elif result.status == StatusType.STOP:
+            self._stop = True
+            return
 
         if self.scenario.abort_on_first_run_crash :  # type: ignore[attr-defined] # noqa F821
             if self.stats.finished_ta_runs == 1 and result.status == StatusType.CRASHED:

--- a/test/test_intensify/test_simple_intensifier.py
+++ b/test/test_intensify/test_simple_intensifier.py
@@ -1,0 +1,186 @@
+import unittest
+from unittest import mock
+
+import logging
+import numpy as np
+import time
+
+from ConfigSpace import Configuration, ConfigurationSpace
+from ConfigSpace.hyperparameters import UniformIntegerHyperparameter
+
+from smac.intensification.abstract_racer import RunInfoIntent
+from smac.intensification.simple_intensifier import SimpleIntensifier
+from smac.runhistory.runhistory import RunHistory, RunInfo, RunValue
+from smac.scenario.scenario import Scenario
+from smac.stats.stats import Stats
+from smac.tae import StatusType
+from smac.tae.execute_func import ExecuteTAFuncDict
+from smac.utils.io.traj_logging import TrajLogger
+
+from .test_eval_utils import eval_challenger
+
+
+def get_config_space():
+    cs = ConfigurationSpace()
+    cs.add_hyperparameter(UniformIntegerHyperparameter(name='a',
+                                                       lower=0,
+                                                       upper=100))
+    cs.add_hyperparameter(UniformIntegerHyperparameter(name='b',
+                                                       lower=0,
+                                                       upper=100))
+    return cs
+
+
+def target_from_run_info(RunInfo):
+    value_from_config = sum([a for a in RunInfo.config.get_dictionary().values()])
+    return RunValue(
+        cost=value_from_config,
+        time=0.5,
+        status=StatusType.SUCCESS,
+        starttime=time.time(),
+        endtime=time.time() + 1,
+        additional_info={}
+    )
+
+
+class TestSimpleIntensifier(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+
+        self.rh = RunHistory()
+        self.cs = get_config_space()
+        self.config1 = Configuration(self.cs,
+                                     values={'a': 7, 'b': 11})
+        self.config2 = Configuration(self.cs,
+                                     values={'a': 13, 'b': 17})
+        self.config3 = Configuration(self.cs,
+                                     values={'a': 0, 'b': 7})
+        self.config4 = Configuration(self.cs,
+                                     values={'a': 29, 'b': 31})
+
+        self.scen = Scenario({"cutoff_time": 2, 'cs': self.cs,
+                              "run_obj": 'runtime',
+                              "output_dir": ''})
+        self.stats = Stats(scenario=self.scen)
+        self.stats.start_timing()
+
+        # Create the base object
+        self.intensifier = SimpleIntensifier(
+            stats=self.stats,
+            traj_logger=TrajLogger(output_dir=None, stats=self.stats),
+            rng=np.random.RandomState(12345),
+            deterministic=True,
+            run_obj_time=False,
+            instances=[1],
+        )
+
+    def test_get_next_run(self):
+        """
+        Makes sure that sampling a configuration returns a valid
+        configuration
+        """
+        intent, run_info = self.intensifier.get_next_run(
+            challengers=[self.config1],
+            incumbent=None,
+            run_history=self.rh,
+            num_workers=1,
+            chooser=None,
+        )
+
+        self.assertEqual(intent, RunInfoIntent.RUN)
+
+        self.assertEqual(run_info, RunInfo(
+            config=self.config1,
+            instance=1,
+            instance_specific="0",
+            seed=0,
+            cutoff=None,
+            capped=False,
+            budget=0.0,
+        ))
+
+    def test_get_next_run_waits_if_no_workers(self):
+        """
+        In the case all workers are busy, we wait so that we do
+        not saturate the process with configurations that will not
+        finish in time
+        """
+        intent, run_info = self.intensifier.get_next_run(
+            challengers=[self.config1, self.config2],
+            incumbent=None,
+            run_history=self.rh,
+            num_workers=1,
+            chooser=None,
+        )
+
+        # We can get the configuration 1
+        self.assertEqual(intent, RunInfoIntent.RUN)
+        self.assertEqual(run_info, RunInfo(
+            config=self.config1,
+            instance=1,
+            instance_specific="0",
+            seed=0,
+            cutoff=None,
+            capped=False,
+            budget=0.0,
+        ))
+
+        # We should not get configuration 2
+        # As there is just 1 worker
+        intent, run_info = self.intensifier.get_next_run(
+            challengers=[self.config2],
+            incumbent=None,
+            run_history=self.rh,
+            num_workers=1,
+            chooser=None,
+        )
+        self.assertEqual(intent, RunInfoIntent.WAIT)
+        self.assertEqual(run_info, RunInfo(
+            config=None,
+            instance=None,
+            instance_specific="0",
+            seed=0,
+            cutoff=None,
+            capped=False,
+            budget=0.0,
+        ))
+
+    def test_process_results(self):
+        """
+        Makes sure that we can process the results of a completed
+        configuration
+        """
+        intent, run_info = self.intensifier.get_next_run(
+            challengers=[self.config1, self.config2],
+            incumbent=None,
+            run_history=self.rh,
+            num_workers=1,
+            chooser=None,
+        )
+        result = RunValue(
+            cost=1,
+            time=0.5,
+            status=StatusType.SUCCESS,
+            starttime=1,
+            endtime=2,
+            additional_info=None,
+        )
+        self.rh.add(
+            config=run_info.config, cost=1, time=0.5,
+            status=StatusType.SUCCESS, instance_id=run_info.instance,
+            seed=run_info.seed, additional_info=None)
+
+        incumbent, inc_perf = self.intensifier.process_results(
+            run_info=run_info,
+            incumbent=None,
+            run_history=self.rh,
+            time_bound=np.inf,
+            result=result,
+        )
+        self.assertEqual(incumbent, run_info.config)
+        self.assertEqual(inc_perf, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_intensify/test_simple_intensifier.py
+++ b/test/test_intensify/test_simple_intensifier.py
@@ -1,12 +1,10 @@
-import unittest
-from unittest import mock
-
-import logging
-import numpy as np
 import time
+import unittest
 
 from ConfigSpace import Configuration, ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformIntegerHyperparameter
+
+import numpy as np
 
 from smac.intensification.abstract_racer import RunInfoIntent
 from smac.intensification.simple_intensifier import SimpleIntensifier
@@ -14,10 +12,7 @@ from smac.runhistory.runhistory import RunHistory, RunInfo, RunValue
 from smac.scenario.scenario import Scenario
 from smac.stats.stats import Stats
 from smac.tae import StatusType
-from smac.tae.execute_func import ExecuteTAFuncDict
 from smac.utils.io.traj_logging import TrajLogger
-
-from .test_eval_utils import eval_challenger
 
 
 def get_config_space():

--- a/test/test_smbo/test_smbo.py
+++ b/test/test_smbo/test_smbo.py
@@ -170,7 +170,8 @@ class TestSMBO(unittest.TestCase):
         self.assertFalse(smbo.solver._stop)
         smbo.optimize()
         self.assertEqual(len(smbo.runhistory.data), 1)
-        self.assertEqual(list(smbo.runhistory.data.values())[0].status, StatusType.RUNNING)
+        # After an optimization, we expect no running instances.
+        self.assertEqual(list(smbo.runhistory.data.values())[0].status, StatusType.STOP)
         self.assertTrue(smbo.solver._stop)
 
     def test_intensification_percentage(self):


### PR DESCRIPTION
Check if workers are idle, and only then launch jobs in the case of the simple intensifier.