### PR TITLE
ci: set dependabot to development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,12 @@ updates:
   # https://docs.github.com/en/enterprise-server@3.4/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "development"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    assignees:
+      - "eddiebergman"
+    reviewers:
+      - "eddiebergman"
+    commit-message:
+      include: "chore: "


### PR DESCRIPTION
Just makes dependabot target development with it's changes. This should prevent divergences between `main` and `development`. I set myself as the reviewer and assignee of these. Please let me know if anyone else want's to be notified and specifically assigned to these.