### PR TITLE
Fix: Deprecation warnings configspace `0.7.1`

### DIFF
--- a/benchmark/src/models/svm.py
+++ b/benchmark/src/models/svm.py
@@ -43,7 +43,7 @@ class SVMModel(Model):
         """Creates a SVM based on a configuration and evaluates it on the
         iris-dataset using cross-validation."""
         assert self.dataset is not None
-        config_dict = config.get_dictionary()
+        config_dict = dict(config)
         if "gamma" in config:
             config_dict["gamma"] = config_dict["gamma_value"] if config_dict["gamma"] == "value" else "auto"
             config_dict.pop("gamma_value", None)

--- a/examples/1_basics/2_svm_cv.py
+++ b/examples/1_basics/2_svm_cv.py
@@ -54,7 +54,7 @@ class SVM:
     def train(self, config: Configuration, seed: int = 0) -> float:
         """Creates a SVM based on a configuration and evaluates it on the
         iris-dataset using cross-validation."""
-        config_dict = config.get_dictionary()
+        config_dict = dict(config)
         if "gamma" in config:
             config_dict["gamma"] = config_dict["gamma_value"] if config_dict["gamma"] == "value" else "auto"
             config_dict.pop("gamma_value", None)

--- a/examples/1_basics/4_callback.py
+++ b/examples/1_basics/4_callback.py
@@ -54,7 +54,7 @@ class CustomCallback(Callback):
 
             incumbent = smbo.intensifier.get_incumbent()
             assert incumbent is not None
-            print(f"Current incumbent: {incumbent.get_dictionary()}")
+            print(f"Current incumbent: {dict(incumbent)}")
             print(f"Current incumbent value: {smbo.runhistory.get_cost(incumbent)}")
             print("")
 

--- a/smac/acquisition/function/prior_acqusition_function.py
+++ b/smac/acquisition/function/prior_acqusition_function.py
@@ -100,7 +100,7 @@ class PriorAcquisitionFunction(AbstractAcquisitionFunction):
     @model.setter
     def model(self, model: AbstractModel) -> None:
         self._model = model
-        self._hyperparameters = model._configspace.get_hyperparameters_dict()
+        self._hyperparameters = dict(model._configspace)
 
         if isinstance(model, AbstractRandomForest):
             if not self._discretize:

--- a/smac/facade/blackbox_facade.py
+++ b/smac/facade/blackbox_facade.py
@@ -111,11 +111,11 @@ class BlackBoxFacade(AbstractFacade):
         cont_dims = np.where(np.array(types) == 0)[0]
         cat_dims = np.where(np.array(types) != 0)[0]
 
-        if (len(cont_dims) + len(cat_dims)) != len(scenario.configspace.get_hyperparameters()):
+        if (len(cont_dims) + len(cat_dims)) != len(scenario.configspace):
             raise ValueError(
                 "The inferred number of continuous and categorical hyperparameters "
                 "must equal the total number of hyperparameters. Got "
-                f"{(len(cont_dims) + len(cat_dims))} != {len(scenario.configspace.get_hyperparameters())}."
+                f"{(len(cont_dims) + len(cat_dims))} != {len(scenario.configspace)}."
             )
 
         # Constant Kernel

--- a/smac/initial_design/abstract_initial_design.py
+++ b/smac/initial_design/abstract_initial_design.py
@@ -77,7 +77,7 @@ class AbstractInitialDesign:
 
         self._additional_configs = additional_configs
 
-        n_params = len(self._configspace.get_hyperparameters())
+        n_params = len(self._configspace)
         if n_configs is not None:
             logger.info("Using `n_configs` and ignoring `n_configs_per_hyperparameter`.")
             self._n_configs = n_configs
@@ -114,7 +114,7 @@ class AbstractInitialDesign:
             "name": self.__class__.__name__,
             "n_configs": self._n_configs,
             "n_configs_per_hyperparameter": self._n_configs_per_hyperparameter,
-            "additional_configs": [c.get_dictionary() for c in self._additional_configs],
+            "additional_configs": [dict(c) for c in self._additional_configs],
             "seed": self._seed,
         }
 
@@ -174,8 +174,7 @@ class AbstractInitialDesign:
         configs : list[Configuration]
             Continuous transformed configs.
         """
-        params = configspace.get_hyperparameters()
-        for idx, param in enumerate(params):
+        for idx, param in enumerate(configspace.values()):
 
             if isinstance(param, IntegerHyperparameter):
                 design[:, idx] = param._inverse_transform(param._transform(design[:, idx]))

--- a/smac/initial_design/factorial_design.py
+++ b/smac/initial_design/factorial_design.py
@@ -22,7 +22,7 @@ class FactorialInitialDesign(AbstractInitialDesign):
     """Factorial initial design to select corner and middle configurations."""
 
     def _select_configurations(self) -> list[Configuration]:
-        params = self._configspace.get_hyperparameters()
+        params = list(self._configspace.values())
 
         values = []
         mid = []

--- a/smac/initial_design/latin_hypercube_design.py
+++ b/smac/initial_design/latin_hypercube_design.py
@@ -16,7 +16,7 @@ class LatinHypercubeInitialDesign(AbstractInitialDesign):
     """
 
     def _select_configurations(self) -> list[Configuration]:
-        params = self._configspace.get_hyperparameters()
+        params = list(self._configspace.values())
 
         constants = 0
         for p in params:

--- a/smac/initial_design/sobol_design.py
+++ b/smac/initial_design/sobol_design.py
@@ -22,14 +22,14 @@ class SobolInitialDesign(AbstractInitialDesign):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        if len(self._configspace.get_hyperparameters()) > 21201:
+        if len(self._configspace) > 21201:
             raise ValueError(
                 "The default initial design Sobol sequence can only handle up to 21201 dimensions. "
                 "Please use a different initial design, such as the Latin Hypercube design."
             )
 
     def _select_configurations(self) -> list[Configuration]:
-        params = self._configspace.get_hyperparameters()
+        params = list(self._configspace.values())
 
         constants = 0
         for p in params:

--- a/smac/intensifier/successive_halving.py
+++ b/smac/intensifier/successive_halving.py
@@ -210,7 +210,7 @@ class SuccessiveHalving(AbstractIntensifier):
             for seed, configs in self._tracker[key]:
                 # We have to make key serializable
                 new_key = f"{key[0]},{key[1]}"
-                tracker[new_key].append((seed, [config.get_dictionary() for config in configs]))
+                tracker[new_key].append((seed, [dict(config) for config in configs]))
 
         return {"tracker": tracker}
 

--- a/smac/main/old/boing.py
+++ b/smac/main/old/boing.py
@@ -99,7 +99,7 @@
 
 #         self.max_configs_local_fracs = max_configs_local_fracs
 #         self.min_configs_local = (
-#             min_configs_local if min_configs_local is not None else 5 * len(self.configspace.get_hyperparameters())
+#             min_configs_local if min_configs_local is not None else 5 * len(self.configspace)
 #         )
 
 #         types, bounds = get_types(self.configspace, instance_features=None)
@@ -117,7 +117,7 @@
 #         self.optimal_value = np.inf
 #         self.optimal_config = None
 
-#         self.ss_threshold = 0.1 ** len(self.configspace.get_hyperparameters())
+#         self.ss_threshold = 0.1 ** len(self.configspace)
 #         if self.do_switching:
 #             # If we want to switch between BOinG and TurBO
 #             self.run_TuRBO = False
@@ -375,7 +375,7 @@
 #                 return chain([cfg_challenger_global_first], challengers_global)
 
 #             activate_dims = []
-#             hps = self.configspace.get_hyperparameters()
+#             hps = list(self.configspace.values())
 #             for idx_hp in np.where(challanger_activate_hps > 0)[0]:
 #                 if isinstance(hps[idx_hp], NumericalHyperparameter):
 #                     activate_dims.append(idx_hp)
@@ -393,7 +393,7 @@
 #             n_min_configs_inner = self.min_configs_local // len(hps) * len(activate_dims)
 #         else:
 #             n_min_configs_inner = self.min_configs_local
-#             activate_dims = np.arange(len(self.configspace.get_hyperparameters()))
+#             activate_dims = np.arange(len(self.configspace))
 
 #         bounds_ss_cont, bounds_ss_cat, ss_data_indices = subspace_extraction(
 #             X=X,

--- a/smac/model/abstract_model.py
+++ b/smac/model/abstract_model.py
@@ -68,7 +68,7 @@ class AbstractModel:
                         raise RuntimeError("Instances must have the same number of features.")
 
         self._n_features = n_features
-        self._n_hps = len(self._configspace.get_hyperparameters())
+        self._n_hps = len(self._configspace)
 
         self._pca = PCA(n_components=self._pca_components)
         self._scaler = MinMaxScaler()

--- a/smac/model/random_forest/abstract_random_forest.py
+++ b/smac/model/random_forest/abstract_random_forest.py
@@ -22,12 +22,16 @@ class AbstractRandomForest(AbstractModel):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
+        # NOTE (eddiebergman): Would be better to use the hyperparaemters name.
+        #   More robust to identifing if the space were to change. Could be detected
+        #   and dealt with accordingly. No way to now this by iteration order.
         self._conditional: dict[int, bool] = dict()
         self._impute_values: dict[int, float] = dict()
 
     def _impute_inactive(self, X: np.ndarray) -> np.ndarray:
         X = X.copy()
-        for idx, hp in enumerate(self._configspace.get_hyperparameters()):
+
+        for idx, hp in enumerate(self._configspace.values()):
             if idx not in self._conditional:
                 parents = self._configspace.get_parents_of(hp.name)
                 if len(parents) == 0:

--- a/smac/runhistory/encoder/abstract_encoder.py
+++ b/smac/runhistory/encoder/abstract_encoder.py
@@ -68,7 +68,7 @@ class AbstractRunHistoryEncoder:
         self._instances = scenario.instances
         self._instance_features = scenario.instance_features
         self._n_features = scenario.count_instance_features()
-        self._n_params = len(scenario.configspace.get_hyperparameters())
+        self._n_params = len(scenario.configspace)
 
         if self._instances is not None and self._n_features == 0:
             logger.warning(

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -259,7 +259,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
 
         # Construct keys and values for the data dictionary
         for key, value in (
-            ("config", config.get_dictionary()),
+            ("config", dict(config)),
             ("config_id", config_id),
             ("instance", instance),
             ("seed", seed),
@@ -780,7 +780,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
         config_origins = {}
         for id_, config in self._ids_config.items():
             if id_ in config_ids_to_serialize:
-                configs[id_] = config.get_dictionary()
+                configs[id_] = dict(config)
 
             config_origins[id_] = config.origin
 

--- a/smac/runner/target_function_script_runner.py
+++ b/smac/runner/target_function_script_runner.py
@@ -130,7 +130,7 @@ class TargetFunctionScriptRunner(AbstractSerialRunner):
         status = StatusType.SUCCESS
 
         # Add config arguments to the kwargs
-        for k, v in config.get_dictionary().items():
+        for k, v in config.items():
             if k in kwargs:
                 raise RuntimeError(f"The key {k} is already in use. Please use a different one.")
             kwargs[k] = v

--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -52,11 +52,22 @@ def get_types(
     -------
     The bounds for the instance features are *not* added in this function.
     """
+    # NOTE (eddiebergman): It would be better return a dict[str, tuple[int, float, float]]
+    #   where the str is the hyperparameters name and the dictionary is in sorted order by
+    #   the hyperparameters name.
+    #
+    # We are currently relying on the order of the hyperparameters of the space always
+    #   being the same. Any future extension which might incorporate changing/shrinking spaces
+    #   or even just changes to ConfigSpace can break this subtly.
+    #
+    # To counter-act this, I can implement this in if wanted but needs someone who's aware
+    #   of it's use in the kernels to verify that this will be okay.
+
     # Extract types vector for rf from config space and the bounds
-    types = [0] * len(configspace.get_hyperparameters())
+    types = [0] * len(configspace)
     bounds = [(np.nan, np.nan)] * len(types)
 
-    for i, param in enumerate(configspace.get_hyperparameters()):
+    for i, param in enumerate(configspace.values()):
         parents = configspace.get_parents_of(param.name)
         if len(parents) == 0:
             can_be_inactive = False

--- a/smac/utils/subspaces/__init__.py
+++ b/smac/utils/subspaces/__init__.py
@@ -93,7 +93,7 @@
 #         else:
 #             self.rng = np.random.RandomState(rng.randint(0, 2**20))
 
-#         n_hypers = len(config_space.get_hyperparameters())
+#         n_hypers = len(config_space)
 #         model_types = copy.deepcopy(hps_types)
 #         model_bounds = copy.deepcopy(bounds)
 
@@ -136,7 +136,7 @@
 #             self.new_config = True
 #             # we normalize the non-CategoricalHyperparameter by x = (x-lb)*scale
 
-#             hps = config_space.get_hyperparameters()
+#             hps = list(config_space.values())
 
 #             # deal with categorical hyperaprameters
 #             for i, cat_idx in enumerate(activate_dims_cat):
@@ -214,7 +214,7 @@
 #             idx_cont = 0
 #             idx_cat = 0
 
-#             hps = config_space.get_hyperparameters()
+#             hps = list(config_space.values())
 
 #             for idx in self.activate_dims:
 #                 param = hps[idx]
@@ -423,7 +423,7 @@
 #             forbidden_hp_name = forbidden.hyperparameter.name
 #             if forbidden_hp_name not in cs_local:
 #                 return None
-#             hp_ss = cs_local.get_hyperparameter(forbidden_hp_name)
+#             hp_ss = cs_local[forbidden_hp_name]
 
 #             def is_value_in_hp(value: Any, hp: Hyperparameter) -> bool:
 #                 """Check if the value is in the range of the hp."""
@@ -629,7 +629,7 @@
 #         self._index = 0
 #         self.config_origin = config_origin
 #         # In case cs_in and cs_out have different dimensions
-#         self.expand_dims = len(cs_global.get_hyperparameters()) != len(cs_local.get_hyperparameters())
+#         self.expand_dims = len(cs_global) != len(cs_local)
 #         self.incumbent_array = incumbent_array
 
 #         if self.expand_dims and self.incumbent_array is None:
@@ -643,11 +643,10 @@
 #             raise StopIteration
 #         challenger = self.challengers[self._index][1]
 #         self._index += 1
-#         value = challenger.get_dictionary()
+#         value = dict(challenger)
 #         if self.expand_dims:
-#             incumbent_array = Configuration(
-#                 configuration_space=self.cs_global, vector=self.incumbent_array
-#             ).get_dictionary()
+#             _config = Configuration(configuration_space=self.cs_global, vector=self.incumbent_array)
+#             incumbent_array = dict(_config)
 #             # we replace the cooresponding value in incumbent array with the value suggested by our optimizer
 #             for k in value.keys():
 #                 incumbent_array[k] = value[k]

--- a/smac/utils/subspaces/boing_subspace.py
+++ b/smac/utils/subspaces/boing_subspace.py
@@ -108,7 +108,7 @@
 #                         6: 10,
 #                         7: 8,
 #                         8: 6,
-#                     }.get(len(self.cs_local.get_hyperparameters()), 5)
+#                     }.get(len(self.cs_local), 5)
 
 #                     subspace_acq_func_opt_kwargs.update(
 #                         {"n_steps_plateau_walk": 5, "local_search_iterations": local_search_iterations}

--- a/smac/utils/subspaces/turbo_subspace.py
+++ b/smac/utils/subspaces/turbo_subspace.py
@@ -92,7 +92,7 @@
 #             activate_dims=activate_dims,
 #             incumbent_array=incumbent_array,
 #         )
-#         hps = config_space.get_hyperparameters()
+#         hps = list(config_space.values())
 #         for hp in hps:
 #             if not isinstance(hp, NumericalHyperparameter):
 #                 raise ValueError("Current TurBO Optimizer only supports Numerical Hyperparameters")

--- a/tests/test_acquisition/test_maximizers.py
+++ b/tests/test_acquisition/test_maximizers.py
@@ -206,8 +206,8 @@ def model(configspace: ConfigurationSpace):
     model = RandomForest(configspace)
 
     np.random.seed(0)
-    X = np.random.rand(100, len(configspace.get_hyperparameters()))
-    y = 1 - (np.sum(X, axis=1) / len(configspace.get_hyperparameters()))
+    X = np.random.rand(100, len(configspace))
+    y = 1 - (np.sum(X, axis=1) / len(configspace))
     model.train(X, y)
 
     return model

--- a/tests/test_initial_design/test_initial_design.py
+++ b/tests/test_initial_design/test_initial_design.py
@@ -45,7 +45,7 @@ def test_config_numbers(make_scenario, configspace_small):
     scenario = make_scenario(configspace_small)
     configs = configspace_small.sample_configuration(n_configs)
 
-    n_hps = len(configspace_small.get_hyperparameters())
+    n_hps = len(configspace_small)
 
     dc = AbstractInitialDesign(
         scenario=scenario,

--- a/tests/test_model/_test_lgpga.py
+++ b/tests/test_model/_test_lgpga.py
@@ -78,7 +78,7 @@ class TestLGPGA(TestGPGPyTorch):
         self.gp_model, self.cs = generate_lgpga(self.kernel, n_dimensions=num_dims, rs=rs)
 
     def test_init(self):
-        np.testing.assert_equal(self.gp_model.cont_dims, np.arange(len(self.cs.get_hyperparameters())))
+        np.testing.assert_equal(self.gp_model.cont_dims, np.arange(len(self.cs)))
         np.testing.assert_equal(self.gp_model.cat_dims, np.array([]))
 
     def test_update_attribute(self):


### PR DESCRIPTION
A while ago ConfigSpace (`~ 0.5.0`), the `Configuration` and `ConfigurationSpace` classes were made to behave like [`Mapping`](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes), i.e. they act like a dictionary with `["lookup"]`, `len()`, `values()`, `keys()`, `items()` and `.get(key, default)` plus whatever other non-mutating dictionary semantics there are.

In `0.7.1`, I changed two core files of ConfigSpace from `.pyx` to `.py` to play better with editors. As part of this I also deprecated the following methods which are basically Java style "getters" for what is already provided by following the Mapping interface.

### Notes
While updating the various locations of these methods, I found a few places that rely on traversal-order which are no order invariant. It might be wise to convert these to use the hyperparamter names and use dicts, relying on sort order of the names when an array is needed.

### Deprecations
```python
# configuration_space.py
class ConfigurationSpace(Mapping[str, HyperParameter]):


    def get_hyperparameter(self, name: str) -> Hyperparameter:
        warnings.warn(
            "Prefer `space[name]` over `get_hyperparameter`",
            DeprecationWarning,
            stacklevel=2,
        )
        return self[name]

    def get_hyperparameters(self) -> list[Hyperparameter]:
        warnings.warn(
            "Prefer using `list(space.values())` over `get_hyperparameters`",
            DeprecationWarning,
            stacklevel=2,
        )
        return list(self._hyperparameters.values())

    def get_hyperparameters_dict(self) -> dict[str, Hyperparameter]:
        warnings.warn(
            "Prefer using `dict(space)` over `get_hyperparameters_dict`",
            DeprecationWarning,
            stacklevel=2,
        )
        return self._hyperparameters.copy()

    def get_hyperparameter_names(self) -> list[str]:
        warnings.warn(
            "Prefer using `list(space.keys())` over `get_hyperparameter_names`",
            DeprecationWarning,
            stacklevel=2,
        )
        return list(self._hyperparameters.keys())


class Configuration(Mapping[str, Any]):

    def get_dictionary(self) -> dict[str, Any]:
        warnings.warn(
            "`Configuration` act's like a dictionary."
            " Please use `dict(config)` instead of `get_dictionary`"
            " if you explicitly need a `dict`",
            DeprecationWarning,
            stacklevel=2,
        )
        return dict(self)
