### PR TITLE
Increase days until stale issues are closed by stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,7 +2,7 @@
 daysUntilStale: 60
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 14
 
 # Issues with these labels will never be considered stale
 exemptLabels:


### PR DESCRIPTION
increases the days until stale issues are close by stalebot from 7 to 14 in order to increase reaction time after an issue has been marked as stale.