### PR TITLE
Don't use mutable default argument.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,16 @@ repos:
         name: flake8 smac
         files: smac
         exclude: "scripts|tests"
+
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args:
+          [
+            "-rn", # Only display messages
+            "-sn", # Don't display the score
+          ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.0.3
+
+## Bugfixes
+
+- Don't use mutable default argument (#1067).
+
 # 2.0.2
 
 ## Improvements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ add-ignore = [ # http://www.pydocstyle.org/en/stable/error_codes.html
     "D415", # First line should end with a period, question mark, or exclamation point
 ]
 
+[tool.pylint."messages control"]
+# FIXME: This is to do a staged introduction of pylint checks for just a single class of problems initially (#1067).
+disable = ["all"]
+enable = ["dangerous-default-value"]
+
 [tool.mypy]
 python_version = "3.9"
 show_error_codes = true

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ extras_require = {
         "pydocstyle",
         "flake8",
         "pre-commit",
+        "pylint",
     ],
 }
 

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -117,11 +117,14 @@ class AbstractFacade:
         runhistory_encoder: AbstractRunHistoryEncoder | None = None,
         config_selector: ConfigSelector | None = None,
         logging_level: int | Path | Literal[False] | None = None,
-        callbacks: list[Callback] = [],
+        callbacks: list[Callback] = None,
         overwrite: bool = False,
         dask_client: Client | None = None,
     ):
         setup_logging(logging_level)
+
+        if callbacks is None:
+            callbacks = []
 
         if model is None:
             model = self.get_model(scenario)

--- a/smac/facade/algorithm_configuration_facade.py
+++ b/smac/facade/algorithm_configuration_facade.py
@@ -125,7 +125,7 @@ class AlgorithmConfigurationFacade(AbstractFacade):
     def get_initial_design(  # type: ignore
         scenario: Scenario,
         *,
-        additional_configs: list[Configuration] = [],
+        additional_configs: list[Configuration] = None,
     ) -> DefaultInitialDesign:
         """Returns an initial design, which returns the default configuration.
 
@@ -134,6 +134,8 @@ class AlgorithmConfigurationFacade(AbstractFacade):
         additional_configs: list[Configuration], defaults to []
             Adds additional configurations to the initial design.
         """
+        if additional_configs is None:
+            additional_configs = []
         return DefaultInitialDesign(
             scenario=scenario,
             additional_configs=additional_configs,

--- a/smac/facade/blackbox_facade.py
+++ b/smac/facade/blackbox_facade.py
@@ -240,7 +240,7 @@ class BlackBoxFacade(AbstractFacade):
         n_configs: int | None = None,
         n_configs_per_hyperparamter: int = 8,
         max_ratio: float = 0.25,
-        additional_configs: list[Configuration] = [],
+        additional_configs: list[Configuration] = None,
     ) -> SobolInitialDesign:
         """Returns a Sobol design instance.
 
@@ -259,6 +259,8 @@ class BlackBoxFacade(AbstractFacade):
         additional_configs: list[Configuration], defaults to []
             Adds additional configurations to the initial design.
         """
+        if additional_configs is None:
+            additional_configs = []
         return SobolInitialDesign(
             scenario=scenario,
             n_configs=n_configs,

--- a/smac/facade/hyperparameter_optimization_facade.py
+++ b/smac/facade/hyperparameter_optimization_facade.py
@@ -138,7 +138,7 @@ class HyperparameterOptimizationFacade(AbstractFacade):
         n_configs: int | None = None,
         n_configs_per_hyperparamter: int = 10,
         max_ratio: float = 0.25,
-        additional_configs: list[Configuration] = [],
+        additional_configs: list[Configuration] | None = None,
     ) -> SobolInitialDesign:
         """Returns a Sobol design instance.
 

--- a/smac/facade/multi_fidelity_facade.py
+++ b/smac/facade/multi_fidelity_facade.py
@@ -67,7 +67,7 @@ class MultiFidelityFacade(HyperparameterOptimizationFacade):
         n_configs: int | None = None,
         n_configs_per_hyperparamter: int = 10,
         max_ratio: float = 0.25,
-        additional_configs: list[Configuration] = [],
+        additional_configs: list[Configuration] = None,
     ) -> RandomInitialDesign:
         """Returns a random initial design.
 
@@ -86,6 +86,8 @@ class MultiFidelityFacade(HyperparameterOptimizationFacade):
         additional_configs: list[Configuration], defaults to []
             Adds additional configurations to the initial design.
         """
+        if additional_configs is None:
+            additional_configs = []
         return RandomInitialDesign(
             scenario=scenario,
             n_configs=n_configs,

--- a/smac/facade/random_facade.py
+++ b/smac/facade/random_facade.py
@@ -92,7 +92,7 @@ class RandomFacade(AbstractFacade):
     def get_initial_design(
         scenario: Scenario,
         *,
-        additional_configs: list[Configuration] = [],
+        additional_configs: list[Configuration] = None,
     ) -> DefaultInitialDesign:
         """Returns an initial design, which returns the default configuration.
 
@@ -101,6 +101,8 @@ class RandomFacade(AbstractFacade):
         additional_configs: list[Configuration], defaults to []
             Adds additional configurations to the initial design.
         """
+        if additional_configs is None:
+            additional_configs = []
         return DefaultInitialDesign(
             scenario=scenario,
             additional_configs=additional_configs,

--- a/smac/main/config_selector.py
+++ b/smac/main/config_selector.py
@@ -91,7 +91,7 @@ class ConfigSelector:
         acquisition_maximizer: AbstractAcquisitionMaximizer,
         acquisition_function: AbstractAcquisitionFunction,
         random_design: AbstractRandomDesign,
-        callbacks: list[Callback] = [],
+        callbacks: list[Callback] = None,
     ) -> None:
         self._runhistory = runhistory
         self._runhistory_encoder = runhistory_encoder
@@ -99,7 +99,7 @@ class ConfigSelector:
         self._acquisition_maximizer = acquisition_maximizer
         self._acquisition_function = acquisition_function
         self._random_design = random_design
-        self._callbacks = callbacks
+        self._callbacks = callbacks if callbacks is not None else []
 
         self._initial_design_configs = initial_design.select_configurations()
         if len(self._initial_design_configs) == 0:

--- a/smac/runhistory/encoder/abstract_encoder.py
+++ b/smac/runhistory/encoder/abstract_encoder.py
@@ -42,17 +42,17 @@ class AbstractRunHistoryEncoder:
     def __init__(
         self,
         scenario: Scenario,
-        considered_states: list[StatusType] = [
-            StatusType.SUCCESS,
-            StatusType.CRASHED,
-            StatusType.MEMORYOUT,
-        ],
+        considered_states: list[StatusType] = None,
         lower_budget_states: list[StatusType] = None,
         scale_percentage: int = 5,
         seed: int | None = None,
     ) -> None:
         if considered_states is None:
-            raise TypeError("No success states are given.")
+            considered_states = [
+                StatusType.SUCCESS,
+                StatusType.CRASHED,
+                StatusType.MEMORYOUT,
+            ]
 
         if seed is None:
             seed = scenario.seed

--- a/smac/runhistory/encoder/abstract_encoder.py
+++ b/smac/runhistory/encoder/abstract_encoder.py
@@ -47,7 +47,7 @@ class AbstractRunHistoryEncoder:
             StatusType.CRASHED,
             StatusType.MEMORYOUT,
         ],
-        lower_budget_states: list[StatusType] = [],
+        lower_budget_states: list[StatusType] = None,
         scale_percentage: int = 5,
         seed: int | None = None,
     ) -> None:
@@ -62,7 +62,7 @@ class AbstractRunHistoryEncoder:
         self._scale_percentage = scale_percentage
         self._n_objectives = scenario.count_objectives()
         self._algorithm_walltime_limit = scenario.trial_walltime_limit
-        self._lower_budget_states = lower_budget_states
+        self._lower_budget_states = lower_budget_states if lower_budget_states is not None else []
         self._considered_states = considered_states
 
         self._instances = scenario.instances

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -178,7 +178,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
         budget: float | None = None,
         starttime: float = 0.0,
         endtime: float = 0.0,
-        additional_info: dict[str, Any] = {},
+        additional_info: dict[str, Any] = None,
         force_update: bool = False,
     ) -> None:
         """Adds a new trial to the RunHistory.
@@ -205,6 +205,8 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
             raise TypeError("Configuration must not be None.")
         elif not isinstance(config, Configuration):
             raise TypeError("Configuration is not of type Configuration, but %s." % type(config))
+        if additional_info is None:
+            additional_info = {}
 
         # Squeeze is important to reduce arrays with one element
         # to scalars.

--- a/smac/runner/abstract_runner.py
+++ b/smac/runner/abstract_runner.py
@@ -50,8 +50,10 @@ class AbstractRunner(ABC):
     def __init__(
         self,
         scenario: Scenario,
-        required_arguments: list[str] = [],
+        required_arguments: list[str] = None,
     ):
+        if required_arguments is None:
+            required_arguments = []
         self._scenario = scenario
         self._required_arguments = required_arguments
 

--- a/smac/runner/target_function_runner.py
+++ b/smac/runner/target_function_runner.py
@@ -45,8 +45,10 @@ class TargetFunctionRunner(AbstractSerialRunner):
         self,
         scenario: Scenario,
         target_function: Callable,
-        required_arguments: list[str] = [],
+        required_arguments: list[str] = None,
     ):
+        if required_arguments is None:
+            required_arguments = []
         super().__init__(scenario=scenario, required_arguments=required_arguments)
         self._target_function = target_function
 

--- a/smac/runner/target_function_script_runner.py
+++ b/smac/runner/target_function_script_runner.py
@@ -51,8 +51,10 @@ class TargetFunctionScriptRunner(AbstractSerialRunner):
         self,
         target_function: str,
         scenario: Scenario,
-        required_arguments: list[str] = [],
+        required_arguments: list[str] = None,
     ):
+        if required_arguments is None:
+            required_arguments = []
         super().__init__(scenario=scenario, required_arguments=required_arguments)
         self._target_function = target_function
 


### PR DESCRIPTION
If this isn't respected, then additional_configs can be built up overtime when multiple optimizers are created in a single process.

This can occur when the use_default_config option is set True and/or when additional_configs are provided.

When different ConfigSpaces are provided this can result in an error due to mismatched defaults, for instance.

In other cases it can result in non-deterministic behavior due to the random ordering of the configs that get added (e.g., with different parallel pytest runs).

- [x] Cleanup other sources of this error as well elsewhere in the code.
- [x] Add pylint checks for this issue.