### PR TITLE
Fix callback order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bugfixes
 - Fix bug in the incumbent selection in the case that multi-fidelity is combined with multi-objective (#1019).
+- Fix callback order (#1040).
 
 # 2.0.1
 

--- a/smac/main/smbo.py
+++ b/smac/main/smbo.py
@@ -461,18 +461,22 @@ class SMBO:
                     logger.info("Cost threshold was reached. Abort is requested.")
                     self._stop = True
 
-    def register_callback(self, callback: Callback, index: int = -1) -> None:
+    def register_callback(self, callback: Callback, index: int | None = None) -> None:
         """
         Registers a callback to be called before, in between, and after the Bayesian optimization loop.
 
+        Callback is appended to the list by default.
 
         Parameters
         ----------
         callback : Callback
             The callback to be registered.
-        index : int
-            The index at which the callback should be registered.
+        index : int, optional
+            The index at which the callback should be registered. The default is None.
+            If it is None, append the callback to the list.
         """
+        if index is None:
+            index = len(self._callbacks)
         self._callbacks.insert(index, callback)
 
     def _initialize_state(self) -> None:


### PR DESCRIPTION
Did not preserve callback order by adding to the index -1. Now appends to the callback list if index is None.

See this example:
Before:
```python
In [1]: cbs = ["U", "W", "S"]
    ...: l = []
    ...: print(cbs)
    ...: for cb in cbs:
    ...:     l.insert(-1, cb)
    ...:     print(cb, l)
    ...: 
['U', 'W', 'S']
U ['U']
W ['W', 'U']
S ['W', 'S', 'U']
```

Now:
```python
In [2]: cbs = ["U", "W", "S"]
   ...: l = []
   ...: print(cbs)
   ...: for cb in cbs:
   ...:     l.insert(len(l), cb)
   ...:     print(cb, l)
   ...: 
['U', 'W', 'S']
U ['U']
W ['U', 'W']
S ['U', 'W', 'S']
```