### PR TITLE
Fix: target runner with partial func

### DIFF
--- a/smac/runner/target_function_runner.py
+++ b/smac/runner/target_function_runner.py
@@ -96,8 +96,10 @@ class TargetFunctionRunner(AbstractSerialRunner):
         f = self._target_function
         if isinstance(f, partial):
             f = f.func
-
-        meta.update({"code": str(f.__code__.co_code)})
+            meta.update({"code": str(f.__code__.co_code)})
+            meta.update({"code-partial-args": repr(f)})
+        else:
+            meta.update({"code": str(self._target_function.__code__.co_code)})
 
         return meta
 

--- a/smac/runner/target_function_runner.py
+++ b/smac/runner/target_function_runner.py
@@ -7,6 +7,7 @@ import inspect
 import math
 import time
 import traceback
+from functools import partial
 
 import numpy as np
 from ConfigSpace import Configuration
@@ -88,7 +89,15 @@ class TargetFunctionRunner(AbstractSerialRunner):
     @property
     def meta(self) -> dict[str, Any]:  # noqa: D102
         meta = super().meta
-        meta.update({"code": str(self._target_function.__code__.co_code)})
+
+        # Partial's don't have a __code__ attribute but are a convenient
+        # way a user might want to pass a function to SMAC, specifying
+        # keyword arguments.
+        f = self._target_function
+        if isinstance(f, partial):
+            f = f.func
+
+        meta.update({"code": str(f.__code__.co_code)})
 
         return meta
 


### PR DESCRIPTION
When encoding the smac instance to disk, part of that process is to use the `__code__` attribute of a function to essentially *hash* it to disk, allowing SMAC to detect if the function has changed between invocations.

However when using a `partial`, these do not have a `__code__` attribute, moreover, they can have extra variables attached to them, as per the reason you would use a `partial`.

This PR fixes this and makes sure that even the arguments used in the `partial` are considered when using `overwrite=False`, and SMAC attempts to restart from it's last state on disk.