### PR TITLE
Change dev version from 0.13.2dev to 0.14.0dev

### DIFF
--- a/smac/__init__.py
+++ b/smac/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 from smac.utils import dependencies
 
-__version__ = '0.13.2dev'
+__version__ = '0.14.0dev'
 __author__ = 'Marius Lindauer, Matthias Feurer, Katharina Eggensperger, Joshua Marben, ' \
              'André Biedenkapp, Francisco Rivera, Ashwin Raaghav, Aaron Klein, Stefan Falkner ' \
              'and Frank Hutter'


### PR DESCRIPTION
The upcoming release will have several breaking changes:
* requiring scipy 1.7.0, while the current release is not compatible with scipy 1.7.0
* renamed the BOHB facade
Auto-sklearn currently requires SMAC < 0.14, so a higher version number would not break Auto-sklearn.

Also, SMAC will have major updates:
* Local models
* Improved docs
* less dependencies

I therefore suggest to bump the version number for the upcoming release to 0.14 and to make sure we don't forget I hereby suggest to already bump the dev version string.