### PR TITLE
fix dask_scheduler_file path

### DIFF
--- a/smac/runner/dask_runner.py
+++ b/smac/runner/dask_runner.py
@@ -91,7 +91,7 @@ class DaskParallelRunner(AbstractRunner):
             )
 
             if self._scenario.output_directory is not None:
-                self._scheduler_file = self._scenario.output_directory / ".dask_scheduler_file"
+                self._scheduler_file = Path(self._scenario.output_directory, ".dask_scheduler_file")
                 self._client.write_scheduler_file(scheduler_file=str(self._scheduler_file))
         else:
             # We just use their set up


### PR DESCRIPTION
The `self._scenario.output_directory` and `".dask_scheduler_file"` is in the `str` type and don't support the `/` operator, which will raise TypeError: unsupported operand type(s) for /: 'str' and 'str'.