### PR TITLE
Replace pydoe by scipy's lhd

### DIFF
--- a/extras_require.json
+++ b/extras_require.json
@@ -3,9 +3,6 @@
     "emcee>=2.1.0",
     "scikit-optimize"
   ],
-  "lhd": [
-    "pyDOE"
-  ],
   "documentation": [
     "sphinx",
     "sphinx_rtd_theme",

--- a/smac/initial_design/latin_hypercube_design.py
+++ b/smac/initial_design/latin_hypercube_design.py
@@ -1,8 +1,6 @@
 import typing
 
-import numpy as np
-
-import pyDOE
+from scipy.stats.qmc import LatinHypercube
 
 from ConfigSpace.configuration_space import Configuration
 from ConfigSpace.hyperparameters import Constant
@@ -36,15 +34,12 @@ class LHDesign(InitialDesign):
 
         params = self.cs.get_hyperparameters()
 
-        # seeding of lhd design
-        np.random.seed(self.rng.randint(1, 2 ** 20))
-
         constants = 0
         for p in params:
             if isinstance(p, Constant):
                 constants += 1
 
-        lhd = pyDOE.lhs(n=len(params) - constants, samples=self.init_budget)
+        lhd = LatinHypercube(d=len(params) - constants, seed=self.rng.randint(0, 1000000)).random(n=self.init_budget)
 
         return self._transform_continuous_designs(design=lhd,
                                                   origin='LHD',


### PR DESCRIPTION
The two perform roughly equivalent using five seeds. Dropping pyDOE reduces our requirement count by one:
```
         Bohachevsky    Branin  Camelback  Forrester  GoldsteinPrice  Hartmann3  Hartmann6   Levy1D    Levy2D  Rosenbrock2D  Rosenbrock5D    SinOne    SinTwo   Average      Rank
lhd_new    -0.453092 -3.067249  -1.457917  -6.368932        1.344273  -4.960274  -1.188263 -6.29473 -0.831744      0.387343      3.273479 -6.564149 -2.164840 -2.180469  1.384615
default    -0.526523 -3.098636  -1.433102  -6.357172        1.523234  -4.785882  -1.017738 -5.71695 -1.752664      0.504228      3.018586 -6.208062 -2.483468 -2.179550  1.615385
```