### PR TITLE
Raise an error for invalid scatter data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.2
+
+## Improvements
+- Add an error when we get an empty dict data_to_scatter so that we can avoid an internal error caused in Dask precautiously
+
 # 2.0.1
 
 ## Improvements

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -310,6 +310,9 @@ class AbstractFacade:
             Best found configuration.
         """
         incumbents = None
+        if isinstance(data_to_scatter, dict) and len(data_to_scatter) == 0:
+            raise ValueError("data_to_scatter must be None or dict with some elements, but got an empty dict.")
+
         try:
             incumbents = self._optimizer.optimize(data_to_scatter=data_to_scatter)
         finally:


### PR DESCRIPTION
When `data_to_scatter={}`, it causes an error in Dask, so I fixed this error.