### PR TITLE
Specfiy to dask that runs shouldn't cache results

### DIFF
--- a/smac/tae/dask_runner.py
+++ b/smac/tae/dask_runner.py
@@ -158,11 +158,15 @@ class DaskParallelRunner(BaseRunner):
                                  "or no workers were properly configured."
                                  )
 
+
         # At this point we can submit the job
+        # For `pure=False`, see
+        #   http://distributed.dask.org/en/stable/client.html#pure-functions-by-default
         self.futures.append(
             self.client.submit(
                 self.single_worker.run_wrapper,
-                run_info
+                run_info,
+                pure=False
             )
         )
 

--- a/smac/tae/dask_runner.py
+++ b/smac/tae/dask_runner.py
@@ -158,7 +158,6 @@ class DaskParallelRunner(BaseRunner):
                                  "or no workers were properly configured."
                                  )
 
-
         # At this point we can submit the job
         # For `pure=False`, see
         #   http://distributed.dask.org/en/stable/client.html#pure-functions-by-default


### PR DESCRIPTION
Doing some unfortunate debugging of one of our examples in `auto-sklearn` and came across [this piece of documentation](http://distributed.dask.org/en/stable/client.html#pure-functions-by-default). Essentially `pure=True` just means `dask` won't recompute `f` given the same input `x`. It's unlikely that we ever have the same input `x` but in the of chance we do, it won't give the same result do to time, randomness in some algorithms etc...

Unlikely to change anything but seems more correct to include `pure=False`.

> By default, distributed assumes that all functions are pure. Pure functions:
>  - always return the same output for a given set of inputs
>  - do not have side effects, like modifying global state or creating files

> If this is not the case, you should use the pure=False keyword argument in methods like Client.map() and Client.submit().
> This key should be the same across all computations with the same inputs and across all machines. If we run the computation above on any computer with the same environment then we should get the exact same key.

> The scheduler avoids redundant computations. If the result is already in memory from a previous call then that old result will be used rather than recomputing it. Calls to submit or map are idempotent in the common case.
