### PR TITLE
Propagate the Scenario random seed to get_random_design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.0.3
+
+## Bugfixes
+
+- Propagate the Scenario random seed to `get_random_design` (#1066)
+
 # 2.0.2
 
 ## Improvements

--- a/smac/facade/hyperparameter_optimization_facade.py
+++ b/smac/facade/hyperparameter_optimization_facade.py
@@ -178,7 +178,7 @@ class HyperparameterOptimizationFacade(AbstractFacade):
         probability : float, defaults to 0.2
             Probability that a configuration will be drawn at random.
         """
-        return ProbabilityRandomDesign(probability=probability)
+        return ProbabilityRandomDesign(probability=probability, seed=scenario.seed)
 
     @staticmethod
     def get_multi_objective_algorithm(  # type: ignore


### PR DESCRIPTION
The random seed specified in the Scenario, is propagated to most other places, but not the default ProbabilityRandomDesign child component.

This is part of an effort to track down some sources of non-determinism.