### PR TITLE
feat: Option preventing SMAC setting up logging

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
             pre-commit run --all-files
 
-      - uses: peter-evans/create-pull-request@v3
+      - uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update/pre-commit-hooks

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
 
       - uses: browniebroke/pre-commit-autoupdate-action@main
                  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Clarify origin of configurations (#908).
 - Random forest with instances predicts the marginalized costs by using a C++ implementation in `pyrfr`, which is much faster (#903).
 - Add version to makefile to install correct test release version
+- Add option to disable logging by setting `logging_level=False`. (#947)
 
 ## Bugfixes
 - Continue run when setting incumbent selection to highest budget when using Successive Halving (#907).

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from typing import Any, Callable
-from typing_extensions import Literal
 
 from pathlib import Path
 
 import joblib
 from ConfigSpace import Configuration
+from typing_extensions import Literal
 
 import smac
 from smac.acquisition.function.abstract_acquisition_function import (

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from typing import Any, Callable
-from typing_extensions import Literal
 
 from pathlib import Path
 

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from typing import Any, Callable
+from typing_extensions import Literal
 
 from pathlib import Path
 
@@ -81,9 +82,11 @@ class AbstractFacade:
         Based on the runhistory, the surrogate model is trained. However, the data first needs to be encoded, which
         is done by the runhistory encoder. For example, inactive hyperparameters need to be encoded or cost values
         can be log transformed.
-    logging_level: int | Path | None
+    logging_level: int | Path | Literal[False] | None
         The level of logging (the lowest level 0 indicates the debug level). If a path is passed, a yaml file is
         expected with the logging configuration. If nothing is passed, the default logging.yml from SMAC is used.
+        If False is passed, SMAC will not do any customization of the logging setup and the responsibility is left
+        to the user.
     callbacks: list[Callback], defaults to []
         Callbacks, which are incorporated into the optimization loop.
     overwrite: bool, defaults to False
@@ -106,11 +109,12 @@ class AbstractFacade:
         multi_objective_algorithm: AbstractMultiObjectiveAlgorithm | None = None,
         runhistory_encoder: AbstractRunHistoryEncoder | None = None,
         config_selector: ConfigSelector | None = None,
-        logging_level: int | Path | None = None,
+        logging_level: int | Path | Literal[False] | None = None,
         callbacks: list[Callback] = [],
         overwrite: bool = False,
     ):
-        setup_logging(logging_level)
+        if logging_level is not False:
+            setup_logging(logging_level)
 
         if model is None:
             model = self.get_model(scenario)

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from typing import Any, Callable
+from typing_extensions import Literal
 
 from pathlib import Path
 


### PR DESCRIPTION
Allow a user to disable SMAC from setting up its own custom logging by passing `logging_level=False`. This change is backwards compatible and does not change any existing behaviours.

Please see issue #948