### PR TITLE
Fix(config_selector): Budget checking

### DIFF
--- a/smac/main/config_selector.py
+++ b/smac/main/config_selector.py
@@ -266,10 +266,7 @@ class ConfigSelector:
         assert self._runhistory_encoder is not None
 
         # If we use a float value as a budget, we want to train the model only on the highest budget
-        unique_budgets: set[float] = {
-            run_key.budget for run_key in self._runhistory
-            if run_key.budget is not None
-        }
+        unique_budgets: set[float] = {run_key.budget for run_key in self._runhistory if run_key.budget is not None}
 
         available_budgets: list[float] | list[None]
         if len(unique_budgets) > 0:

--- a/smac/main/config_selector.py
+++ b/smac/main/config_selector.py
@@ -266,14 +266,17 @@ class ConfigSelector:
         assert self._runhistory_encoder is not None
 
         # If we use a float value as a budget, we want to train the model only on the highest budget
-        available_budgets = []
-        for run_key in self._runhistory:
-            budget = run_key.budget
-            if budget not in available_budgets:
-                available_budgets.append(run_key.budget)
+        unique_budgets: set[float] = {
+            run_key.budget for run_key in self._runhistory
+            if run_key.budget is not None
+        }
 
-        # Sort available budgets from highest to lowest budget
-        available_budgets = sorted(list(set(available_budgets)), reverse=True)  # type: ignore
+        available_budgets: list[float] | list[None]
+        if len(unique_budgets) > 0:
+            # Sort available budgets from highest to lowest budget
+            available_budgets = sorted(unique_budgets, reverse=True)
+        else:
+            available_budgets = [None]
 
         # Get #points per budget and if there are enough samples, then build a model
         for b in available_budgets:


### PR DESCRIPTION
I had an error here `l:276`, `NoneType` is not comparable with `float`

https://github.com/automl/SMAC3/blob/e64e1918eeb88e93f9f201ece343624fb2943e9d/smac/main/config_selector.py#L269-L276

The previous version was expecting `available_budget` to be `list[float] | list[None]` but it was possible to get `list[float | None]` as `TrialKey.budget: float | None`. When this happen, it would cause the later `sorted` to fail

Essentially for some reason I had `None` and a `float` value in `available_budgets` (most likely due to warmstarting). I'm not sure where the root issue is but we can circumvent it with this.

The previous version should have caught this potential error with mypy but didn't.
The reason this problem didn't show up was due to the `# type: ignore` which would have correctly warned that you could not sort on `available_budgets: list[float | None]`. Might be advisable to check where else the `# type: ignore` as they are often a potential source of an issue.

