### PR TITLE
Compute the actual differences between the isb keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Bugfixes
 - Continue run when setting incumbent selection to highest budget when using Successive Halving (#907).
 - If integer features are used, they are automatically converted to strings.
+- The ISB-pair differences over the incumbent's configurations are computed correctly now (#956).
 
 ## Workflows
 - Added workflow to update pre-commit versions (#874).

--- a/smac/intensifier/abstract_intensifier.py
+++ b/smac/intensifier/abstract_intensifier.py
@@ -419,7 +419,10 @@ class AbstractIntensifier:
             if len(incumbent_isb_keys) <= 1:
                 return []
 
-            incumbent_isb_keys = list(set.difference(*map(set, incumbent_isb_keys)))  # type: ignore
+            # Compute the actual differences
+            intersection_isb_keys = set.intersection(*map(set, incumbent_isb_keys))  # type: ignore
+            union_isb_keys = set.union(*map(set, incumbent_isb_keys))  # type: ignore
+            incumbent_isb_keys = list(union_isb_keys - intersection_isb_keys)  # type: ignore
 
             if len(incumbent_isb_keys) == 0:
                 return []


### PR DESCRIPTION
Fixes #956 , by first computing the union and intersection of the incumbents and then taking the difference. 