### PR TITLE
allow rf to impute OrdinalHyperparameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.0.3
 
 ## Bugfixes
-- Add OrdinalHyperparameter for random forest imputer.
+- Add OrdinalHyperparameter for random forest imputer (#1065).
 
 # 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.3
+
+## Bugfixes
+- Add OrdinalHyperparameter for random forest imputer.
+
 # 2.0.2
 
 ## Improvements

--- a/smac/model/random_forest/abstract_random_forest.py
+++ b/smac/model/random_forest/abstract_random_forest.py
@@ -6,6 +6,7 @@ import numpy as np
 from ConfigSpace import (
     CategoricalHyperparameter,
     Constant,
+    OrdinalHyperparameter,
     UniformFloatHyperparameter,
     UniformIntegerHyperparameter,
 )
@@ -36,12 +37,14 @@ class AbstractRandomForest(AbstractModel):
                     self._conditional[idx] = True
                     if isinstance(hp, CategoricalHyperparameter):
                         self._impute_values[idx] = len(hp.choices)
+                    elif isinstance(hp, OrdinalHyperparameter):
+                        self._impute_values[idx] = len(hp.sequence)
                     elif isinstance(hp, (UniformFloatHyperparameter, UniformIntegerHyperparameter)):
                         self._impute_values[idx] = -1
                     elif isinstance(hp, Constant):
                         self._impute_values[idx] = 1
                     else:
-                        raise ValueError
+                        raise ValueError(f"Unsupported hyperparameter type: {type(hp)}")
 
             if self._conditional[idx] is True:
                 nonfinite_mask = ~np.isfinite(X[:, idx])

--- a/tests/test_model/test_rf.py
+++ b/tests/test_model/test_rf.py
@@ -257,18 +257,25 @@ def test_with_ordinal():
 
 def test_impute_inactive_hyperparameters():
     cs = ConfigurationSpace(seed=0)
-    a = cs.add_hyperparameter(CategoricalHyperparameter("a", [0, 1]))
+    a = cs.add_hyperparameter(CategoricalHyperparameter("a", [0, 1, 2]))
     b = cs.add_hyperparameter(CategoricalHyperparameter("b", [0, 1]))
     c = cs.add_hyperparameter(UniformFloatHyperparameter("c", 0, 1))
+    d = cs.add_hyperparameter(OrdinalHyperparameter("d", [0, 1, 2]))
     cs.add_condition(EqualsCondition(b, a, 1))
     cs.add_condition(EqualsCondition(c, a, 0))
+    cs.add_condition(EqualsCondition(d, a, 2))
 
     configs = cs.sample_configuration(size=100)
     config_array = convert_configurations_to_array(configs)
     for line in config_array:
         if line[0] == 0:
             assert np.isnan(line[1])
+            assert np.isnan(line[3])
         elif line[0] == 1:
+            assert np.isnan(line[2])
+            assert np.isnan(line[3])
+        elif line[0] == 2:
+            assert np.isnan(line[1])
             assert np.isnan(line[2])
 
     model = RandomForest(configspace=cs)
@@ -276,5 +283,10 @@ def test_impute_inactive_hyperparameters():
     for line in config_array:
         if line[0] == 0:
             assert line[1] == 2
+            assert line[3] == 3
         elif line[0] == 1:
+            assert line[2] == -1
+            assert line[3] == 3
+        elif line[0] == 2:
+            assert line[1] == 2
             assert line[2] == -1


### PR DESCRIPTION
`OrdinalHyperparameter`is missing for random forest imputer (as this type of hp is allowed by SMAC's configuration space constructor: https://github.com/automl/SMAC3/blob/main/smac/utils/configspace.py#L72)
An additional message is raised to make the Value error more concrete. 