### PR TITLE
Fix Multi-Objective cache

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# 1.4.0
+
+## Improvements
+* Enabled caching for multi-objectives (#872). Costs are now normalized in `get_cost` 
+or optionally in `average_cost`/`sum_cost`/`min_cost` to receive a single float value. Therefore,
+the cached cost values do not need to be updated everytime a new entry to the runhistory was added.
+
+
 # 1.3.4
 * Added reference to JMLR paper.
 * Typos in documentations.

--- a/examples/python/plot_simple_multi_objective.py
+++ b/examples/python/plot_simple_multi_objective.py
@@ -27,7 +27,10 @@ def plot(all_x):
     plt.figure()
     for x in all_x:
         f1, f2 = schaffer(x)
-        plt.scatter(f1, f2, c="blue", alpha=0.1)
+        plt.scatter(f1, f2, c="blue", alpha=0.1, zorder=3000)
+
+    plt.vlines([1], 0, 4, linestyles="dashed", colors=["red"])
+    plt.hlines([1], 0, 4, linestyles="dashed", colors=["red"])
 
     plt.show()
 

--- a/smac/facade/smac_ac_facade.py
+++ b/smac/facade/smac_ac_facade.py
@@ -530,7 +530,7 @@ class SMAC4AC(object):
 
         if scenario.multi_objectives is not None and num_obj > 1:  # type: ignore[attr-defined] # noqa F821
             # define any defaults here
-            _multi_objective_kwargs = {"rng": rng, "num_obj": num_obj}
+            _multi_objective_kwargs = {"rng": rng}
 
             if multi_objective_kwargs is not None:
                 _multi_objective_kwargs.update(multi_objective_kwargs)

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -296,9 +296,10 @@ class AbstractRacer(object):
         # reasons)
         chall_inst_seeds = run_history.get_runs_for_config(challenger, only_max_observed_budget=True)
         chal_sum_cost = run_history.sum_cost(
-            config=challenger,
-            instance_seed_budget_keys=chall_inst_seeds,
+            config=challenger, instance_seed_budget_keys=chall_inst_seeds, normalize=True
         )
+        assert type(chal_sum_cost) == float
+
         cutoff = min(curr_cutoff, inc_sum_cost * self.adaptive_capping_slackfactor - chal_sum_cost)
         return cutoff
 
@@ -341,17 +342,11 @@ class AbstractRacer(object):
 
         # performance on challenger runs, the challenger only becomes incumbent
         # if it dominates the incumbent
-        chal_perf = run_history.average_cost(challenger, to_compare_runs)
-        inc_perf = run_history.average_cost(incumbent, to_compare_runs)
+        chal_perf = run_history.average_cost(challenger, to_compare_runs, normalize=True)
+        inc_perf = run_history.average_cost(incumbent, to_compare_runs, normalize=True)
 
-        # Multi-Objective setting: We have to normalize the values here
-        if type(chal_perf) == list or type(inc_perf) == list:
-            assert type(chal_perf) == type(inc_perf)
-            chal_perf = run_history.get_cost(challenger)
-            inc_perf = run_history.get_cost(incumbent)
-        else:
-            assert type(chal_perf) == float
-            assert type(inc_perf) == float
+        assert type(chal_perf) == float
+        assert type(inc_perf) == float
 
         # Line 15
         if np.any(chal_perf > inc_perf) and len(chall_runs) >= self.minR:

--- a/smac/intensification/abstract_racer.py
+++ b/smac/intensification/abstract_racer.py
@@ -13,7 +13,6 @@ from smac.runhistory.runhistory import RunHistory, RunInfo, RunValue
 from smac.stats.stats import Stats
 from smac.utils.io.traj_logging import TrajLogger
 from smac.utils.logging import format_array
-from smac.utils.multi_objective import normalize_costs
 
 _config_to_run_type = Iterator[Optional[Configuration]]
 

--- a/smac/intensification/hyperband.py
+++ b/smac/intensification/hyperband.py
@@ -98,7 +98,6 @@ class _Hyperband(_SuccessiveHalving):
         min_chall: int = 1,
         incumbent_selection: str = "highest_executed_budget",
         identifier: int = 0,
-        num_obj: int = 1,
     ) -> None:
 
         super().__init__(
@@ -119,7 +118,6 @@ class _Hyperband(_SuccessiveHalving):
             adaptive_capping_slackfactor=adaptive_capping_slackfactor,
             min_chall=min_chall,
             incumbent_selection=incumbent_selection,
-            num_obj=num_obj,
         )
 
         self.identifier = identifier

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -24,7 +24,6 @@ from smac.stats.stats import Stats
 from smac.utils.constants import MAXINT
 from smac.utils.io.traj_logging import TrajLogger
 from smac.utils.logging import format_array
-from smac.utils.multi_objective import normalize_costs
 
 __author__ = "Katharina Eggensperger, Marius Lindauer"
 __copyright__ = "Copyright 2018, ML4AAD"
@@ -896,16 +895,7 @@ class Intensifier(AbstractRacer):
         # because of efficiency computed here
         inst_seed_pairs = list(inc_inst_seeds - set(missing_runs))
         # cost used by incumbent for going over all runs in inst_seed_pairs
-        inc_sum_cost = run_history.sum_cost(
-            config=incumbent,
-            instance_seed_budget_keys=inst_seed_pairs,
-        )
-
-        # Multi-Objective
-        if type(inc_sum_cost) == list:
-            costs = normalize_costs(inc_sum_cost, run_history.objective_bounds)
-            return to_run, float(np.mean(costs))
-
+        inc_sum_cost = run_history.sum_cost(config=incumbent, instance_seed_budget_keys=inst_seed_pairs, normalize=True)
         assert type(inc_sum_cost) == float
         return to_run, inc_sum_cost
 

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -144,7 +144,6 @@ class Intensifier(AbstractRacer):
         maxR: int = 2000,
         adaptive_capping_slackfactor: float = 1.2,
         min_chall: int = 2,
-        num_obj: int = 1,
     ):
         super().__init__(
             stats=stats,
@@ -159,7 +158,6 @@ class Intensifier(AbstractRacer):
             maxR=maxR,
             adaptive_capping_slackfactor=adaptive_capping_slackfactor,
             min_chall=min_chall,
-            num_obj=num_obj,
         )
 
         self.logger = logging.getLogger(self.__module__ + "." + self.__class__.__name__)
@@ -795,6 +793,7 @@ class Intensifier(AbstractRacer):
         """
         chal_runs = run_history.get_runs_for_config(challenger, only_max_observed_budget=True)
         chal_perf = run_history.get_cost(challenger)
+
         # if all <instance, seed> have been run, compare challenger performance
         if not self.to_run:
             new_incumbent = self._compare_configs(

--- a/smac/intensification/intensification.py
+++ b/smac/intensification/intensification.py
@@ -24,6 +24,7 @@ from smac.stats.stats import Stats
 from smac.utils.constants import MAXINT
 from smac.utils.io.traj_logging import TrajLogger
 from smac.utils.logging import format_array
+from smac.utils.multi_objective import normalize_costs
 
 __author__ = "Katharina Eggensperger, Marius Lindauer"
 __copyright__ = "Copyright 2018, ML4AAD"
@@ -900,6 +901,12 @@ class Intensifier(AbstractRacer):
             instance_seed_budget_keys=inst_seed_pairs,
         )
 
+        # Multi-Objective
+        if type(inc_sum_cost) == list:
+            costs = normalize_costs(inc_sum_cost, run_history.objective_bounds)
+            return to_run, float(np.mean(costs))
+
+        assert type(inc_sum_cost) == float
         return to_run, inc_sum_cost
 
     def get_next_challenger(

--- a/smac/intensification/parallel_scheduling.py
+++ b/smac/intensification/parallel_scheduling.py
@@ -89,7 +89,6 @@ class ParallelScheduler(AbstractRacer):
         inst_seed_pairs: Optional[List[Tuple[str, int]]] = None,
         min_chall: int = 1,
         incumbent_selection: str = "highest_executed_budget",
-        num_obj: int = 1,
     ) -> None:
 
         super().__init__(
@@ -103,7 +102,6 @@ class ParallelScheduler(AbstractRacer):
             run_obj_time=run_obj_time,
             adaptive_capping_slackfactor=adaptive_capping_slackfactor,
             min_chall=min_chall,
-            num_obj=num_obj,
         )
 
         # We have a pool of instances that yield configurations ot run

--- a/smac/intensification/simple_intensifier.py
+++ b/smac/intensification/simple_intensifier.py
@@ -46,7 +46,6 @@ class SimpleIntensifier(AbstractRacer):
         cutoff: Optional[float] = None,
         deterministic: bool = False,
         run_obj_time: bool = True,
-        num_obj: int = 1,
         **kwargs: Any,
     ) -> None:
 
@@ -61,10 +60,7 @@ class SimpleIntensifier(AbstractRacer):
             run_obj_time=run_obj_time,
             adaptive_capping_slackfactor=1.0,
             min_chall=1,
-            num_obj=num_obj,
         )
-        # Simple intensifier does not require comparing run results, thus we could simply ignore num_obj here
-
         # We want to control the number of runs that are sent to
         # the workers. At any time, we want to make sure that if there
         # are just W workers, there should be at max W active runs

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -628,12 +628,13 @@ class _SuccessiveHalving(AbstractRacer):
         if incumbent and incumbent != challenger:
             inc_runs = run_history.get_runs_for_config(incumbent, only_max_observed_budget=True)
             inc_sum_cost = run_history.sum_cost(config=incumbent, instance_seed_budget_keys=inc_runs, normalize=True)
-            assert type(inc_sum_cost) == float
         else:
             inc_sum_cost = np.inf
             if self.first_run:
                 self.logger.info("First run, no incumbent provided; challenger is assumed to be the incumbent")
                 incumbent = challenger
+
+        assert type(inc_sum_cost) == float
 
         # Selecting instance-seed subset for this budget, depending on the kind of budget
         if self.instance_as_budget:

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -14,6 +14,7 @@ from smac.stats.stats import Stats
 from smac.tae import StatusType
 from smac.utils.constants import MAXINT
 from smac.utils.io.traj_logging import TrajLogger
+from smac.utils.multi_objective import normalize_costs
 
 __author__ = "Ashwin Raaghav Narayanan"
 __copyright__ = "Copyright 2019, ML4AAD"
@@ -633,6 +634,13 @@ class _SuccessiveHalving(AbstractRacer):
             if self.first_run:
                 self.logger.info("First run, no incumbent provided; challenger is assumed to be the incumbent")
                 incumbent = challenger
+
+        # Multi-Objective
+        if type(inc_sum_cost) == list:
+            costs = normalize_costs(inc_sum_cost, run_history.objective_bounds)
+            inc_sum_cost = float(np.mean(costs))
+        else:
+            assert type(inc_sum_cost) == float
 
         # selecting instance-seed subset for this budget, depending on the kind of budget
         if self.instance_as_budget:

--- a/smac/intensification/successive_halving.py
+++ b/smac/intensification/successive_halving.py
@@ -137,7 +137,6 @@ class _SuccessiveHalving(AbstractRacer):
         min_chall: int = 1,
         incumbent_selection: str = "highest_executed_budget",
         identifier: int = 0,
-        num_obj: int = 1,
     ) -> None:
         super().__init__(
             stats=stats,
@@ -150,7 +149,6 @@ class _SuccessiveHalving(AbstractRacer):
             run_obj_time=run_obj_time,
             adaptive_capping_slackfactor=adaptive_capping_slackfactor,
             min_chall=min_chall,
-            num_obj=num_obj,
         )
 
         self.identifier = identifier

--- a/smac/optimizer/multi_objective/abstract_multi_objective_algorithm.py
+++ b/smac/optimizer/multi_objective/abstract_multi_objective_algorithm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC
 from typing import Optional
 
@@ -11,7 +13,6 @@ class AbstractMultiObjectiveAlgorithm(ABC):
     """
 
     def __init__(self, num_obj: int, rng: Optional[np.random.RandomState] = None):
-
         if rng is None:
             rng = np.random.RandomState(0)
 

--- a/smac/optimizer/multi_objective/abstract_multi_objective_algorithm.py
+++ b/smac/optimizer/multi_objective/abstract_multi_objective_algorithm.py
@@ -12,9 +12,8 @@ class AbstractMultiObjectiveAlgorithm(ABC):
     It can be applied to rh2epm or epmchooser.
     """
 
-    def __init__(self, num_obj: int, rng: Optional[np.random.RandomState] = None):
+    def __init__(self, rng: Optional[np.random.RandomState] = None):
         if rng is None:
             rng = np.random.RandomState(0)
 
-        self.num_obj = num_obj
         self.rng = rng

--- a/smac/optimizer/multi_objective/aggregation_strategy.py
+++ b/smac/optimizer/multi_objective/aggregation_strategy.py
@@ -47,4 +47,4 @@ class MeanAggregationStrategy(AggregationStrategy):
         -------
             cost (float): Combined cost.
         """
-        return np.mean(values, axis=1)
+        return np.mean(values, axis=0)

--- a/smac/optimizer/multi_objective/aggregation_strategy.py
+++ b/smac/optimizer/multi_objective/aggregation_strategy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 
 import numpy as np
@@ -9,22 +11,24 @@ from smac.optimizer.multi_objective.abstract_multi_objective_algorithm import (
 
 class AggregationStrategy(AbstractMultiObjectiveAlgorithm):
     """
-    An abstract class to aggregate multi-objective losses to a single objective losses, which can then be utilized
-    by the single-objective optimizer.
+    An abstract class to aggregate multi-objective losses to a single objective losses,
+    which can then be utilized by the single-objective optimizer.
     """
 
     @abstractmethod
-    def __call__(self, values: np.ndarray) -> float:
+    def __call__(self, values: list[float]) -> float:
         """
         Transform a multi-objective loss to a single loss.
 
         Parameters
         ----------
-            values: np.ndarray[num_evaluations, num_obj].
+        values : list[float]
+            Normalized values.
 
         Returns
         -------
-            cost: float.
+        cost : float
+            Combined cost.
         """
         raise NotImplementedError
 
@@ -35,16 +39,18 @@ class MeanAggregationStrategy(AggregationStrategy):
     which can then be utilized by the single-objective optimizer.
     """
 
-    def __call__(self, values: np.ndarray) -> float:
+    def __call__(self, values: list[float]) -> float:
         """
         Transform a multi-objective loss to a single loss.
 
         Parameters
         ----------
-            values (np.ndarray): Normalized values.
+        values : list[float]
+            Normalized values.
 
         Returns
         -------
-            cost (float): Combined cost.
+        cost : float
+            Combined cost.
         """
         return np.mean(values, axis=0)

--- a/smac/optimizer/multi_objective/aggregation_strategy.py
+++ b/smac/optimizer/multi_objective/aggregation_strategy.py
@@ -11,7 +11,7 @@ from smac.optimizer.multi_objective.abstract_multi_objective_algorithm import (
 
 class AggregationStrategy(AbstractMultiObjectiveAlgorithm):
     """
-    An abstract class to aggregate multi-objective losses to a single objective losses,
+    An abstract class to aggregate multi-objective losses to a single objective loss,
     which can then be utilized by the single-objective optimizer.
     """
 

--- a/smac/optimizer/multi_objective/parego.py
+++ b/smac/optimizer/multi_objective/parego.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np
@@ -15,17 +17,19 @@ class ParEGO(AggregationStrategy):
         super(ParEGO, self).__init__(num_obj=num_obj, rng=rng)
         self.rho = rho
 
-    def __call__(self, values: np.ndarray) -> float:
+    def __call__(self, values: list[float]) -> float:
         """
         Transform a multi-objective loss to a single loss.
 
         Parameters
         ----------
-            values (np.ndarray): Normalized values.
+        values : list[float]
+            Normalized values.
 
         Returns
         -------
-            cost (float): Combined cost.
+        cost : float
+            Combined cost.
         """
         # Then we have to compute the weight
         theta = self.rng.rand(self.num_obj)

--- a/smac/optimizer/multi_objective/parego.py
+++ b/smac/optimizer/multi_objective/parego.py
@@ -35,5 +35,4 @@ class ParEGO(AggregationStrategy):
 
         # Weight the values
         theta_f = theta * values
-
-        return np.max(theta_f, axis=1) + self.rho * np.sum(theta_f, axis=1)
+        return np.max(theta_f, axis=0) + self.rho * np.sum(theta_f, axis=0)

--- a/smac/optimizer/multi_objective/parego.py
+++ b/smac/optimizer/multi_objective/parego.py
@@ -10,11 +10,10 @@ from smac.optimizer.multi_objective.aggregation_strategy import AggregationStrat
 class ParEGO(AggregationStrategy):
     def __init__(
         self,
-        num_obj: int,
         rng: Optional[np.random.RandomState] = None,
         rho: float = 0.05,
     ):
-        super(ParEGO, self).__init__(num_obj=num_obj, rng=rng)
+        super(ParEGO, self).__init__(rng=rng)
         self.rho = rho
 
     def __call__(self, values: list[float]) -> float:
@@ -32,7 +31,7 @@ class ParEGO(AggregationStrategy):
             Combined cost.
         """
         # Then we have to compute the weight
-        theta = self.rng.rand(self.num_obj)
+        theta = self.rng.rand(len(values))
 
         # Normalize st all theta values sum up to 1
         theta = theta / (np.sum(theta) + 1e-10)

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -539,8 +539,8 @@ class RunHistory(Mapping[RunKey, RunValue]):
             costs = normalize_costs(cost, self.objective_bounds)
             return float(np.mean(costs))
 
-        assert type(cost) == float
-        return cost
+        assert type(cost) == float or type(cost) == int
+        return float(cost)
 
     def get_min_cost(self, config: Configuration) -> float:
         """Returns the lowest empirical cost for a configuration, across all runs (budgets)
@@ -567,8 +567,8 @@ class RunHistory(Mapping[RunKey, RunValue]):
             # Note: We have to mean here because we already got the min cost
             return float(np.mean(costs))
 
-        assert type(cost) == float
-        return cost
+        assert type(cost) == float or type(cost) == int
+        return float(cost)
 
     def average_cost(
         self,

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -555,7 +555,7 @@ class RunHistory(Mapping[RunKey, RunValue]):
             costs = normalize_costs(cost, self.objective_bounds)
             return float(np.mean(costs))
 
-        assert type(cost) == float or type(cost) == int
+        assert type(cost) == float
         return float(cost)
 
     def get_min_cost(self, config: Configuration) -> float:
@@ -583,7 +583,7 @@ class RunHistory(Mapping[RunKey, RunValue]):
             # Note: We have to mean here because we already got the min cost
             return float(np.mean(costs))
 
-        assert type(cost) == float or type(cost) == int
+        assert type(cost) == float
         return float(cost)
 
     def average_cost(

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -415,6 +415,7 @@ class RunHistory(Mapping[RunKey, RunValue]):
         # Squeeze is important to reduce arrays with one element
         # to scalars.
         cost_array = np.asarray(cost).squeeze()
+        num_obj = np.size(cost_array)
 
         # Get the config id
         config_id_tmp = self.config_ids.get(config)
@@ -427,16 +428,14 @@ class RunHistory(Mapping[RunKey, RunValue]):
             config_id = cast(int, config_id_tmp)
 
         if self.num_obj == -1:
-            self.num_obj = np.size(cost_array)
-        else:
-            if np.size(cost_array) != self.num_obj:
-                raise ValueError(
-                    f"Cost is not of the same length ({np.size(cost)}) as the number " f"of objectives ({self.num_obj})"
-                )
+            self.num_obj = num_obj
+        elif num_obj != self.num_obj:
+            raise ValueError(
+                f"Cost is not of the same length ({num_obj}) as the number " f"of objectives ({self.num_obj})"
+            )
 
+        # Let's always work with floats; Makes it easier to deal with later on
         c = cost_array.tolist()
-
-        # Let's always work with floats
         if self.num_obj == 1:
             c = float(c)
         else:
@@ -473,7 +472,7 @@ class RunHistory(Mapping[RunKey, RunValue]):
             if self.num_obj > 1:
                 raise RuntimeError("Not supported yet.")
 
-            # overwrite if censored with a larger cutoff
+            # Overwrite if censored with a larger cutoff
             if cost > self.data[k].cost:
                 self._add(k, v, status, origin)
         else:

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -24,6 +24,7 @@ from smac.configspace import Configuration, ConfigurationSpace
 from smac.tae import StatusType
 from smac.utils.logging import PickableLoggerAdapter
 from smac.utils.multi_objective import normalize_costs
+from smac.utils.logging import PickableLoggerAdapter
 
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2015, ML4AAD"
@@ -31,6 +32,8 @@ __license__ = "3-clause BSD"
 __maintainer__ = "Marius Lindauer"
 __email__ = "lindauer@cs.uni-freiburg.de"
 __version__ = "0.0.1"
+
+logger = PickableLoggerAdapter(__name__)
 
 
 # NOTE class instead of collection to have a default value for budget in RunKey
@@ -379,31 +382,31 @@ class RunHistory(Mapping[RunKey, RunValue]):
 
         Parameters
         ----------
-            config : dict (or other type -- depending on config space module)
-                Parameter configuration
-            cost: Union[int, float, list, np.ndarray]
-                Cost of TA run (will be minimized)
-            time: float
-                Runtime of TA run
-            status: str
-                Status in {SUCCESS, TIMEOUT, CRASHED, ABORT, MEMOUT}
-            instance_id: str
-                String representing an instance (default: None)
-            seed: int
-                Random seed used by TA (default: None)
-            budget: float
-                budget (cutoff) used in intensifier to limit TA (default: 0)
-            starttime: float
-                starting timestamp of TA evaluation
-            endtime: float
-                ending timestamp of TA evaluation
-            additional_info: dict
-                Additional run infos (could include further returned
-                information from TA or fields such as start time and host_id)
-            origin: DataOrigin
-                Defines how data will be used.
-            force_update: bool (default: False)
-                Forces the addition of a config to the history
+        config : dict (or other type -- depending on config space module)
+            Parameter configuration
+        cost: Union[int, float, list, np.ndarray]
+            Cost of TA run (will be minimized)
+        time: float
+            Runtime of TA run
+        status: str
+            Status in {SUCCESS, TIMEOUT, CRASHED, ABORT, MEMOUT}
+        instance_id: str
+            String representing an instance (default: None)
+        seed: int
+            Random seed used by TA (default: None)
+        budget: float
+            budget (cutoff) used in intensifier to limit TA (default: 0)
+        starttime: float
+            starting timestamp of TA evaluation
+        endtime: float
+            ending timestamp of TA evaluation
+        additional_info: dict
+            Additional run infos (could include further returned
+            information from TA or fields such as start time and host_id)
+        origin: DataOrigin
+            Defines how data will be used.
+        force_update: bool (default: False)
+            Forces the addition of a config to the history
         """
         if config is None:
             raise TypeError("Configuration to add to the runhistory must not be None")
@@ -429,12 +432,13 @@ class RunHistory(Mapping[RunKey, RunValue]):
 
         if self.num_obj == -1:
             self.num_obj = num_obj
-        elif num_obj != self.num_obj:
+        elif self.num_obj != num_obj:
             raise ValueError(
                 f"Cost is not of the same length ({num_obj}) as the number " f"of objectives ({self.num_obj})"
             )
 
         # Let's always work with floats; Makes it easier to deal with later on
+        # array.tolist() returns a scalar if the array has one element.
         c = cost_array.tolist()
         if self.num_obj == 1:
             c = float(c)
@@ -476,7 +480,7 @@ class RunHistory(Mapping[RunKey, RunValue]):
             if cost > self.data[k].cost:
                 self._add(k, v, status, origin)
         else:
-            raise RuntimeError("Entry could not be added.")
+            logger.info("Entry was not added to the runhistory because existing runs will not overwritten.")
 
     def update_cost(self, config: Configuration) -> None:
         """Stores the performance of a configuration across the instances in self.cost_per_config

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -574,6 +574,7 @@ class RunHistory(Mapping[RunKey, RunValue]):
         self,
         config: Configuration,
         instance_seed_budget_keys: Optional[Iterable[InstSeedBudgetKey]] = None,
+        normalize: bool = False,
     ) -> float | list[float]:
         """Return the average cost of a configuration. This is the mean of costs of all instance-
         seed pairs.
@@ -585,6 +586,10 @@ class RunHistory(Mapping[RunKey, RunValue]):
         instance_seed_budget_keys : list, optional (default=None)
             List of tuples of instance-seeds-budget keys. If None, the run_history is
             queried for all runs of the given configuration.
+        normalize : bool, optional (default=False)
+            Normalizes the costs wrt objective bounds in the multi-objective setting.
+            Only a float is returned if normalize is True. Warning: The value can change
+            over time because the objective bounds are changing.
 
         Returns
         -------
@@ -596,7 +601,13 @@ class RunHistory(Mapping[RunKey, RunValue]):
             if self.num_obj > 1:
                 # Each objective is averaged separately
                 # [[100, 200], [0, 0]] -> [50, 100]
-                return np.mean(costs, axis=0).tolist()
+                averaged_costs = np.mean(costs, axis=0).tolist()
+
+                if normalize:
+                    normalized_costs = normalize_costs(averaged_costs, self.objective_bounds)
+                    return float(np.mean(normalized_costs))
+                else:
+                    return averaged_costs
 
             return float(np.mean(costs))
 
@@ -606,6 +617,7 @@ class RunHistory(Mapping[RunKey, RunValue]):
         self,
         config: Configuration,
         instance_seed_budget_keys: Optional[Iterable[InstSeedBudgetKey]] = None,
+        normalize: bool = False,
     ) -> float | list[float]:
         """Return the sum of costs of a configuration. This is the sum of costs of all instance-seed
         pairs.
@@ -617,6 +629,10 @@ class RunHistory(Mapping[RunKey, RunValue]):
         instance_seed_budget_keys : list, optional (default=None)
             List of tuples of instance-seeds-budget keys. If None, the run_history is
             queried for all runs of the given configuration.
+        normalize : bool, optional (default=False)
+            Normalizes the costs wrt objective bounds in the multi-objective setting.
+            Only a float is returned if normalize is True. Warning: The value can change
+            over time because the objective bounds are changing.
 
         Returns
         -------
@@ -629,7 +645,13 @@ class RunHistory(Mapping[RunKey, RunValue]):
             if self.num_obj > 1:
                 # Each objective is summed separately
                 # [[100, 200], [20, 10]] -> [120, 210]
-                return np.sum(costs, axis=0).tolist()
+                summed_costs = np.sum(costs, axis=0).tolist()
+
+                if normalize:
+                    normalized_costs = normalize_costs(summed_costs, self.objective_bounds)
+                    return float(np.mean(normalized_costs))
+                else:
+                    return summed_costs
 
         return float(np.sum(costs))
 
@@ -637,6 +659,7 @@ class RunHistory(Mapping[RunKey, RunValue]):
         self,
         config: Configuration,
         instance_seed_budget_keys: Optional[Iterable[InstSeedBudgetKey]] = None,
+        normalize: bool = False,
     ) -> float | list[float]:
         """Return the minimum cost of a configuration.
 
@@ -665,7 +688,13 @@ class RunHistory(Mapping[RunKey, RunValue]):
             if self.num_obj > 1:
                 # Each objective is viewed separately
                 # [[100, 200], [20, 500]] -> [20, 200]
-                return np.min(costs, axis=0).tolist()
+                min_costs = np.min(costs, axis=0).tolist()
+
+                if normalize:
+                    normalized_costs = normalize_costs(min_costs, self.objective_bounds)
+                    return float(np.mean(normalized_costs))
+                else:
+                    return min_costs
 
             return float(np.min(costs))
 

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -24,7 +24,6 @@ from smac.configspace import Configuration, ConfigurationSpace
 from smac.tae import StatusType
 from smac.utils.logging import PickableLoggerAdapter
 from smac.utils.multi_objective import normalize_costs
-from smac.utils.logging import PickableLoggerAdapter
 
 __author__ = "Marius Lindauer"
 __copyright__ = "Copyright 2015, ML4AAD"

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -528,6 +528,9 @@ class RunHistory(Mapping[RunKey, RunValue]):
             Computed cost for configuration
         """
         config_id = self.config_ids.get(config)
+
+        # Cost is always a single value (Single objective) or a list of values (Multi-objective)
+        # For example, _cost_per_config always holds the value on the highest budget
         cost = self._cost_per_config.get(config_id, np.nan)  # type: ignore[arg-type] # noqa F821
 
         if self.num_obj > 1:

--- a/smac/runhistory/runhistory2epm.py
+++ b/smac/runhistory/runhistory2epm.py
@@ -473,7 +473,7 @@ class RunHistory2EPM4Cost(AbstractRunHistory2EPM):
 
                 # Let's normalize y here
                 # We use the objective_bounds calculated by the runhistory
-                y_ = normalize_costs([run.cost], runhistory.objective_bounds)
+                y_ = normalize_costs(run.cost, runhistory.objective_bounds)
                 y_agg = self.multi_objective_algorithm(y_)
                 y[row] = y_agg
             else:
@@ -698,7 +698,7 @@ class RunHistory2EPM4EIPS(AbstractRunHistory2EPM):
 
                 # Let's normalize y here
                 # We use the objective_bounds calculated by the runhistory
-                y_ = normalize_costs([run.cost], runhistory.objective_bounds)
+                y_ = normalize_costs(run.cost, runhistory.objective_bounds)
                 y_agg = self.multi_objective_algorithm(y_)
                 y[row, 0] = y_agg
             else:

--- a/smac/runhistory/runhistory2epm.py
+++ b/smac/runhistory/runhistory2epm.py
@@ -489,7 +489,6 @@ class RunHistory2EPM4Cost(AbstractRunHistory2EPM):
                 self.max_y = np.max(y, axis=0)
 
         y = self.transform_response_values(values=y)
-
         return X, y
 
     def transform_response_values(self, values: np.ndarray) -> np.ndarray:

--- a/smac/utils/multi_objective.py
+++ b/smac/utils/multi_objective.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import numpy as np
 
 

--- a/smac/utils/multi_objective.py
+++ b/smac/utils/multi_objective.py
@@ -12,16 +12,17 @@ def normalize_costs(values: list[float], bounds: list[tuple[float, float]] | Non
     values : list[float]
         List of costs to be normalized.
     bounds : list[tuple[float, float]] | None, optional
-        List of tuple of bounds. By default None. If no bounds are passed, only ones are returned.
+        List of tuple of bounds. By default None. If no bounds are passed, the values are returned
+        unnormalized.
 
     Returns
     -------
     normalized_costs : list[float]
-        Normalized costs based on the bounds. If no bounds are given, ones are returned.
-        Also, if min and max bounds are the same, the value is set to 1.
+        Normalized costs based on the bounds. If no bounds are given, the values are returned unnormalized.
+        Also, if min and max bounds are the same, the value of the corresponding objective is set to 1.
     """
     if bounds is None:
-        return np.ones(len(values)).tolist()
+        return values
 
     if len(values) != len(bounds):
         raise ValueError("Number of values and bounds must be equal.")

--- a/smac/utils/multi_objective.py
+++ b/smac/utils/multi_objective.py
@@ -1,7 +1,4 @@
 from __future__ import annotations
-
-from typing import List, Optional, Tuple, Union
-
 import numpy as np
 
 

--- a/smac/utils/multi_objective.py
+++ b/smac/utils/multi_objective.py
@@ -1,66 +1,38 @@
+from __future__ import annotations
+
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
 
-def normalize_costs(
-    values: Union[np.ndarray, List, List[List], List[np.ndarray]],
-    bounds: Optional[List[Tuple[float, float]]] = None,
-) -> np.ndarray:
-    """Normalizes the costs to be between 0 and 1 if no bounds are given. Otherwise, the costs are
-    normalized according to the bounds.
-
-    Example
-    -------
-
-    [0, 10, 5] -> [[0], [1], [0.5]]
-    [[0], [10], [5]] -> [[0], [1], [0.5]]
-    [[0, 0], [10, 50], [5, 200]] -> [[0, 0], [1, 0.25], [0.5, 1]]
+def normalize_costs(values: list[float], bounds: list[tuple[float, float]] | None = None) -> list[float]:
+    """
+    Normalizes a list of floats with corresponding bounds.
 
     Parameters
     ----------
-    values : Union[np.ndarray, List, List[List]]
-        Cost values which should be normalized.
-        If array/list is one-dimensional, it is expanded by one dimension.
-    bounds : Optional[List[Tuple[float, float]]], optional
-        Min and max bounds which should be applied to the values, by default None.
-        If bounds are None the min and max values from the data are used.
+    values : list[float]
+        List of costs to be normalized.
+    bounds : list[tuple[float, float]] | None, optional
+        List of tuple of bounds. By default None. If no bounds are passed, only ones are returned.
 
     Returns
     -------
-    np.ndarray
-        Normalized costs.
+    normalized_costs : list[float]
+        If no bounds were passed or
     """
-    _values: np.ndarray
-    if isinstance(values, list):
-        _values = np.array(values)
-    else:
-        _values = values
+    if bounds is None:
+        return np.ones(len(values)).tolist()
 
-    if len(_values.shape) == 1:
-        _values = np.expand_dims(_values, axis=-1)
+    costs = []
+    for v, b in zip(values, bounds):
+        p = v - b[0]
+        q = b[1] - b[0]
 
-    normalized_values = []
-    for col in range(_values.shape[1]):
-        data = _values[:, col].astype(float)
-
-        if bounds is not None:
-            assert len(bounds) == _values.shape[1]
-
-            min_value = bounds[col][0]
-            max_value = bounds[col][1]
+        if q < 1e-10:
+            cost = 1.0
         else:
-            min_value = np.min(data)
-            max_value = np.max(data)
+            cost = p / q
+        costs += [cost]
 
-        denominator = max_value - min_value
-
-        # Prevent divide by zero
-        if denominator < 1e-10:
-            # Return ones
-            normalized_values.append(np.ones_like(data))
-        else:
-            numerator = data - min_value
-            normalized_values.append(numerator / denominator)
-
-    return np.swapaxes(np.array(normalized_values), 0, 1)
+    return costs

--- a/smac/utils/multi_objective.py
+++ b/smac/utils/multi_objective.py
@@ -19,13 +19,18 @@ def normalize_costs(values: list[float], bounds: list[tuple[float, float]] | Non
     Returns
     -------
     normalized_costs : list[float]
-        If no bounds were passed or
+        Normalized costs based on the bounds. If no bounds are given, ones are returned.
+        Also, if min and max bounds are the same, the value is set to 1.
     """
     if bounds is None:
         return np.ones(len(values)).tolist()
 
+    if len(values) != len(bounds):
+        raise ValueError("Number of values and bounds must be equal.")
+
     costs = []
     for v, b in zip(values, bounds):
+        assert type(v) != list
         p = v - b[0]
         q = b[1] - b[0]
 

--- a/smac/utils/multi_objective.py
+++ b/smac/utils/multi_objective.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import numpy as np
-
 
 def normalize_costs(values: list[float], bounds: list[tuple[float, float]] | None = None) -> list[float]:
     """

--- a/tests/test_multi_objective/test_schaffer.py
+++ b/tests/test_multi_objective/test_schaffer.py
@@ -42,9 +42,13 @@ def get_optimum():
 
 def plot(all_x):
     plt.figure()
+
     for x in all_x:
         f1, f2 = schaffer(x)
-        plt.scatter(f1, f2, c="blue", alpha=0.1)
+        plt.scatter(f1, f2, c="blue", alpha=0.2, zorder=3000)
+
+    plt.vlines([1], 0, 4, linestyles="dashed", colors=["red"])
+    plt.hlines([1], 0, 4, linestyles="dashed", colors=["red"])
 
     plt.show()
 
@@ -73,7 +77,7 @@ class SchafferTest(unittest.TestCase):
         self.scenario = Scenario(
             {
                 "run_obj": "quality",  # we optimize quality (alternatively runtime)
-                "runcount-limit": 20,  # max. number of function evaluations
+                "runcount-limit": 25,  # max. number of function evaluations
                 "cs": self.cs,  # configuration space
                 "deterministic": True,
                 "multi_objectives": "metric1, metric2",
@@ -97,7 +101,7 @@ class SchafferTest(unittest.TestCase):
 
     def test_facades(self):
         results = []
-        for facade in [SMAC4AC]:  # ROAR, SMAC4BB, SMAC4HPO, SMAC4AC]:
+        for facade in [ROAR, SMAC4BB, SMAC4HPO, SMAC4AC]:
             for kwargs in [self.facade_kwargs, self.parego_facade_kwargs]:
                 smac = facade(**kwargs)
                 incumbent = smac.optimize()
@@ -109,7 +113,7 @@ class SchafferTest(unittest.TestCase):
                 opt = f1_opt + f2_opt
                 diff = abs(inc - opt)
 
-                assert diff < 0.1
+                assert diff < 0.5
                 results.append(smac)
 
         return results

--- a/tests/test_multi_objective/test_schaffer.py
+++ b/tests/test_multi_objective/test_schaffer.py
@@ -97,13 +97,14 @@ class SchafferTest(unittest.TestCase):
 
     def test_facades(self):
         results = []
-        for facade in [ROAR, SMAC4BB, SMAC4HPO, SMAC4AC]:
+        for facade in [SMAC4AC]:  # ROAR, SMAC4BB, SMAC4HPO, SMAC4AC]:
             for kwargs in [self.facade_kwargs, self.parego_facade_kwargs]:
                 smac = facade(**kwargs)
                 incumbent = smac.optimize()
 
                 f1_inc, f2_inc = schaffer(incumbent["x"])
                 f1_opt, f2_opt = get_optimum()
+
                 inc = f1_inc + f2_inc
                 opt = f1_opt + f2_opt
                 diff = abs(inc - opt)

--- a/tests/test_runhistory/test_runhistory_multi_objective.py
+++ b/tests/test_runhistory/test_runhistory_multi_objective.py
@@ -148,8 +148,6 @@ class RunhistoryMultiObjectiveTest(unittest.TestCase):
             status=StatusType.SUCCESS,
         )
 
-        print(rh._cost_per_config)
-
         # Only one value: Normalization goes to 1.0
         self.assertEqual(rh.get_cost(config1), 1.0)
 
@@ -550,8 +548,8 @@ class RunhistoryMultiObjectiveTest(unittest.TestCase):
         self.assertEqual(rh.objective_bounds[1], (10, 30))
 
         # Average cost returns us the cost of the latest budget
-        self.assertEqual(rh.average_cost(config1), 0.375)
-        self.assertEqual(rh.average_cost(config2), 0.75)
+        self.assertEqual(rh.get_cost(config1), 0.375)
+        self.assertEqual(rh.get_cost(config2), 0.75)
 
     def test_budgets(self):
         rh = RunHistory()
@@ -604,9 +602,13 @@ class RunhistoryMultiObjectiveTest(unittest.TestCase):
         self.assertEqual(rh.objective_bounds[1], (50, 150))
 
         # Average cost returns us the cost of the latest budget
-        self.assertEqual(rh.average_cost(config1), 0.75)
-        self.assertEqual(rh.average_cost(config2), 0.5)
+        self.assertEqual(rh.get_cost(config1), 0.75)
+        self.assertEqual(rh.average_cost(config1), [40.0, 100.0])
+
+        self.assertEqual(rh.get_cost(config2), 0.5)
+        self.assertEqual(rh.average_cost(config2), [0, 150])
 
 
 if __name__ == "__main__":
     t = RunhistoryMultiObjectiveTest()
+    t.test_instances()

--- a/tests/test_runhistory/test_runhistory_multi_objective.py
+++ b/tests/test_runhistory/test_runhistory_multi_objective.py
@@ -580,8 +580,8 @@ class RunhistoryMultiObjectiveTest(unittest.TestCase):
         # SMAC does not overwrite by default
         rh.add(
             config=config1,
-            cost=[50, 100],
-            time=10,
+            cost=[502342352, 23425234],
+            time=11,
             status=StatusType.SUCCESS,
             instance_id=1,
             seed=1,
@@ -611,4 +611,4 @@ class RunhistoryMultiObjectiveTest(unittest.TestCase):
 
 if __name__ == "__main__":
     t = RunhistoryMultiObjectiveTest()
-    t.test_instances()
+    t.test_budgets()

--- a/tests/test_utils/test_multi_objective.py
+++ b/tests/test_utils/test_multi_objective.py
@@ -16,10 +16,10 @@ class MultiObjectiveTest(unittest.TestCase):
         self.bounds_invalid = [(0, 0), (5, 5)]
 
     def test_normalize_costs(self):
-        # If no bounds are passed, we get ones back
+        # If no bounds are passed, we get the same result back
         v = [5, 2]
         nv = normalize_costs(v)
-        self.assertEqual(nv, [1.0, 1.0])
+        self.assertEqual(nv, [5, 2])
 
         # Normalize between 0..1 given data only
         v = [25, 50]

--- a/tests/test_utils/test_multi_objective.py
+++ b/tests/test_utils/test_multi_objective.py
@@ -1,5 +1,5 @@
-from multiprocessing.sharedctypes import Value
 import unittest
+from multiprocessing.sharedctypes import Value
 
 import numpy as np
 import pytest


### PR DESCRIPTION
Closes #852.

I slightly rearranged the runhistory so that it's more intuitive.

What else did I do?
`average_cost/min_cost/sum_cost` return a list of floats (instead of a float) now.
For example, for `average_cost`, each objective is averaged separately. Imagine you have two runs with [100, 200] and [0, 0] then you'd get [50, 100]. However, once you call `get_cost`, this (cached) [50, 100] is normalized based on all passed entries. That means that `get_cost` returns a float in the end. 

> Unfortunately, the intensifier and also some other methods work with `average_cost` or `sum_cost` (which should actually be a private method). So, I have to call `normalize_cost` in the intensifier again. Since `_cost_per_config`(cache for `average_cost`) is always storing the current state with all objective values, we are caching it correctly and normalize it once it's needed in the `get_cost` method.

Edit: I added an argument in `average_cost/min_cost/sum_cost` to return the normalized (single float) values. Makes the code easier and scalable.

One more thing which really is weird: In the runhistory2epm we iterate over the run dictionary (runkey, runvalue). But here we use the `run.cost` directly and hence we have to call `normalize_costs` in the case of MO again. I wonder why this is done this way? @mfeurer 