### PR TITLE
Added CITATION.cff and updated docs reference

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 @inproceedings {lindauer-arxiv21a,
   author = {Marius Lindauer and Katharina Eggensperger and Matthias Feurer and André Biedenkapp and Difan Deng and Carolin Benjamins and René Sass and Frank Hutter},
   title = {SMAC3: A Versatile Bayesian Optimization Package for Hyperparameter Optimization},
@@ -5,3 +6,114 @@
   year = {2021},
   url = {https://arxiv.org/abs/2109.09831}
 }
+=======
+---
+cff-version: 1.2.0
+
+message: "If you used SMAC in one of your research projects, please cite us:"
+
+title: "SMAC3"
+date-released: "2016-08-17"
+
+url: "https://automl.github.io/SMAC3/master/index.html"
+repository-code: "https://github.com/automl/SMAC3"
+
+version: "1.0.1"
+
+type: "software"
+keywords:
+  - "blackbox optimization"
+  - "optimization"
+  - "bayesian optimization"
+  - "algorithm configuration"
+  - "machine learning"
+  - "algorithms"
+
+license: "BSD-3-Clause"
+
+authors:
+  - family-names: "Lindauer"
+    given-names: "Marius"
+    affiliation: "Leibniz Universität Hannover"
+
+  - family-names: "Eggensperger"
+    given-names: "Katharina" 
+    orcid: "https://orcid.org/0000-0002-0309-401X"
+    affiliation: "University of Freiburg, Germany"
+
+  - family-names: "Feurer"
+    given-names: "Matthias"
+    orcid: "https://orcid.org/0000-0001-9611-8588"
+    affiliation: "University of Freiburg, Germany"
+
+  - family-names: "Biedenkapp"
+    given-names: "André"
+    orcid: "https://orcid.org/0000-0002-8703-8559"
+    affiliation: "University of Freiburg, Germany"
+
+  - family-names: "Deng"
+    given-names: "Difan"
+    affiliation: "Leibniz Universität Hannover"
+
+  - family-names: "Benjamins"
+    given-names: "Carolin"
+    affiliation: "Leibniz Universität Hannover"
+
+  - family-names: "Sass"
+    given-names: "René"
+    affiliation: "Leibniz Universität Hannover"
+
+  - family-names: "Hutter"
+    given-names: "Frank"
+    affiliation: "University of Freiburg, Germany"
+
+  - family-names: "Falkner"
+    given-names: "Stefan"
+    orcid: "https://orcid.org/0000-0002-6303-9418"
+    affiliation: "Bosch Center for Artificial Intelligence, Rennigen, Germany"
+
+preferred-citation:
+  type: "article"
+  title: "SMAC3: A Versatile Bayesian Optimization Package for Hyperparameter Optimization"
+  month: "9"
+  year: "2021"
+  url: "https://arxiv.org/abs/2109.09831"
+  repository-code: "https://github.com/automl/SMAC3"
+
+  authors:
+    - family-names: "Lindauer"
+      given-names: "Marius"
+      affiliation: "Leibniz Universität Hannover"
+
+    - family-names: "Eggensperger"
+      given-names: "Katharina" 
+      orcid: "https://orcid.org/0000-0002-0309-401X"
+      affiliation: "University of Freiburg, Germany"
+
+    - family-names: "Feurer"
+      given-names: "Matthias"
+      orcid: "https://orcid.org/0000-0001-9611-8588"
+      affiliation: "University of Freiburg, Germany"
+
+    - family-names: "Biedenkapp"
+      given-names: "André "
+      orcid: "https://orcid.org/0000-0002-8703-8559"
+      affiliation: "University of Freiburg, Germany"
+
+    - family-names: "Deng"
+      given-names: "Difan"
+      affiliation: "Leibniz Universität Hannover"
+
+    - family-names: "Benjamins"
+      given-names: "Carolin"
+      affiliation: "Leibniz Universität Hannover"
+
+    - family-names: "Sass"
+      given-names: "René"
+      affiliation: "Leibniz Universität Hannover"
+
+    - family-names: "Hutter"
+      given-names: "Frank"
+      affiliation: "University of Freiburg, Germany"
+...
+>>>>>>> c4ca5484 (Added CITATION.cff and updated docs reference)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -47,12 +47,13 @@ Contents:
    please cite us:
 
 
-     | @misc{smac-2017,
-     |    title={SMAC v3: Algorithm Configuration in Python},
-     |    author={Marius Lindauer and Katharina Eggensperger and Matthias Feurer and Stefan Falkner and André Biedenkapp and Frank Hutter},
-     |    year={2017},
-     |    publisher={GitHub},
-     |    howpublished={\\url{https://github.com/automl/SMAC3}}
+     | @misc{lindauer2021smac3,
+     |    title={SMAC3: A Versatile Bayesian Optimization Package for Hyperparameter Optimization}
+     |    author={Marius Lindauer and Katharina Eggensperger and Matthias Feurer and André Biedenkapp and Difan Deng and Carolin Benjamins and René Sass and Frank Hutter},
+     |    year={2021},
+     |    eprint={2109.09831},
+     |    archivePrefix={arXiv},
+     |    primaryClass={cs.LG}
      | }
 
 SMAC3 is mainly written in Python 3 and continuously tested with Python 3.7-3.9.


### PR DESCRIPTION
Ello,

This PR adds a `CITATION.cff` file to use githubs [new referencing features](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files).

It also updates the docs (`index.rst`) to reference the [newly release smac paper on arxix](https://arxiv.org/abs/2109.09831). The reference copies the one as exported by arxiv.

Please have a look through and make sure there authors and information is correct, let me know if not