### PR TITLE
Remove failing assert

### DIFF
--- a/smac/intensifier/abstract_intensifier.py
+++ b/smac/intensifier/abstract_intensifier.py
@@ -508,7 +508,6 @@ class AbstractIntensifier:
         # Little sanity check here for consistency
         if len(incumbents) > 0:
             assert incumbent_isb_keys is not None
-            assert len(incumbent_isb_keys) > 0
 
         # If there are no incumbents at all, we just use the new config as new incumbent
         # Problem: We can add running incumbents


### PR DESCRIPTION
closes #1050

This assert is checking a state that is legal. As @dengdifan  noted in the issue, this is a bug.
While there is a workaround, making the facade able to instantiate symmetrically seems desirable.