### PR TITLE
[Bug Fix] Fixes the signature of ROAR to match it's parent SMAC4AC

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 1.2.1
+
+## Minor Changes
+* Updated the signature of the `ROAR` facade to match with it's parent class `SMAC4AC`. Anyone relying on the output directory **without** specifying an explicit `run_id` to a `ROAR` facade should now expect to see the output directory at `run_0` instead of `run_1`. See #827
+
+
 # 1.2
 
 ## Features

--- a/smac/facade/roar_facade.py
+++ b/smac/facade/roar_facade.py
@@ -59,9 +59,9 @@ class ROAR(SMAC4AC):
         cannot be used together with initial_design
     stats: Stats
         optional stats object
-    rng: np.random.RandomState
+    rng: Optional[int, np.random.RandomState]
         Random number generator
-    run_id: int, (default: 1)
+    run_id: Optional[int]
         Run ID will be used as subfolder for output_dir.
     dask_client : dask.distributed.Client
         User-created dask client, can be used to start a dask cluster and then attach SMAC to it.
@@ -95,8 +95,8 @@ class ROAR(SMAC4AC):
                  initial_design_kwargs: typing.Optional[dict] = None,
                  initial_configurations: typing.List[Configuration] = None,
                  stats: Stats = None,
-                 rng: np.random.RandomState = None,
-                 run_id: int = 1,
+                 rng: typing.Optional[typing.Union[int, np.random.RandomState]] = None,
+                 run_id: typing.Optional[int] = None,
                  dask_client: typing.Optional[dask.distributed.Client] = None,
                  n_jobs: typing.Optional[int] = 1,
                  ):


### PR DESCRIPTION
**[minor breaking change, see note below when making release notes]**

The `ROAR(SMAC4AC)` facade had a default `run_id = 1` while `SMAC4AC` has it as `run_id = None`. This caused issues with respect to assumed paths in autosklearn when passing a different SMAC facade as we relied on the behaviour to be similar to `SMAC4AC`.

Edit:
Turns out it was a bad test setup in autosklearn which is easily fixable on my end. Still though, I think it's worth fixing this.

Looking through the code, I couldn't find any reason why `ROAR` should set it explicitly to `1` while it's super should be `None`.

It's possible someone out there relied on this behaviour, this should probably be mentioned as a minor breaking change in release notes.

I also updated the type signatures to match for `run_id` and `rng`.

## For release notes
> Anyone relying on the output directory without specifying an explicit `run_id` to a `ROAR` facade should now expect to see the output directory at `run_0` instead of `run_1`. This is inline with its parent `SMAC4AC`. See https://github.com/automl/SMAC3/pull/827


