### PR TITLE
Transform integer feature names to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Bugfixes
 - Continue run when setting incumbent selection to highest budget when using Successive Halving (#907).
+- If integer features are used, they are automatically converted to strings.
 
 ## Workflows
 - Added workflow to update pre-commit versions (#874).

--- a/smac/scenario.py
+++ b/smac/scenario.py
@@ -112,14 +112,16 @@ class Scenario:
         if self.seed == -1:
             seed = random.randint(0, 999999)
             object.__setattr__(self, "seed", seed)
-            
+
         # Transform instances to string if they are not
         if self.instances is not None:
-            self.instances = [str(instance) for instance in self.instances]
-            
+            instances = [str(instance) for instance in self.instances]
+            object.__setattr__(self, "instances", instances)
+
         # Transform instance features to string if they are not
         if self.instance_features is not None:
-            self.instance_features = {str(instance): features for instance, features in self.instance_features.items()}
+            instance_features = {str(instance): features for instance, features in self.instance_features.items()}
+            object.__setattr__(self, "instance_features", instance_features)
 
         # Change directory wrt name and seed
         self._change_output_directory()

--- a/smac/scenario.py
+++ b/smac/scenario.py
@@ -112,6 +112,14 @@ class Scenario:
         if self.seed == -1:
             seed = random.randint(0, 999999)
             object.__setattr__(self, "seed", seed)
+            
+        # Transform instances to string if they are not
+        if self.instances is not None:
+            self.instances = [str(instance) for instance in self.instances]
+            
+        # Transform instance features to string if they are not
+        if self.instance_features is not None:
+            self.instance_features = {str(instance): features for instance, features in self.instance_features.items()}
 
         # Change directory wrt name and seed
         self._change_output_directory()


### PR DESCRIPTION
Solves #927

This problem should not happen in the first place because the scenario should accept strings as feature names only. However, this makes SMAC more robust and user-friendly.