### PR TITLE
Remove leftover CLI entry points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,9 +76,6 @@ setuptools.setup(
     extras_require=extras_require,
     test_suite="pytest",
     platforms=["Linux"],
-    entry_points={
-        "console_scripts": ["smac = smac.smac_cli:cmd_line_call"],
-    },
     classifiers=[
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
It seems like the CLI was removed at some point but the entry points are still there.

Ref: https://github.com/search?q=repo%3Aautoml%2FSMAC3%20cmd_line_call&type=code