### PR TITLE
fix(logging): Prevent automatic logging setup at init

### DIFF
--- a/smac/__init__.py
+++ b/smac/__init__.py
@@ -23,10 +23,6 @@ version = "2.0.0"
 
 
 try:
-    from smac.utils.logging import setup_logging
-
-    setup_logging(0)
-
     from smac.callback import Callback
     from smac.facade import (
         AlgorithmConfigurationFacade,

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -113,8 +113,7 @@ class AbstractFacade:
         callbacks: list[Callback] = [],
         overwrite: bool = False,
     ):
-        if logging_level is not False:
-            setup_logging(logging_level)
+        setup_logging(logging_level)
 
         if model is None:
             model = self.get_model(scenario)

--- a/smac/utils/logging.py
+++ b/smac/utils/logging.py
@@ -5,6 +5,7 @@ import logging.config
 from pathlib import Path
 
 import yaml
+from typing_extensions import Literal
 
 import smac
 
@@ -12,14 +13,20 @@ __copyright__ = "Copyright 2022, automl.org"
 __license__ = "3-clause BSD"
 
 
-def setup_logging(level: int | Path | None = None) -> None:
+def setup_logging(
+    level: int | Path | Literal[False] | None = False,
+) -> None:
     """Sets up the logging configuration for all modules.
 
     Parameters
     ----------
-    level : int | Path | None, defaults to None
+    level : int | Path | Literal[False] | None, defaults to None
         An integer representing the logging level. An custom logging configuration can be used when passing a path.
+        If False, no logging setup is performed.
     """
+    if level is False:
+        return
+
     if isinstance(level, Path):
         log_filename = level
     else:


### PR DESCRIPTION
Prevent SMAC doing automatic logging setup at import, in general it's very bad practice for libraries to automatically perform computation at import time as simply `import smac` performs unknown changes to a users environemnt.

* Closes #948 