### PR TITLE
Handle configspace as dictionary in mlp example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Bugfixes
 - Fix bug in the incumbent selection in the case that multi-fidelity is combined with multi-objective (#1019).
 - Fix callback order (#1040).
+- Handle configspace as dictionary in mlp example.
 
 # 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix bug in the incumbent selection in the case that multi-fidelity is combined with multi-objective (#1019).
 - Fix callback order (#1040).
 - Handle configspace as dictionary in mlp example.
+- Adapt sgd loss to newest scikit-learn version.
 
 # 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## Bugfixes
 - Fix bug in the incumbent selection in the case that multi-fidelity is combined with multi-objective (#1019).
 - Fix callback order (#1040).
-- Handle configspace as dictionary in mlp example.
+- Handle configspace as dictionary in mlp and parego example.
 - Adapt sgd loss to newest scikit-learn version.
 
 # 2.0.1

--- a/examples/2_multi_fidelity/1_mlp_epochs.py
+++ b/examples/2_multi_fidelity/1_mlp_epochs.py
@@ -84,18 +84,18 @@ class MLP:
         # For deactivated parameters (by virtue of the conditions),
         # the configuration stores None-values.
         # This is not accepted by the MLP, so we replace them with placeholder values.
-        lr = config["learning_rate"] if config["learning_rate"] else "constant"
-        lr_init = config["learning_rate_init"] if config["learning_rate_init"] else 0.001
-        batch_size = config["batch_size"] if config["batch_size"] else 200
+        lr = config.get("learning_rate") if config.get("learning_rate") else "constant"
+        lr_init = config.get("learning_rate_init") if config.get("learning_rate_init") else 0.001
+        batch_size = config.get("batch_size") if config.get("batch_size") else 200
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
 
             classifier = MLPClassifier(
-                hidden_layer_sizes=[config["n_neurons"]] * config["n_layer"],
-                solver=config["solver"],
+                hidden_layer_sizes=[config.get("n_neurons")] * config.get("n_layer"),
+                solver=config.get("solver"),
                 batch_size=batch_size,
-                activation=config["activation"],
+                activation=config.get("activation"),
                 learning_rate=lr,
                 learning_rate_init=lr_init,
                 max_iter=int(np.ceil(budget)),

--- a/examples/2_multi_fidelity/1_mlp_epochs.py
+++ b/examples/2_multi_fidelity/1_mlp_epochs.py
@@ -84,18 +84,18 @@ class MLP:
         # For deactivated parameters (by virtue of the conditions),
         # the configuration stores None-values.
         # This is not accepted by the MLP, so we replace them with placeholder values.
-        lr = config.get("learning_rate") if config.get("learning_rate") else "constant"
-        lr_init = config.get("learning_rate_init") if config.get("learning_rate_init") else 0.001
-        batch_size = config.get("batch_size") if config.get("batch_size") else 200
+        lr = config.get("learning_rate", "constant")
+        lr_init = config.get("learning_rate_init", 0.001)
+        batch_size = config.get("batch_size", 200)
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
 
             classifier = MLPClassifier(
-                hidden_layer_sizes=[config.get("n_neurons")] * config.get("n_layer"),
-                solver=config.get("solver"),
+                hidden_layer_sizes=[config["n_neurons"]] * config["n_layer"],
+                solver=config["solver"],
                 batch_size=batch_size,
-                activation=config.get("activation"),
+                activation=config["activation"],
                 learning_rate=lr,
                 learning_rate_init=lr_init,
                 max_iter=int(np.ceil(budget)),

--- a/examples/2_multi_fidelity/2_sgd_datasets.py
+++ b/examples/2_multi_fidelity/2_sgd_datasets.py
@@ -89,7 +89,7 @@ class SGD:
 
             # SGD classifier using given configuration
             clf = SGDClassifier(
-                loss="log",
+                loss="log_loss",
                 penalty="elasticnet",
                 alpha=config["alpha"],
                 l1_ratio=config["l1_ratio"],

--- a/examples/3_multi_objective/2_parego.py
+++ b/examples/3_multi_objective/2_parego.py
@@ -66,9 +66,9 @@ class MLP:
         return cs
 
     def train(self, config: Configuration, seed: int = 0, budget: int = 10) -> dict[str, float]:
-        lr = config["learning_rate"] if config["learning_rate"] else "constant"
-        lr_init = config["learning_rate_init"] if config["learning_rate_init"] else 0.001
-        batch_size = config["batch_size"] if config["batch_size"] else 200
+        lr = config.get("learning_rate") if config.get("learning_rate") else "constant"
+        lr_init = config.get("learning_rate_init") if config.get("learning_rate_init") else 0.001
+        batch_size = config.get("batch_size") if config.get("batch_size") else 200
 
         start_time = time.time()
 
@@ -76,10 +76,10 @@ class MLP:
             warnings.filterwarnings("ignore")
 
             classifier = MLPClassifier(
-                hidden_layer_sizes=[config["n_neurons"]] * config["n_layer"],
-                solver=config["solver"],
+                hidden_layer_sizes=[config.get("n_neurons")] * config.get("n_layer"),
+                solver=config.get("solver"),
                 batch_size=batch_size,
-                activation=config["activation"],
+                activation=config.get("activation"),
                 learning_rate=lr,
                 learning_rate_init=lr_init,
                 max_iter=int(np.ceil(budget)),

--- a/examples/3_multi_objective/2_parego.py
+++ b/examples/3_multi_objective/2_parego.py
@@ -66,9 +66,9 @@ class MLP:
         return cs
 
     def train(self, config: Configuration, seed: int = 0, budget: int = 10) -> dict[str, float]:
-        lr = config.get("learning_rate") if config.get("learning_rate") else "constant"
-        lr_init = config.get("learning_rate_init") if config.get("learning_rate_init") else 0.001
-        batch_size = config.get("batch_size") if config.get("batch_size") else 200
+        lr = config.get("learning_rate", "constant")
+        lr_init = config.get("learning_rate_init", 0.001)
+        batch_size = config.get("batch_size", 200)
 
         start_time = time.time()
 
@@ -76,10 +76,10 @@ class MLP:
             warnings.filterwarnings("ignore")
 
             classifier = MLPClassifier(
-                hidden_layer_sizes=[config.get("n_neurons")] * config.get("n_layer"),
-                solver=config.get("solver"),
+                hidden_layer_sizes=[config["n_neurons"]] * config["n_layer"],
+                solver=config["solver"],
                 batch_size=batch_size,
-                activation=config.get("activation"),
+                activation=config["activation"],
                 learning_rate=lr,
                 learning_rate_init=lr_init,
                 max_iter=int(np.ceil(budget)),

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -71,7 +71,7 @@ class SGD:
 
             # SGD classifier using given configuration
             clf = SGDClassifier(
-                loss="log",
+                loss="log_loss",
                 penalty="elasticnet",
                 alpha=config["alpha"],
                 l1_ratio=config["l1_ratio"],


### PR DESCRIPTION
- Handle configspace as dictionary in mlp and parego example
- Adapt sgd loss to newest scikit-learn version ("log" not accepted anymore")