### PR TITLE
Feature/add version to make publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements
 - Clarify origin of configurations (#908).
 - Random forest with instances predicts the marginalized costs by using a C++ implementation in `pyrfr`, which is much faster (#903).
+- Add version to makefile to install correct test release version
 
 ## Bugfixes
 - Continue run when setting incumbent selection to highest budget when using Successive Halving (#907).

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ publish: clean build
 	$(PYTHON) -m twine upload --repository testpypi ${DIST}/*
 	@echo
 	@echo "Test with the following:"
-	@echo "* Create a new virtual environment to install the uplaoded distribution into"
+	@echo "* Create a new virtual environment to install the uploaded distribution into"
 	@echo "* Run the following:"
 	@echo "--- pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ ${PACKAGE_NAME}==${VERSION}"
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 
 NAME := SMAC3
 PACKAGE_NAME := smac
-VERSION := 2.0.0b1
+VERSION := 2.0.0b2
 
 DIR := "${CURDIR}"
 SOURCE_DIR := ${PACKAGE_NAME}
@@ -136,7 +136,8 @@ clean-data:
 # Will echo the commands to actually publish to be run to publish to actual PyPi
 # This is done to prevent accidental publishing but provide the same conveniences
 publish: clean build
-	read -p "Did you update the version number? Did you add the old version to docs/conf.py?"
+	read -p "Did you update the version number in Makefile, smac/__init__.py, benchmark/src/wrappers/v20.py? \
+	Did you add the old version to docs/conf.py? Did you add changes to CHANGELOG.md?"
 	
 	$(PIP) install twine
 	$(PYTHON) -m twine upload --repository testpypi ${DIST}/*

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 # These have been configured to only really run short tasks. Longer form tasks
 # are usually completed in github actions.
 
+SHELL := /bin/bash
+
 NAME := SMAC3
 PACKAGE_NAME := smac
+VERSION := 2.0.0b1
 
 DIR := "${CURDIR}"
 SOURCE_DIR := ${PACKAGE_NAME}
@@ -141,7 +144,7 @@ publish: clean build
 	@echo "Test with the following:"
 	@echo "* Create a new virtual environment to install the uplaoded distribution into"
 	@echo "* Run the following:"
-	@echo "--- pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ ${NAME}"
+	@echo "--- pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ ${PACKAGE_NAME}==${VERSION}"
 	@echo
 	@echo "* Run this to make sure it can import correctly, plus whatever else you'd like to test:"
 	@echo "--- python -c 'import ${PACKAGE_NAME}'"

--- a/benchmark/src/wrappers/v20.py
+++ b/benchmark/src/wrappers/v20.py
@@ -6,7 +6,7 @@ from src.wrappers.wrapper import Wrapper
 
 
 class Version20(Wrapper):
-    supported_versions: list[str] = ["2.0.0b1"]
+    supported_versions: list[str] = ["2.0.0b2"]
 
     def __init__(self, task: Task, seed: int) -> None:
         super().__init__(task, seed)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@ options = {
     "version": version,
     "versions": {
         f"v{version} (unstable)": "#",
+        "v2.0.0b1": "https://automl.github.io/SMAC3/v2.0.0b1/",
         "v2.0.0a2": "https://automl.github.io/SMAC3/v2.0.0a2/",
         "v2.0.0a1": "https://automl.github.io/SMAC3/v2.0.0a1/",
         "v1.4.0": "https://automl.github.io/SMAC3/v1.4.0/",

--- a/smac/__init__.py
+++ b/smac/__init__.py
@@ -19,7 +19,7 @@ copyright = f"""
     Copyright {datetime.date.today().strftime('%Y')}, Marius Lindauer, Katharina Eggensperger,
     Matthias Feurer, André Biedenkapp, Difan Deng, Carolin Benjamins, Tim Ruhkopf, René Sass
     and Frank Hutter"""
-version = "2.0.0b1"
+version = "2.0.0b2"
 
 
 try:


### PR DESCRIPTION
- Update version numbers to 2.0.0b2
- Use bash in makefile (else `read` command does not work)
- Fix make publish to use version set in makefile (else the command to install the test-release does not work for pre-versions)
- Fix make publish to use package-name