### PR TITLE
Version bump 0.13.2dev -> 0.14.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@
 * Uses scrambled Sobol Sequence (#733)
 * Moved to Github actions (#715)
 * Improved testing (#720, #723, #739, #743)
+* Added option `save_results_instantly` in scenario object to save results instantly (#728)
+* Changed level of intensification messages to debug (#724)
 
 ## Bug Fixes
 * Github badges updated (#732)

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,25 @@
 # 0.13.2
 
+## Major Changes
+* Drop support for Python 3.6 (#726)
+* Added Colab to try SMAC in your browser! (#697)
+* `BOHB4HPO` facade has been renamed to `SMAC4MF` facade
+
 ## Minor Changes
-* Require emcee >= 3.0.0
+* Require `emcee` >= 3.0.0 (#723)
+* Require `scipy` >= 1.7 (#729)
+* Added gradient boosting example
+* `lazy_import` dependency dropped (#741)
+* Dropped `pyDOE` requirement, using `scipy` instead (#735)
+* Uses scrambled Sobol Sequence (#733)
+
+## Bug Fixes
+* Github badges updated (#732)
+* Fixed memory limit issue for `pynisher` (#717)
+* More robust multiprocessing (#709, #712)
+* Fixed serialization with runhistory entries (#706)
+* runhistory is now saved after each individual run (#734)
+* Logging for Wallclock time limit reached changed to debug (#724)
 
 # 0.13.1
 
@@ -21,7 +39,7 @@
 * Drop support for Python 3.5
 
 ## Minor Changes
-* Update Readme 
+* Update Readme
 * Remove runhistory from TAE (#663)
 * Store SMAC's internal config id in the configuration object (#679)
 * Introduce Status Type STOP (#690)

--- a/changelog.md
+++ b/changelog.md
@@ -25,7 +25,6 @@
 * More robust multiprocessing (#709, #712)
 * Fixed serialization with runhistory entries (#706)
 * Separated evaluation from get next challengers in intensification (#734)
-* Logging for Wallclock time limit reached changed to debug (#724)
 * Doc fixes (#727, #714)
 
 # 0.13.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,25 +1,30 @@
-# 0.13.2
+# 0.14.0
+
+## Breaking Changes
+* `BOHB4HPO` facade has been renamed to `SMAC4MF` facade (#738)
+* Require `scipy` >= 1.7 (#729)
+* Require `emcee` >= 3.0.0 (#723)
 
 ## Major Changes
 * Drop support for Python 3.6 (#726)
 * Added Colab to try SMAC in your browser! (#697)
-* `BOHB4HPO` facade has been renamed to `SMAC4MF` facade
 
 ## Minor Changes
-* Require `emcee` >= 3.0.0 (#723)
-* Require `scipy` >= 1.7 (#729)
-* Added gradient boosting example
+* Added gradient boosting example, removed random forest example (#722)
 * `lazy_import` dependency dropped (#741)
-* Dropped `pyDOE` requirement, using `scipy` instead (#735)
+* Replaced `pyDOE` requirement with `scipy` for LHD design (#735)
 * Uses scrambled Sobol Sequence (#733)
+* Moved to Github actions (#715)
+* Improved testing (#720, #723, #739, #743)
 
 ## Bug Fixes
 * Github badges updated (#732)
 * Fixed memory limit issue for `pynisher` (#717)
 * More robust multiprocessing (#709, #712)
 * Fixed serialization with runhistory entries (#706)
-* runhistory is now saved after each individual run (#734)
+* Separated evaluation from get next challengers in intensification (#734)
 * Logging for Wallclock time limit reached changed to debug (#724)
+* Doc fixes (#727, #714)
 
 # 0.13.1
 
@@ -34,7 +39,7 @@
 # 0.13.0
 
 ## Major Changes
-* Split choosing next challenger from evaluating challenger (#663)
+* Separated evaluation from get next challengers in intensification (#663)
 * Implemented parallel SMAC using dask (#675, #677, #681, #685, #686)
 * Drop support for Python 3.5
 

--- a/smac/__init__.py
+++ b/smac/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 from smac.utils import dependencies
 
-__version__ = '0.13.2dev'
+__version__ = '0.13.2'
 __author__ = 'Marius Lindauer, Matthias Feurer, Katharina Eggensperger, Joshua Marben, ' \
              'André Biedenkapp, Francisco Rivera, Ashwin Raaghav, Aaron Klein, Stefan Falkner ' \
              'and Frank Hutter'

--- a/smac/__init__.py
+++ b/smac/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 from smac.utils import dependencies
 
-__version__ = '0.13.2'
+__version__ = '0.14.0'
 __author__ = 'Marius Lindauer, Matthias Feurer, Katharina Eggensperger, Joshua Marben, ' \
              'André Biedenkapp, Francisco Rivera, Ashwin Raaghav, Aaron Klein, Stefan Falkner ' \
              'and Frank Hutter'

--- a/test/test_initial_design/test_factorical_design.py
+++ b/test/test_initial_design/test_factorical_design.py
@@ -46,7 +46,7 @@ class TestFactorial(unittest.TestCase):
                 max_config_fracs=0.25,
                 init_budget=1,
             )
-            configs = FactorialInitialDesign(
+            FactorialInitialDesign(
                 cs=cs,
                 **factorial_kwargs
             ).select_configurations()

--- a/test/test_initial_design/test_initial_design.py
+++ b/test/test_initial_design/test_initial_design.py
@@ -2,8 +2,7 @@ import unittest
 import unittest.mock
 
 import numpy as np
-from ConfigSpace import Configuration, UniformFloatHyperparameter,\
-    Constant, CategoricalHyperparameter, OrdinalHyperparameter
+from ConfigSpace import Configuration, UniformFloatHyperparameter
 
 from smac.configspace import ConfigurationSpace
 from smac.initial_design.default_configuration_design import DefaultConfiguration


### PR DESCRIPTION
Updates from `0.13.2dev` to `0.13.2`, filling in the changelog. 