### PR TITLE
Raise error if resource limitation and parallelization is requested

### DIFF
--- a/docs/advanced_usage/9_parallelism.rst
+++ b/docs/advanced_usage/9_parallelism.rst
@@ -21,6 +21,39 @@ SMAC supports multiple workers natively via Dask. Just specify ``n_workers`` in 
     When using multiple workers, SMAC is not reproducible anymore.
 
 
+..warning::
+
+    You cannot use resource limitation (pynisher, via the `scenario` arguments `trail_walltime_limit` and `trial_memory_limit`).
+    This is because pynisher works by running your function inside of a subprocess.
+    Once in the subprocess, the resources will be limited for that process before running your function. 
+    This does not work together with pickling - which is required by dask to schedule jobs on the cluster, even on a local one.
+
+
+.. warning ::
+
+    Start/run SMAC inside ``if __name__ == "__main__"`` in your script otherwise Dask is not able to correctly
+    spawn jobs and probably this runtime error will be raised:
+
+    .. code-block ::
+
+        RuntimeError: 
+            An attempt has been made to start a new process before the
+            current process has finished its bootstrapping phase.
+
+            This probably means that you are not using fork to start your
+            child processes and you have forgotten to use the proper idiom
+            in the main module:
+
+                if __name__ == '__main__':
+                    freeze_support()
+                    ...
+
+            The "freeze_support()" line can be omitted if the program
+            is not going to be frozen to produce an executable.
+
+
+
+
 Running on a Cluster
 --------------------
 You can also pass a custom dask client, e.g. to run on a slurm cluster.

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -455,6 +455,18 @@ class AbstractFacade:
         # Make sure the same acquisition function is used
         assert self._acquisition_function == self._acquisition_maximizer._acquisition_function
 
+        if isinstance(self._runner, DaskParallelRunner) and (
+            self.scenario.trial_walltime_limit is not None or self.scenario.trial_memory_limit is not None
+        ):
+            # This is probably due to pickling dask jobs
+            raise ValueError(
+                "Parallelization via Dask cannot be used in combination with limiting "
+                "the resources "
+                "of the target function via `scenario.trial_walltime_limit` or "
+                "`scenario.trial_memory_limit`. Set those to `None` if you want "
+                "parallelization. "
+            )
+
     def _get_signature_arguments(self) -> list[str]:
         """Returns signature arguments, which are required by the intensifier."""
         arguments = []


### PR DESCRIPTION
- This is not a fix sadly
- Related to #1020 
- Dask cannot pickle jobs using processes themselves (this is what I suspect why it does not work)
- Throw error if both resource limitation and parallization is requested