### PR TITLE
Interrupt optimization through IncorporateRunResultCallback

### DIFF
--- a/smac/callbacks.py
+++ b/smac/callbacks.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+from typing import Optional
 
 if TYPE_CHECKING:
     from smac.optimizer.smbo import SMBO
@@ -31,12 +32,16 @@ How to add a new callback
 
 class IncorporateRunResultCallback:
 
-    """Callback to react on a new run result. Called after the finished run is added to the runhistory."""
+    """Callback to react on a new run result.
+
+    Called after the finished run is added to the runhistory.
+    Optionally return `False` to (gracefully) stop the optimization.
+    """
 
     def __call__(
             self, smbo: 'SMBO',
             run_info: RunInfo,
             result: RunValue,
             time_left: float,
-    ) -> None:
+    ) -> Optional[bool]:
         pass


### PR DESCRIPTION
I wanted to implement a hook in autosklearn for the user to be able to implement his own stopping strategy. @eddiebergman suggested [here](https://github.com/automl/auto-sklearn/issues/1223) to use the `IncorporateRunResultCallback` of SMAC. However, currently the callback cannot interrupt the optimization loop.

I now added the possibility to gracefully abort the optimization by returning `False` from the callback (when returning None the optimization still continues for backward compatibility). I also added a unit test to test this.

Please let me know if there is anything I should change/add/fix. I'm very happy to contribute :)