### PR TITLE
Propagate minR and maxR from scenario into intensifier

### DIFF
--- a/smac/facade/smac_ac_facade.py
+++ b/smac/facade/smac_ac_facade.py
@@ -427,6 +427,9 @@ class SMAC4AC(object):
             'min_chall': scenario.intens_min_chall  # type: ignore[attr-defined] # noqa F821
         }
 
+        if intensifier is None:
+            intensifier = Intensifier
+
         if isinstance(intensifier, Intensifier) \
                 or (intensifier is not None and inspect.isclass(intensifier) and issubclass(intensifier, Intensifier)):
             intensifier_def_kwargs['always_race_against'] = scenario.cs.get_default_configuration()  # type: ignore[attr-defined] # noqa F821
@@ -436,11 +439,8 @@ class SMAC4AC(object):
         if intensifier_kwargs is not None:
             intensifier_def_kwargs.update(intensifier_kwargs)
 
-        if intensifier is None:
-            intensifier_instance = (
-                Intensifier(**intensifier_def_kwargs)  # type: ignore[arg-type] # noqa F821
-            )  # type: AbstractRacer
-        elif inspect.isclass(intensifier):
+        assert intensifier is not None
+        if inspect.isclass(intensifier):
             intensifier_instance = intensifier(**intensifier_def_kwargs)  # type: ignore[arg-type] # noqa F821
         else:
             raise TypeError(

--- a/test/test_facade/test_smac_facade.py
+++ b/test/test_facade/test_smac_facade.py
@@ -41,8 +41,9 @@ class TestSMACFacade(unittest.TestCase):
 
     def setUp(self):
         self.cs = ConfigurationSpace()
-        self.scenario = Scenario({'cs': self.cs, 'run_obj': 'quality',
-                                  'output_dir': ''})
+        self.scenario_dict_default = {'cs': self.cs, 'run_obj': 'quality',
+                                      'output_dir': ''}
+        self.scenario = Scenario(self.scenario_dict_default)
         self.sh_intensifier_kwargs = {'n_seeds': 1,
                                       'initial_budget': 1,
                                       'eta': 3,
@@ -217,6 +218,18 @@ class TestSMACFacade(unittest.TestCase):
         )
         self.assertIsInstance(smbo.solver.intensifier, DummyIntensifier)
         self.assertEqual(smbo.solver.intensifier.maxR, 987)
+
+        # Assert that minR, maxR and use_ta_time propagate from scenario to the default intensifier.
+        for scenario_dict in [{}, {'minR': self.scenario.minR + 1, 'maxR': self.scenario.maxR + 1,
+                                   'use_ta_time': not self.scenario.use_ta_time}]:
+            for k, v in self.scenario_dict_default.items():
+                if k not in scenario_dict:
+                    scenario_dict[k] = v
+            scenario = Scenario(scenario_dict)
+            smac = SMAC4AC(scenario=scenario)
+            self.assertEqual(scenario.minR, smac.solver.intensifier.minR)
+            self.assertEqual(scenario.maxR, smac.solver.intensifier.maxR)
+            self.assertEqual(scenario.use_ta_time, smac.solver.intensifier.use_ta_time_bound)
 
     def test_construct_initial_design(self):
 


### PR DESCRIPTION
Ensure that the options `minR`, `maxR`, and `use_ta_time` are propagated from the scenario into the intensifier in case the intensifier class is not provided explicitly to `SMAC4AC` (namely when `scripts/smac` is called).