### PR TITLE
fix(RandomForest): Always cast `seed` to `int`

### DIFF
--- a/smac/model/random_forest/random_forest.py
+++ b/smac/model/random_forest/random_forest.py
@@ -87,7 +87,9 @@ class RandomForest(AbstractRandomForest):
         self._rf_opts.compute_law_of_total_variance = False
         self._rf: BinaryForest | None = None
         self._log_y = log_y
-        self._rng = regression.default_random_engine(seed)
+
+        # Case to `int` incase we get an `np.integer` type
+        self._rng = regression.default_random_engine(int(seed))
 
         self._n_trees = n_trees
         self._n_points_per_tree = n_points_per_tree


### PR DESCRIPTION
In cases where seeds were generated from some numpy objects, sometimes
you'd get back an `np.integer`, which causes the program to crash when
communicating with `pyrfr` through `swig`. It seems that swig doesn't
know that it's an _int-like_ and so we explicitly cast it to `int`.
