### PR TITLE
fix(runhistory): set id of the sampled config

### DIFF
--- a/smac/main/smbo.py
+++ b/smac/main/smbo.py
@@ -278,9 +278,6 @@ class SMBO:
                 # Sample next trial from the intensification
                 trial_info = self.ask()
 
-                # Set the ID of the sampled config object
-                trial_info.config.config_id = self.runhistory.config_ids[trial_info.config]
-
                 # We submit the trial to the runner
                 # In multi-worker mode, SMAC waits till a new worker is available here
                 self._runner.submit_trial(trial_info=trial_info)

--- a/smac/main/smbo.py
+++ b/smac/main/smbo.py
@@ -278,8 +278,8 @@ class SMBO:
                 # Sample next trial from the intensification
                 trial_info = self.ask()
 
-		# Set the ID on the sampled config 
-		run_info.config.config_id = self.runhistory.config_ids[run_info.config]
+                # Set the ID of the sampled config object
+                trial_info.config.config_id = self.runhistory.config_ids[trial_info.config]
 
                 # We submit the trial to the runner
                 # In multi-worker mode, SMAC waits till a new worker is available here

--- a/smac/main/smbo.py
+++ b/smac/main/smbo.py
@@ -278,6 +278,9 @@ class SMBO:
                 # Sample next trial from the intensification
                 trial_info = self.ask()
 
+		# Set the ID on the sampled config 
+		run_info.config.config_id = self.runhistory.config_ids[run_info.config]
+
                 # We submit the trial to the runner
                 # In multi-worker mode, SMAC waits till a new worker is available here
                 self._runner.submit_trial(trial_info=trial_info)

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -221,6 +221,9 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
 
             config_id = self._n_id
 
+        # Set the id attribute of the config object, so that users can access it
+        config.config_id = config_id
+
         if status != StatusType.RUNNING:
             if self._n_objectives == -1:
                 self._n_objectives = n_objectives


### PR DESCRIPTION
### Context
[Auto-sklearn](https://github.com/automl/auto-sklearn) is heavily dependent on SMAC. I'm currently trying to bump up our dependency to the latest version of SMAC.

### Problem Description
Auto-sklearn used to rely on the fact that SMAC set the [config_id attribute](https://github.com/automl/ConfigSpace/blob/1d93d98e4b0b73a0d3a6799f05f11f4c1a4bb5f9/ConfigSpace/configuration_space.pyx#L1651) of a sampled Configuration object before the `submit_trial()` method was called on the function runner object in the [main optimization loop](https://github.com/automl/SMAC3/blob/731854e8effe72d76cb07636458e783143f32dc5/smac/main/smbo.py#L272-L319).

This functionality got removed since 2.0, and now the config_ids of the sampled Configurations are all None.

### Question
Is there any good reason why you got rid of it?

### Solution
If there isn't, then this brief PR tries to resolve it in a simple way. The config_id gets set to the ID of the Configuration object already present in the run_history.
