### PR TITLE
Local search fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 1.4.1
+
+## Bugfix or Minor Changes
+* Local search now stops when it reaches a local optimum or when a user-defined maximum number of steps is reached.
+
+
 # 1.4.0
 
 ## Features


### PR DESCRIPTION
- Search stops when maximum number of steps is reached.
- Search stops when it is stuck in a local optimum.
- Size of sampled neighbours to compute the acquisition value over is reset to `self.vectorization_min_obtain` instead of a fixed size of 2.
- Extended logging output message.