### PR TITLE
test: Fix upper bounds for `test_transformer()` and no random in `test_transformer_conditional()`

### DIFF
--- a/tests/test_runhistory/test_runhistory_encoder.py
+++ b/tests/test_runhistory/test_runhistory_encoder.py
@@ -14,6 +14,7 @@ from smac.runhistory.encoder.encoder import RunHistoryEncoder
 from smac.runner.abstract_runner import StatusType
 
 from ConfigSpace import Configuration
+from ConfigSpace.hyperparameters import CategoricalHyperparameter
 
 
 @pytest.fixture
@@ -183,7 +184,9 @@ def test_multi_objective(runhistory, make_scenario, configspace_small, configs):
 
     # Multi objective algorithm must be set
     with pytest.raises(AssertionError):
-        encoder = RunHistoryEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+        encoder = RunHistoryEncoder(
+            scenario=scenario, considered_states=[StatusType.SUCCESS]
+        )
         encoder.runhistory = runhistory
         _, Y = encoder.transform()
 
@@ -239,7 +242,9 @@ def test_ignore(runhistory, make_scenario, configspace_small, configs):
     )
 
     # Normal encoder
-    encoder = RunHistoryEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistoryEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
     X1, Y1 = encoder.transform()
 
@@ -278,10 +283,14 @@ def test_budgets(runhistory, make_scenario, configspace_small, configs):
         budget=2,
     )
 
-    runhistory.add(config=configs[1], cost=5, time=4, status=StatusType.SUCCESS, budget=2)
+    runhistory.add(
+        config=configs[1], cost=5, time=4, status=StatusType.SUCCESS, budget=2
+    )
 
     # Normal encoder
-    encoder = RunHistoryEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistoryEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
     X, Y = encoder.transform(budget_subset=[2])
     assert Y.tolist() == [[99999999]]
@@ -310,10 +319,14 @@ def test_budgets(runhistory, make_scenario, configspace_small, configs):
         budget=2,
     )
 
-    runhistory.add(config=configs[1], cost=5, time=4, status=StatusType.SUCCESS, budget=2)
+    runhistory.add(
+        config=configs[1], cost=5, time=4, status=StatusType.SUCCESS, budget=2
+    )
 
     # Normal encoder
-    encoder = RunHistoryEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistoryEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
     X, Y = encoder.transform(budget_subset=[2])
     assert Y.tolist() == [[99999999]]
@@ -325,12 +338,20 @@ def test_budgets(runhistory, make_scenario, configspace_small, configs):
 def test_lower_budget_states(runhistory, make_scenario, configspace_small, configs):
     """Tests lower budgets based on budget subset and considered states."""
     scenario = make_scenario(configspace_small)
-    encoder = RunHistoryEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistoryEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
 
-    runhistory.add(config=configs[0], cost=1, time=1, status=StatusType.SUCCESS, budget=3)
-    runhistory.add(config=configs[0], cost=2, time=2, status=StatusType.SUCCESS, budget=4)
-    runhistory.add(config=configs[0], cost=3, time=4, status=StatusType.TIMEOUT, budget=5)
+    runhistory.add(
+        config=configs[0], cost=1, time=1, status=StatusType.SUCCESS, budget=3
+    )
+    runhistory.add(
+        config=configs[0], cost=2, time=2, status=StatusType.SUCCESS, budget=4
+    )
+    runhistory.add(
+        config=configs[0], cost=3, time=4, status=StatusType.TIMEOUT, budget=5
+    )
 
     # We request a higher budget but can't find it, so we expect an empty list
     X, Y = encoder.transform(budget_subset=[500])

--- a/tests/test_runhistory/test_runhistory_encoder.py
+++ b/tests/test_runhistory/test_runhistory_encoder.py
@@ -47,7 +47,7 @@ def test_transform(runhistory, make_scenario, configspace_small, configs):
     )
     encoder.runhistory = runhistory
 
-    # TODO: Please replace with the more general solution in the future
+    # TODO: Please replace with the more general solution once ConfigSpace 1.0
     # upper = np.array([hp.upper_vectorized for hp in space.values()])
     # lower = np.array([hp.lower_vectorized for hp in space.values()])
     # -

--- a/tests/test_runhistory/test_runhistory_encoder.py
+++ b/tests/test_runhistory/test_runhistory_encoder.py
@@ -13,6 +13,8 @@ from smac.runhistory.encoder import (
 from smac.runhistory.encoder.encoder import RunHistoryEncoder
 from smac.runner.abstract_runner import StatusType
 
+from ConfigSpace import Configuration
+
 
 @pytest.fixture
 def configs(configspace_small):

--- a/tests/test_runhistory/test_runhistory_encoder.py
+++ b/tests/test_runhistory/test_runhistory_encoder.py
@@ -47,62 +47,96 @@ def test_transform(runhistory, make_scenario, configspace_small, configs):
     assert ((X1 <= 1.0) & (X1 >= 0.0)).all()
 
     # Log encoder
-    encoder = RunHistoryLogEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistoryLogEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
     assert Y.tolist() != Y1.tolist()
     assert ((X <= 1.0) & (X >= 0.0)).all()
 
-    encoder = RunHistoryLogScaledEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistoryLogScaledEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
     assert Y.tolist() != Y1.tolist()
     assert ((X <= 1.0) & (X >= 0.0)).all()
 
-    encoder = RunHistoryScaledEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistoryScaledEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
     assert Y.tolist() != Y1.tolist()
     assert ((X <= 1.0) & (X >= 0.0)).all()
 
-    encoder = RunHistoryInverseScaledEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistoryInverseScaledEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
     assert Y.tolist() != Y1.tolist()
     assert ((X <= 1.0) & (X >= 0.0)).all()
 
-    encoder = RunHistorySqrtScaledEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistorySqrtScaledEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
     assert Y.tolist() != Y1.tolist()
     assert ((X <= 1.0) & (X >= 0.0)).all()
 
-    encoder = RunHistoryEIPSEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistoryEIPSEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
     assert Y.tolist() != Y1.tolist()
     assert ((X <= 1.0) & (X >= 0.0)).all()
 
 
-def test_transform_conditionals(runhistory, make_scenario, configspace_large, configs):
-    configs = configspace_large.sample_configuration(20)
+def test_transform_conditionals(runhistory, make_scenario, configspace_large):
     scenario = make_scenario(configspace_large)
 
+    config_1 = Configuration(
+        configspace_large,
+        values={
+            "activation": "tanh",
+            "n_layer": 5,
+            "n_neurons": 27,
+            "solver": "lbfgs",
+        },
+    )
+    config_2 = Configuration(
+        configspace_large,
+        values={
+            "activation": "tanh",
+            "batch_size": 47,
+            "learning_rate": "adaptive",
+            "learning_rate_init": 0.6673206111956781,
+            "n_layer": 3,
+            "n_neurons": 88,
+            "solver": "sgd",
+        },
+    )
     runhistory.add(
-        config=configs[0],
+        config=config_1,
         cost=1,
         time=1,
         status=StatusType.SUCCESS,
     )
 
     runhistory.add(
-        config=configs[2],
+        config=config_2,
         cost=5,
         time=4,
         status=StatusType.SUCCESS,
     )
 
-    encoder = RunHistoryEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
+    encoder = RunHistoryEncoder(
+        scenario=scenario, considered_states=[StatusType.SUCCESS]
+    )
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
 


### PR DESCRIPTION
When testing the [new ConfigSpace branch](https://github.com/automl/ConfigSpace/tree/typing-cython-3) to check if it would break anything in SMAC, this test failed just due to a change on randomization.

I've fixed the test to not rely on the randomization of sampling. 