### PR TITLE
Handle invalid neighbors in local search gracefully

### DIFF
--- a/smac/configspace/__init__.py
+++ b/smac/configspace/__init__.py
@@ -3,6 +3,7 @@ from functools import partial
 from ConfigSpace import ConfigurationSpace, Configuration, Constant, \
     CategoricalHyperparameter, UniformFloatHyperparameter, \
     UniformIntegerHyperparameter, InCondition
+from ConfigSpace.exceptions import ForbiddenValueError
 from ConfigSpace.read_and_write import pcs, pcs_new, json
 from ConfigSpace.util import get_one_exchange_neighbourhood
 from smac.configspace.util import convert_configurations_to_array
@@ -22,7 +23,8 @@ __all__ = ["ConfigurationSpace",
            "pcs_new",
            "json",
            "get_one_exchange_neighbourhood",
-           "convert_configurations_to_array"
+           "convert_configurations_to_array",
+           "ForbiddenValueError"
            ]
 
 get_one_exchange_neighbourhood = partial(get_one_exchange_neighbourhood, stdev=0.05, num_neighbors=8)

--- a/smac/optimizer/ei_optimization.py
+++ b/smac/optimizer/ei_optimization.py
@@ -369,7 +369,8 @@ class LocalSearch(AcquisitionFunctionMaximizer):
                             neighbors_generated[i] += 1
                             neighbors_for_i.append(n)
                         except ValueError as e:
-                            # `neighborhood_iterator` raises `ValueError` with some probability when it reaches an invalid configuration.
+                            # `neighborhood_iterator` raises `ValueError` with some probability when it reaches 
+                            # an invalid configuration.
                             self.logger.debug(e)
                             new_neighborhood[i] = True
                         except StopIteration:

--- a/smac/optimizer/ei_optimization.py
+++ b/smac/optimizer/ei_optimization.py
@@ -367,10 +367,14 @@ class LocalSearch(AcquisitionFunctionMaximizer):
                             n = next(neighborhood_iterator)
                             neighbors_generated[i] += 1
                             neighbors_for_i.append(n)
+                        except ValueError as e:
+                            # `neighborhood_iterator` raises `ValueError` with some probability when it reaches an invalid configuration.
+                            self.logger.debug(e)
+                            new_neighborhood[i] = True
                         except StopIteration:
-                            obtain_n[i] = len(neighbors_for_i)
                             new_neighborhood[i] = True
                             break
+                    obtain_n[i] = len(neighbors_for_i)
                     neighbors.extend(neighbors_for_i)
 
             if len(neighbors) != 0:

--- a/smac/optimizer/ei_optimization.py
+++ b/smac/optimizer/ei_optimization.py
@@ -369,7 +369,7 @@ class LocalSearch(AcquisitionFunctionMaximizer):
                             neighbors_generated[i] += 1
                             neighbors_for_i.append(n)
                         except ValueError as e:
-                            # `neighborhood_iterator` raises `ValueError` with some probability when it reaches 
+                            # `neighborhood_iterator` raises `ValueError` with some probability when it reaches
                             # an invalid configuration.
                             self.logger.debug(e)
                             new_neighborhood[i] = True


### PR DESCRIPTION
The iterator returned by `ConfigSpace.util.get_one_exchange_neighborhood` may visit an invalid configuration. If it does so, it either raises a `ValueError` (with the probability 0.05) or yields the configuration (otherwise). This pull request ensures that `LocalSearch._do_search` handles these situations gracefully.

1. If `ValueError` is raised, it is caught and ignored (instead of crashing `smac`).
2. If an invalid configuration is visited and scores better than the current candidate, it is ignored (instead of replacing the current candidate).

The script `run.sh` in [demo.zip](https://github.com/automl/SMAC3/files/7156367/demo.zip) demonstrates raising of `ValueError` from the iterator. The error is raised with a probability greater than 0 and smaller than 1.

Issue at ConfigSpace that discusses the non-determinism of the configuration validation: https://github.com/automl/ConfigSpace/issues/194