### PR TITLE
Add Mapping type to Runhistory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 1.2.1
+
+## Features
+* The `RunHistory` can now act as a `Mapping` in that you can use the usual methods you can use on dicts, i.e. `len(rh)`, `rh.items()`, `rh[key]`. Previously this was usually done by accessing `rh.data` which is still possible.
+
+
 # 1.2
 
 ## Features
@@ -10,7 +16,7 @@ a trial is added.
 * Determinstic behaviour (defined in scenario) is default now. Calling a function/TAE with the same
 seed and configuration is expected to be the same.
 * Limit resources behaviour is by default false now. This is particually important because pynisher
-does not work on all machines (e.g. Colab, Mac, Windows, ...) properly. 
+does not work on all machines (e.g. Colab, Mac, Windows, ...) properly.
 * Renamed scenario object `save_results_instantly` to `save_instantly`.
 * Added `multi_objectives` as scenario argument.
 * Expanded `cost_for_crash` for multi-objective support.

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -1,7 +1,19 @@
 import collections
 from enum import Enum
 import json
-from typing import List, Dict, Union, Optional, Any, Type, Iterable, cast, Tuple
+from typing import (
+    List,
+    Dict,
+    Union,
+    Optional,
+    Any,
+    Type,
+    Iterable,
+    cast,
+    Tuple,
+    Mapping,
+    Iterator
+)
 
 import numpy as np
 
@@ -128,7 +140,7 @@ class DataOrigin(Enum):
     EXTERNAL_DIFFERENT_INSTANCES = 3
 
 
-class RunHistory(object):
+class RunHistory(Mapping[RunKey, RunValue]):
     """Container for target algorithm run information.
 
     Most importantly, the runhistory contains an efficient mapping from each evaluated configuration to the
@@ -947,3 +959,19 @@ class RunHistory(object):
             [(inst, np.mean(costs)) for inst, costs in cost_per_inst.items()]
         )
         return cost_per_inst
+
+    def __contains__(self, k: object) -> bool:
+        """Dictionary semantics for `k in runhistory`"""
+        return k in self.data
+
+    def __getitem__(self, k: RunKey) -> RunValue:
+        """Dictionary semantics for `v = runhistory[k]`"""
+        return self.data[k]
+
+    def __iter__(self) -> Iterator[RunKey]:
+        """Dictionary semantics for `for k in runhistory.keys()`, enables .items()"""
+        return iter(self.data.keys())
+
+    def __len__(self) -> int:
+        """Enables the `len(runhistory)`"""
+        return len(self.data)

--- a/test/test_runhistory/test_runhistory.py
+++ b/test/test_runhistory/test_runhistory.py
@@ -508,7 +508,6 @@ class RunHistoryMappingTest(unittest.TestCase):
         assert len(list(iter(self.runhistory))) == len(self.runhistory)
         assert len(list(iter(self.runhistory))) == len(self.runhistory.data)
 
-
     def test_items(self):
         """Test that items goes in correct insertion order and returns key values
         as expected.

--- a/test/test_runhistory/test_runhistory.py
+++ b/test/test_runhistory/test_runhistory.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import os
 import pickle
 import tempfile
@@ -7,7 +9,7 @@ from ConfigSpace import Configuration, ConfigurationSpace
 from ConfigSpace.hyperparameters import UniformIntegerHyperparameter
 
 from smac.tae import StatusType
-from smac.runhistory.runhistory import RunHistory
+from smac.runhistory.runhistory import RunHistory, RunKey
 
 __copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
 __license__ = "3-clause BSD"
@@ -418,6 +420,130 @@ class RunhistoryTest(unittest.TestCase):
             self.assertEqual(rh.get_all_configs()[0].origin, origin)
 
             os.remove(path)
+
+
+class RunHistoryMappingTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.cs = get_config_space()
+        self.runhistory = RunHistory()
+
+    def add_item(
+        self,
+        cost: float = 0.0,
+        time: float = 1.0,
+        seed: int = 0,
+        instance_id: Optional[str] = None,
+        budget: float = 0.0,
+        status=StatusType.SUCCESS
+    ) -> RunKey:
+        """No easy way to generate a key before hand"""
+        self.runhistory.add(
+            config=self.cs.sample_configuration(),
+            cost=cost,
+            time=time,
+            instance_id=instance_id,
+            seed=seed,
+            budget=budget,
+            status=status,
+        )
+        return RunKey(
+            config_id=self.runhistory._n_id,  # What's used internally during `add`
+            instance_id=instance_id,
+            seed=seed,
+            budget=budget
+        )
+
+    def test_contains(self):
+        """Test that keys added are contained `in` and not if not added"""
+        k = self.add_item()
+        assert k in self.runhistory
+
+        new_rh = RunHistory()
+        assert k not in new_rh
+
+    def test_getting(self):
+        """Test that rh[k] will return the correct value"""
+        k = self.add_item(cost=1.0)
+        k2 = self.add_item(cost=2.0)
+
+        v = self.runhistory[k]
+        assert v.cost == 1.0
+
+        v2 = self.runhistory[k2]
+        assert v2.cost == 2.0
+
+    def test_len(self):
+        """Test that adding items will increase the length monotonically"""
+        assert len(self.runhistory) == 0
+
+        n_items = 5
+
+        for i in range(n_items):
+            assert len(self.runhistory) == i
+
+            self.add_item()
+
+            assert len(self.runhistory) == i + 1
+
+        assert len(self.runhistory) == n_items
+
+    def test_iter(self):
+        """Test that iter goes in the order of insertion and has consitent length
+        with the runhistory's advertised length and it's internal `data`
+        """
+        params = [
+            {"instance_id": "a", "cost": 1.0},
+            {"instance_id": "b", "cost": 2.0},
+            {"instance_id": "c", "cost": 3.0},
+            {"instance_id": "d", "cost": 4.0},
+        ]
+
+        for p in params:
+            self.add_item(**p)
+
+        expected_id_order = [p["instance_id"] for p in params]
+        assert [k.instance_id for k in iter(self.runhistory)] == expected_id_order
+
+        assert len(list(iter(self.runhistory))) == len(self.runhistory)
+        assert len(list(iter(self.runhistory))) == len(self.runhistory.data)
+
+
+    def test_items(self):
+        """Test that items goes in correct insertion order and returns key values
+        as expected.
+        """
+        params = [
+            {"instance_id": "a", "cost": 1.0},
+            {"instance_id": "b", "cost": 2.0},
+            {"instance_id": "c", "cost": 3.0},
+            {"instance_id": "d", "cost": 4.0},
+        ]
+
+        for p in params:
+            self.add_item(**p)
+
+        for (k, v), expected in zip(self.runhistory.items(), params):
+            assert k.instance_id == expected["instance_id"]
+            assert v.cost == expected["cost"]
+
+    def test_unpack(self):
+        """Test that unpacking maintains order and returns key values as expected"""
+        params = [
+            {"instance_id": "a", "cost": 1.0},
+            {"instance_id": "b", "cost": 2.0},
+            {"instance_id": "c", "cost": 3.0},
+            {"instance_id": "d", "cost": 4.0},
+        ]
+
+        for p in params:
+            self.add_item(**p)
+
+        unpacked = {**self.runhistory}
+
+        for (k, v), expected in zip(unpacked.items(), params):
+            assert k.instance_id == expected["instance_id"]
+            assert v.cost == expected["cost"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add some dunder methods to `RunHistory` so it acts a little bit more like a [`Mapping`](https://docs.python.org/3/library/collections.abc.html).

```python
rh = RunHistory()
... populate it somehow

# Iter it
keys = list(rh)
values = list(rh.values())
for runkey, runvalue in rh.items():
    ...
    
# Query it
if runkey in rh:
   ...
   
# Get stuff
runvalue = rh[runkey]

# Unpack it, because why not
unpacked = {**rh}

# Get the length of it
if len(rh) > 0:
    """This is more pythonic than defining an `empty` method as it does,
    but i don't want to break anything so empty can stay in"""
   ...
```

Note:
I wanted to make it a `MutableMapping` which lets you add things into the dictionary with the normal `dictionary[key] = value` syntax, but the class is pretty heavily designed against it due to it's `add` method not taking RunValues but rather all the individual components. I tried using the `_add` method too but that doesn't work unless it's called from `add` directly, due to how ids and such are allocated.

In general, I don't see this being useful to consumers of SMAC but maybe just internally as well as advertising a bit more what RunHistory is meant to act like. It might save like 10 characters in auto-sklearn though `runhistory.data.items() -> runhistory.items()` :upside_down_face: 