### PR TITLE
Fix validate method of SMAC to use the seed given in the scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.1
+
+## Bugfixes
+- Fix validation in smbo to use the seed in the scenario.
+
 # 2.0.0
 
 ## Improvements

--- a/smac/intensifier/abstract_intensifier.py
+++ b/smac/intensifier/abstract_intensifier.py
@@ -271,13 +271,12 @@ class AbstractIntensifier:
 
             i = 0
             while True:
-                # We have two conditions to stop the loop:
-                # A) We found enough configs
-                # B) We used enough seeds
-                A = self._max_config_calls is not None and len(instance_seed_keys) >= self._max_config_calls
-                B = self._n_seeds is not None and i >= self._n_seeds
+                found_enough_configs = (
+                    self._max_config_calls is not None and len(instance_seed_keys) >= self._max_config_calls
+                )
+                used_enough_seeds = self._n_seeds is not None and i >= self._n_seeds
 
-                if A or B:
+                if found_enough_configs or used_enough_seeds:
                     break
 
                 if validate:

--- a/smac/main/smbo.py
+++ b/smac/main/smbo.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import numpy as np
 from ConfigSpace import Configuration
+from numpy import ndarray
 
 from smac.acquisition.function.abstract_acquisition_function import (
     AbstractAcquisitionFunction,
@@ -512,28 +513,27 @@ class SMBO:
         config: Configuration,
         *,
         seed: int | None = None,
-    ) -> float | list[float]:
+    ) -> float | ndarray[float]:
         """Validates a configuration on other seeds than the ones used in the optimization process and on the highest
-        budget (if budget type is real-valued).
+        budget (if budget type is real-valued). Does not exceed the maximum number of config calls or seeds as defined
+        in the scenario.
 
         Parameters
         ----------
         config : Configuration
             Configuration to validate
-        instances : list[str] | None, defaults to None
-            Which instances to validate. If None, all instances specified in the scenario are used.
             In case that the budget type is real-valued budget, this argument is ignored.
         seed : int | None, defaults to None
             If None, the seed from the scenario is used.
 
         Returns
         -------
-        cost : float | list[float]
+        cost : float | ndarray[float]
             The averaged cost of the configuration. In case of multi-fidelity, the cost of each objective is
             averaged.
         """
         if seed is None:
-            seed = 0
+            seed = self._scenario.seed
 
         costs = []
         for trial in self._intensifier.get_trials_of_interest(config, validate=True, seed=seed):


### PR DESCRIPTION
Previously, if no seed was given, the seed 0 was used.