### PR TITLE
Fix config rejection for #1068

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.3
+
+## Bugfixes
+- Configurations that fail to become incumbents will be added to the rejected lists
+
 # 2.0.2
 
 ## Improvements

--- a/smac/intensifier/abstract_intensifier.py
+++ b/smac/intensifier/abstract_intensifier.py
@@ -572,7 +572,15 @@ class AbstractIntensifier:
         if len(previous_incumbents) == len(new_incumbents):
             if previous_incumbents == new_incumbents:
                 # No changes in the incumbents
-                self._remove_rejected_config(config_id)
+                # need this clause to make sure set difference isn't empty
+                if config_id in new_incumbent_ids:
+                    # TODO: can this case even happen? Intuitively a config should not be among incumbents and rejected
+                    # config IDs at the same time when starting incumbent update. (add/remove rejected config methods
+                    # are only called within update_incumbents.)
+                    self._remove_rejected_config(config_id)
+                else:
+                    # config worse than incumbents and thus rejected
+                    self._add_rejected_config(config_id)
                 return
             else:
                 # In this case, we have to determine which config replaced which incumbent and reject it

--- a/smac/intensifier/abstract_intensifier.py
+++ b/smac/intensifier/abstract_intensifier.py
@@ -571,12 +571,8 @@ class AbstractIntensifier:
 
         if len(previous_incumbents) == len(new_incumbents):
             if previous_incumbents == new_incumbents:
-                # No changes in the incumbents
-                # need this clause to make sure set difference isn't empty
+                # No changes in the incumbents, we need this clause because we can't use set difference then
                 if config_id in new_incumbent_ids:
-                    # TODO: can this case even happen? Intuitively a config should not be among incumbents and rejected
-                    # config IDs at the same time when starting incumbent update. (add/remove rejected config methods
-                    # are only called within update_incumbents.)
                     self._remove_rejected_config(config_id)
                 else:
                     # config worse than incumbents and thus rejected

--- a/tests/test_intensifier/test_abstract_intensifier.py
+++ b/tests/test_intensifier/test_abstract_intensifier.py
@@ -108,6 +108,47 @@ def test_incumbent_selection_multi_objective(make_scenario, configspace_small, m
     intensifier.update_incumbents(config2)
     assert intensifier.get_incumbents() == [config]
 
+def test_config_rejection_single_objective(configspace_small, make_scenario):
+    """ Tests whether configs are rejected properly if they are worse than the incumbent. """
+    scenario = make_scenario(configspace_small, use_instances=False)
+    runhistory = RunHistory()
+    intensifier = Intensifier(scenario=scenario)
+    intensifier.runhistory = runhistory
+
+    configs = configspace_small.sample_configuration(3)
+
+    runhistory.add(config=configs[0],
+                   cost=5,
+                   time=0.0,
+                   seed=0,
+                   status=StatusType.SUCCESS,
+                   force_update=True)
+    intensifier.update_incumbents(configs[0])
+
+    assert intensifier._rejected_config_ids == []
+
+    # add config that yielded better results, updating incumbent and sending prior incumbent to rejected
+    runhistory.add(config=configs[1],
+                   cost=1,
+                   time=0.0,
+                   seed=0,
+                   status=StatusType.SUCCESS,
+                   force_update=True)
+    intensifier.update_incumbents(config=configs[1])
+    
+    assert intensifier._rejected_config_ids == [1]
+
+    # add config that is no better should thus go to rejected
+    runhistory.add(config=configs[2],
+                   cost=1,
+                   time=0.0,
+                   seed=0,
+                   status=StatusType.SUCCESS,
+                   force_update=True)
+    intensifier.update_incumbents(config=configs[2])
+    
+    assert intensifier._rejected_config_ids == [1, 3]
+
 
 def test_incumbent_differences(make_scenario, configspace_small):
     pass

--- a/tests/test_intensifier/test_abstract_intensifier.py
+++ b/tests/test_intensifier/test_abstract_intensifier.py
@@ -108,6 +108,7 @@ def test_incumbent_selection_multi_objective(make_scenario, configspace_small, m
     intensifier.update_incumbents(config2)
     assert intensifier.get_incumbents() == [config]
 
+
 def test_config_rejection_single_objective(configspace_small, make_scenario):
     """ Tests whether configs are rejected properly if they are worse than the incumbent. """
     scenario = make_scenario(configspace_small, use_instances=False)


### PR DESCRIPTION
Fixes #1068 to make sure newly evaluated configs are rejected in case they are worse than the existing incumbent.