### PR TITLE
Drop scikit-optimize dependency

### DIFF
--- a/extras_require.json
+++ b/extras_require.json
@@ -1,7 +1,6 @@
 {
   "gp": [
     "emcee>=3.0.0",
-    "scikit-optimize"
   ],
   "documentation": [
     "sphinx",

--- a/extras_require.json
+++ b/extras_require.json
@@ -1,6 +1,6 @@
 {
   "gp": [
-    "emcee>=3.0.0",
+    "emcee>=3.0.0"
   ],
   "documentation": [
     "sphinx",

--- a/smac/__init__.py
+++ b/smac/__init__.py
@@ -25,8 +25,6 @@ for name, requirements in extras_require.items():
         extras_installed.add(name)
     for requirement in requirements:
         package_name = dependencies.RE_PATTERN.match(requirement).group('name')  # type: ignore[union-attr] # noqa F821
-        if package_name == 'scikit-optimize':
-            package_name = 'skopt'
         lazy_import.lazy_module(package_name)
 
 if sys.version_info < (3, 7, 0):

--- a/smac/epm/base_gp.py
+++ b/smac/epm/base_gp.py
@@ -1,20 +1,14 @@
-from typing import List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import List, Optional, Tuple, Union
 
 from smac.configspace import ConfigurationSpace
 import numpy as np
-import sklearn.gaussian_process.kernels
 
 from smac.epm.base_epm import AbstractEPM
 import smac.epm.gp_base_prior
 
-if TYPE_CHECKING:
-    from skopt.learning.gaussian_process.kernels import Kernel
-    from skopt.learning.gaussian_process import GaussianProcessRegressor
-else:
-    from lazy_import import lazy_callable
-    Kernel = lazy_callable('skopt.learning.gaussian_process.kernels.Kernel')
-    GaussianProcessRegressor = lazy_callable(
-        'skopt.learning.gaussian_process.GaussianProcessRegressor')
+import sklearn.gaussian_process
+from sklearn.gaussian_process.kernels import Kernel, KernelOperator
+from sklearn.gaussian_process import GaussianProcessRegressor
 
 
 class BaseModel(AbstractEPM):
@@ -104,11 +98,11 @@ class BaseModel(AbstractEPM):
         to_visit.append(self.gp.kernel.k2)
         while len(to_visit) > 0:
             current_param = to_visit.pop(0)
-            if isinstance(current_param, sklearn.gaussian_process.kernels.KernelOperator):
+            if isinstance(current_param, KernelOperator):
                 to_visit.insert(0, current_param.k1)
                 to_visit.insert(1, current_param.k2)
                 continue
-            elif isinstance(current_param, sklearn.gaussian_process.kernels.Kernel):
+            elif isinstance(current_param, Kernel):
                 hps = current_param.hyperparameters
                 assert len(hps) == 1
                 hp = hps[0]

--- a/smac/epm/gaussian_process.py
+++ b/smac/epm/gaussian_process.py
@@ -9,8 +9,8 @@ from smac.epm.base_gp import BaseModel
 from smac.epm.gp_base_prior import Prior
 from smac.utils.constants import VERY_SMALL_NUMBER
 
-from skopt.learning.gaussian_process.kernels import Kernel
-from skopt.learning.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process.kernels import Kernel
+from sklearn.gaussian_process import GaussianProcessRegressor
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +147,6 @@ class GaussianProcess(BaseModel):
             optimizer=None,
             n_restarts_optimizer=-1,  # Do not use scikit-learn's optimization routine
             alpha=0,  # Governed by the kernel
-            noise=None,
             random_state=self.rng,
         )
 

--- a/smac/epm/gaussian_process_mcmc.py
+++ b/smac/epm/gaussian_process_mcmc.py
@@ -11,8 +11,8 @@ from smac.epm.base_gp import BaseModel
 from smac.epm.gaussian_process import GaussianProcess
 from smac.epm.gp_base_prior import Prior
 
-from skopt.learning.gaussian_process.kernels import Kernel
-from skopt.learning.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process.kernels import Kernel
+from sklearn.gaussian_process import GaussianProcessRegressor
 
 logger = logging.getLogger(__name__)
 

--- a/smac/epm/gaussian_process_mcmc.py
+++ b/smac/epm/gaussian_process_mcmc.py
@@ -285,7 +285,6 @@ class GaussianProcessMCMC(BaseModel):
             optimizer=None,
             n_restarts_optimizer=-1,  # Do not use scikit-learn's optimization routine
             alpha=0,  # Governed by the kernel
-            noise=None,
         )
 
     def _ll(self, theta: np.ndarray) -> float:

--- a/smac/epm/gp_kernels.py
+++ b/smac/epm/gp_kernels.py
@@ -656,7 +656,8 @@ class HammingKernel(MagicMixin, kernels.StationaryKernelMixin, kernels.Normalize
         prior: Optional[Prior] = None,
         has_conditions: bool = False,
     ) -> None:
-        super(HammingKernel, self).__init__(length_scale=length_scale, length_scale_bounds=length_scale_bounds)
+        self.length_scale = length_scale
+        self.length_scale_bounds = length_scale_bounds
         self.set_active_dims(operate_on)
         self.prior = prior
         self.has_conditions = has_conditions
@@ -664,9 +665,9 @@ class HammingKernel(MagicMixin, kernels.StationaryKernelMixin, kernels.Normalize
     @property
     def hyperparameter_length_scale(self) -> kernels.Hyperparameter:
         length_scale = self.length_scale
-        anisotropic = np.iterable(length_scale) and len(length_scale) > 1
+        anisotropic = np.iterable(length_scale) and len(length_scale) > 1  # type: ignore
         if anisotropic:
-            return kernels.Hyperparameter("length_scale", "numeric", self.length_scale_bounds, len(length_scale))
+            return kernels.Hyperparameter("length_scale", "numeric", self.length_scale_bounds, len(length_scale))  # type: ignore  # noqa: E501
         return kernels.Hyperparameter("length_scale", "numeric", self.length_scale_bounds)
 
     def _call(

--- a/smac/epm/gp_kernels.py
+++ b/smac/epm/gp_kernels.py
@@ -3,13 +3,12 @@ import math
 from typing import Optional, Union, Tuple, List, Callable, Dict, Any
 
 import numpy as np
-import sklearn.gaussian_process.kernels
+import sklearn.gaussian_process.kernels as kernels
 import scipy.optimize
 import scipy.spatial.distance
 import scipy.special
 
 from smac.epm.gp_base_prior import Prior
-import skopt.learning.gaussian_process.kernels as kernels
 
 # This file contains almost no type annotations to simplify comparing it to the original scikit-learn version!
 
@@ -428,7 +427,7 @@ class Matern(MagicMixin, kernels.Matern):
         """
 
         X = np.atleast_2d(X)
-        length_scale = sklearn.gaussian_process.kernels._check_length_scale(X, self.length_scale)
+        length_scale = kernels._check_length_scale(X, self.length_scale)
 
         if Y is None:
             dists = scipy.spatial.distance.pdist(X / length_scale, metric='euclidean')
@@ -545,7 +544,7 @@ class RBF(MagicMixin, kernels.RBF):
         """
 
         X = np.atleast_2d(X)
-        length_scale = sklearn.gaussian_process.kernels._check_length_scale(X, self.length_scale)
+        length_scale = kernels._check_length_scale(X, self.length_scale)
 
         if Y is None:
             dists = scipy.spatial.distance.pdist(X / length_scale, metric='sqeuclidean')
@@ -647,7 +646,7 @@ class WhiteKernel(MagicMixin, kernels.WhiteKernel):
             return np.zeros((X.shape[0], Y.shape[0]))
 
 
-class HammingKernel(MagicMixin, kernels.HammingKernel):
+class HammingKernel(MagicMixin, kernels.StationaryKernelMixin, kernels.NormalizedKernelMixin, kernels.Kernel):
 
     def __init__(
         self,
@@ -661,6 +660,14 @@ class HammingKernel(MagicMixin, kernels.HammingKernel):
         self.set_active_dims(operate_on)
         self.prior = prior
         self.has_conditions = has_conditions
+
+    @property
+    def hyperparameter_length_scale(self) -> kernels.Hyperparameter:
+        length_scale = self.length_scale
+        anisotropic = np.iterable(length_scale) and len(length_scale) > 1
+        if anisotropic:
+            return kernels.Hyperparameter("length_scale", "numeric", self.length_scale_bounds, len(length_scale))
+        return kernels.Hyperparameter("length_scale", "numeric", self.length_scale_bounds)
 
     def _call(
         self,
@@ -701,7 +708,7 @@ class HammingKernel(MagicMixin, kernels.HammingKernel):
         """
 
         X = np.atleast_2d(X)
-        length_scale = sklearn.gaussian_process.kernels._check_length_scale(X, self.length_scale)
+        length_scale = kernels._check_length_scale(X, self.length_scale)
 
         if Y is None:
             Y = X

--- a/test/test_epm/test_gp.py
+++ b/test/test_epm/test_gp.py
@@ -191,7 +191,7 @@ class TestGP(unittest.TestCase):
         self.assertFalse(np.any(theta_ == fixture))
         np.testing.assert_array_almost_equal(theta, theta_)
 
-    @unittest.mock.patch('skopt.learning.gaussian_process.GaussianProcessRegressor.fit')
+    @unittest.mock.patch('sklearn.gaussian_process.GaussianProcessRegressor.fit')
     def test_train_continue_on_linalg_error(self, fit_mock):
         # Check that training does not stop on a linalg error, but that uncertainty is increased!
 
@@ -215,7 +215,7 @@ class TestGP(unittest.TestCase):
         model._train(X[:10], Y[:10], do_optimize=False)
         self.assertAlmostEqual(np.exp(model.gp.kernel.theta[-1]), fixture + 10)
 
-    @unittest.mock.patch('skopt.learning.gaussian_process.GaussianProcessRegressor.log_marginal_likelihood')
+    @unittest.mock.patch('sklearn.gaussian_process.GaussianProcessRegressor.log_marginal_likelihood')
     def test_train_continue_on_linalg_error_2(self, fit_mock):
         # Check that training does not stop on a linalg error during hyperparameter optimization
 


### PR DESCRIPTION
This PR stops using scikit-optimize and instead uses the raw scikit-learn GP. I checked the performance on a bunch of test functions using 5 repetitions and the numbers are favorable:
```
                   Bohachevsky    Branin  Camelback  Forrester  GoldsteinPrice  Hartmann3  Hartmann6    Levy1D    Levy2D  Rosenbrock2D  Rosenbrock5D    SinOne    SinTwo   Average      Rank
skopt      -0.739422 -3.775036  -1.666626  -5.694597        1.089118  -5.007008  -0.600312 -6.614990 -1.097518      0.542982      3.371725 -6.648250 -2.264304 -2.238788  1.692308
sklearn    -0.652663 -5.012642  -1.667781  -7.306148        1.089118  -5.375514  -0.600312 -6.908985 -1.097518      0.542982      3.371725 -6.996612 -2.264304 -2.529127  1.307692
```