### PR TITLE
Random forest speed up v1.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 1.4.0
 
+## Bugfix or Minor Changes
+* Random forest with instances predicts the marginalized costs by using a C++ implementation in `pyrfr`, which is much faster. 
+
+# 1.4.0
+
 ## Features
 * [BOinG](https://arxiv.org/abs/2111.05834): A two-stage Bayesian optimization approach to allow the 
 optimizer to focus on the most promising regions.

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
         "ConfigSpace>=0.5.0",
         "joblib",
         "scikit-learn>=0.22.0",
-        "pyrfr>=0.8.3",
+        "pyrfr>=0.8.4",
         "dask",
         "distributed",
         "emcee>=3.0.0",

--- a/smac/epm/random_forest/rf_with_instances.py
+++ b/smac/epm/random_forest/rf_with_instances.py
@@ -298,7 +298,6 @@ class RandomForestWithInstances(BaseModel):
             dat_ = self.rf.predict_marginalized_over_instances_batch(X, self.instance_features, self.log_y)
             dat_ = np.array(dat_)
         except AttributeError:
-            self.logger.warning("Old Implementation")
             dat_ = np.zeros((X.shape[0], self.rf_opts.num_trees))  # marginalized predictions for each tree
             for i, x in enumerate(X):
 

--- a/smac/epm/random_forest/rf_with_instances.py
+++ b/smac/epm/random_forest/rf_with_instances.py
@@ -294,30 +294,9 @@ class RandomForestWithInstances(BaseModel):
             raise ValueError("Rows in X should have %d entries but have %d!" % (len(self.bounds), X.shape[1]))
 
         X = self._impute_inactive(X)
-        try:
-            dat_ = self.rf.predict_marginalized_over_instances_batch(X, self.instance_features, self.log_y)
-            dat_ = np.array(dat_)
-        except AttributeError:
-            dat_ = np.zeros((X.shape[0], self.rf_opts.num_trees))  # marginalized predictions for each tree
-            for i, x in enumerate(X):
 
-                # marginalize over instances
-                # 1. get all leaf values for each tree
-                preds_trees = [[] for i in range(self.rf_opts.num_trees)]  # type: List[List[float]]
-
-                for feat in self.instance_features:
-                    x_ = np.concatenate([x, feat])
-                    preds_per_tree = self.rf.all_leaf_values(x_)
-                    for tree_id, preds in enumerate(preds_per_tree):
-                        preds_trees[tree_id] += preds
-
-                # 2. average in each tree
-                if self.log_y:
-                    for tree_id in range(self.rf_opts.num_trees):
-                        dat_[i, tree_id] = np.log(np.exp(np.array(preds_trees[tree_id])).mean())
-                else:
-                    for tree_id in range(self.rf_opts.num_trees):
-                        dat_[i, tree_id] = np.array(preds_trees[tree_id]).mean()
+        dat_ = self.rf.predict_marginalized_over_instances_batch(X, self.instance_features, self.log_y)
+        dat_ = np.array(dat_)
 
         # 3. compute statistics across trees
         mean_ = dat_.mean(axis=1)


### PR DESCRIPTION
Random forest with instances predicts the marginalized costs by using a C++ implementation in `pyrfr`.

Please let me know if the `try .. except` construction should be kept. 