### PR TITLE
Fix 531 correctly create integers in initial design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Updated documentation based on new implementation.
 - Added benchmark to compare different versions.
 
+## Bugfixes
+- Correct handling of integer hyperparameters in the initial design.
+
 
 # 2.0.0a2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added benchmark to compare different versions.
 
 ## Bugfixes
-- Correct handling of integer hyperparameters in the initial design.
+- Correct handling of integer hyperparameters in the initial design (#531).
 
 
 # 2.0.0a2

--- a/smac/initial_design/abstract_initial_design.py
+++ b/smac/initial_design/abstract_initial_design.py
@@ -10,6 +10,7 @@ from ConfigSpace.configuration_space import Configuration, ConfigurationSpace
 from ConfigSpace.hyperparameters import (
     CategoricalHyperparameter,
     Constant,
+    IntegerHyperparameter,
     NumericalHyperparameter,
     OrdinalHyperparameter,
 )
@@ -162,7 +163,10 @@ class AbstractInitialDesign:
         """
         params = configspace.get_hyperparameters()
         for idx, param in enumerate(params):
-            if isinstance(param, NumericalHyperparameter):
+
+            if isinstance(param, IntegerHyperparameter):
+                design[:, idx] = param._inverse_transform(param._transform(design[:, idx]))
+            elif isinstance(param, NumericalHyperparameter):
                 continue
             elif isinstance(param, Constant):
                 design_ = np.zeros(np.array(design.shape) + np.array((0, 1)))
@@ -178,7 +182,7 @@ class AbstractInitialDesign:
                 v_design[v_design == 1] = 1 - 10**-10
                 design[:, idx] = np.array(v_design * len(param.sequence), dtype=int)
             else:
-                raise ValueError("Hyperparameter not supported in LHD.")
+                raise ValueError("Hyperparameter not supported when transforming a continuous design.")
 
         configs = []
         for vector in design:


### PR DESCRIPTION
This PR fixes a bug in which integer hyperparameters would not be created correctly in the initial design. This went unnoticed, except in the case where it was part of a condition and the function deactivate_inactive_hyperparameters was called.

This PR fixes this bug by mapping the random float that was sampled by, for example and LHD or Sobol sequence, to the float representation of an integer by calling _transform and _inverse_transform of the integer hyperparameter.