### PR TITLE
fix(configspace): shows all keys in print

### DIFF
--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -174,8 +174,8 @@ def print_config_changes(
 
     lines = []
     for k in sorted(all_keys):
-        inc_k = incumbent.get(k)
-        cha_k = challenger.get(k)
+        inc_k = incumbent.get(k, "-inactive-")
+        cha_k = challenger.get(k, "-inactive-")
         lines.append(f"--- {k}: {inc_k} -> {cha_k}" + " (unchanged)" if inc_k == cha_k else "")
 
     msg = "\n".join(lines)

--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -169,7 +169,9 @@ def print_config_changes(
     if incumbent is None or challenger is None:
         return
 
-    all_keys = set(incumbent.keys().union(challenger.keys()))
+    inc_keys = set(incumbent.keys())
+    challenger_keys = set(challenger.keys())
+    all_keys = inc_keys.union(challenger_keys)
 
     params = sorted([(param, incumbent.get(param), challenger.get(param)) for param in all_keys])
     for key, inc_val, challenger_val in params:

--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -176,9 +176,7 @@ def print_config_changes(
     for k in sorted(all_keys):
         inc_k = incumbent.get(k)
         cha_k = challenger.get(k)
-        lines.append(
-            f"--- {k}: {inc_k} -> {cha_k}" + " (unchanged)" if inc_k == cha_k else ""
-        )
+        lines.append(f"--- {k}: {inc_k} -> {cha_k}" + " (unchanged)" if inc_k == cha_k else "")
 
     msg = "\n".join(lines)
     logger.debug(msg)

--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -169,12 +169,16 @@ def print_config_changes(
     if incumbent is None or challenger is None:
         return
 
-    params = sorted([(param, incumbent[param], challenger[param]) for param in challenger.keys()])
-    for param in params:
-        if param[1] != param[2]:
-            logger.info("--- %s: %r -> %r" % param)
-        else:
-            logger.debug("--- %s Remains unchanged: %r", param[0], param[1])
+    all_keys = set(incumbent.keys().union(challenger.keys()))
+
+    params = sorted(
+        [(param, incumbent.get(param), challenger.get(param)) for param in all_keys]
+    )
+    for (key, inc_val, challenger_val) in params:
+        msg = f"--- {key}: {inc_val} -> {challenger_val}"
+        if inc_val == challenger_val:
+            msg += " (unchanged)"
+        logger.debug(msg)
 
 
 # def check_subspace_points(

--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -171,10 +171,8 @@ def print_config_changes(
 
     all_keys = set(incumbent.keys().union(challenger.keys()))
 
-    params = sorted(
-        [(param, incumbent.get(param), challenger.get(param)) for param in all_keys]
-    )
-    for (key, inc_val, challenger_val) in params:
+    params = sorted([(param, incumbent.get(param), challenger.get(param)) for param in all_keys])
+    for key, inc_val, challenger_val in params:
         msg = f"--- {key}: {inc_val} -> {challenger_val}"
         if inc_val == challenger_val:
             msg += " (unchanged)"

--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -170,15 +170,18 @@ def print_config_changes(
         return
 
     inc_keys = set(incumbent.keys())
-    challenger_keys = set(challenger.keys())
-    all_keys = inc_keys.union(challenger_keys)
+    all_keys = inc_keys.union(challenger.keys())
 
-    params = sorted([(param, incumbent.get(param), challenger.get(param)) for param in all_keys])
-    for key, inc_val, challenger_val in params:
-        msg = f"--- {key}: {inc_val} -> {challenger_val}"
-        if inc_val == challenger_val:
-            msg += " (unchanged)"
-        logger.debug(msg)
+    lines = []
+    for k in sorted(all_keys):
+        inc_k = incumbent.get(k)
+        cha_k = challenger.get(k)
+        lines.append(
+            f"--- {k}: {inc_k} -> {cha_k}" + " (unchanged)" if inc_k == cha_k else ""
+        )
+
+    msg = "\n".join(lines)
+    logger.debug(msg)
 
 
 # def check_subspace_points(


### PR DESCRIPTION
Previously this would only show keys present in the challenger and not in the incumbent. Also by using string `[key]` indexing instead of `.get(key)`, there could be a `KeyError` if the `key` was not present in the `Configuration`.

* Closes #1041 