### PR TITLE
fixed bug for conditional params

### DIFF
--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -169,7 +169,7 @@ def print_config_changes(
     if incumbent is None or challenger is None:
         return
 
-    params = sorted([(param, incumbent[param], challenger[param]) for param in challenger.keys()])
+    params = sorted([(param, incumbent.get(param), challenger.get(param)) for param in challenger.keys()])
     for param in params:
         if param[1] != param[2]:
             logger.info("--- %s: %r -> %r" % param)


### PR DESCRIPTION
hello,

I found a bug in the print statement which prevents the whole loop from running (I'm using `MultiFidelityFacade`), when there are conditional hyperparameters in the challenger, but not in the incumbent, then the line I have changed would raise a key error - using `get` method instead simply gives None for nonexistent keys, which to me seems like an OK solution for this kind of print statement

cheers

