### PR TITLE
Adding in CPU time to wherever time is defined as variable "cpu_time"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Improvements
 - Add logger information on handling of stopIteration error (#960)
 - Replace deprecated ConfigSpace methods (#1139)
+- Separated Wallclock time measurements from CPU time measurements and storing them under new 'cpu_time' variable (#????)
 
 ## Dependencies
 - Allow numpy >= 2.x (#1146)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## Improvements
 - Add logger information on handling of stopIteration error (#960)
 - Replace deprecated ConfigSpace methods (#1139)
-- Separated Wallclock time measurements from CPU time measurements and storing them under new 'cpu_time' variable (#????)
+- Separated Wallclock time measurements from CPU time measurements and storing them under new 'cpu_time' variable (#1173)
 
 ## Dependencies
 - Allow numpy >= 2.x (#1146)

--- a/smac/main/smbo.py
+++ b/smac/main/smbo.py
@@ -81,6 +81,7 @@ class SMBO:
         # Stats variables
         self._start_time: float | None = None
         self._used_target_function_walltime = 0.0
+        self._used_target_function_cputime = 0.0
 
         # Set walltime used method for intensifier
         self._intensifier.used_walltime = lambda: self.used_walltime  # type: ignore
@@ -108,7 +109,7 @@ class SMBO:
     @property
     def remaining_cputime(self) -> float:
         """Subtracts the target function running budget with the used time."""
-        return self._scenario.cputime_limit - self._used_target_function_walltime
+        return self._scenario.cputime_limit - self._used_target_function_cputime
 
     @property
     def remaining_trials(self) -> int:
@@ -136,6 +137,11 @@ class SMBO:
     def used_target_function_walltime(self) -> float:
         """Returns how much walltime the target function spend so far."""
         return self._used_target_function_walltime
+
+    @property
+    def used_target_function_cputime(self) -> float:
+        """Returns how much cputime the target function spend so far."""
+        return self._used_target_function_cputime
 
     def ask(self) -> TrialInfo:
         """Asks the intensifier for the next trial.
@@ -204,6 +210,7 @@ class SMBO:
             config=info.config,
             cost=value.cost,
             time=value.time,
+            cpu_time=value.cpu_time,
             status=value.status,
             instance=info.instance,
             seed=info.seed,
@@ -355,6 +362,7 @@ class SMBO:
     def reset(self) -> None:
         """Resets the internal variables of the optimizer, intensifier, and runhistory."""
         self._used_target_function_walltime = 0
+        self._used_target_function_cputime = 0
         self._finished = False
 
         # We also reset runhistory and intensifier here
@@ -398,6 +406,7 @@ class SMBO:
             self._intensifier.load(intensifier_fn)
 
             self._used_target_function_walltime = data["used_target_function_walltime"]
+            self._used_target_function_cputime = data["used_target_function_cputime"]
             self._finished = data["finished"]
             self._start_time = time.time() - data["used_walltime"]
 
@@ -409,6 +418,7 @@ class SMBO:
             data = {
                 "used_walltime": self.used_walltime,
                 "used_target_function_walltime": self.used_target_function_walltime,
+                "used_target_function_cputime": self.used_target_function_cputime,
                 "last_update": time.time(),
                 "finished": self._finished,
             }
@@ -442,6 +452,7 @@ class SMBO:
 
             # Update SMAC stats
             self._used_target_function_walltime += float(trial_value.time)
+            self._used_target_function_cputime += float(trial_value.cpu_time)
 
             # Gracefully end optimization if termination cost is reached
             if self._scenario.termination_cost_threshold != np.inf:
@@ -582,7 +593,7 @@ class SMBO:
 
             # TODO: Use submit run for faster evaluation
             # self._runner.submit_trial(trial_info=trial)
-            _, cost, _, _ = self._runner.run(config, **kwargs)
+            _, cost, _, _, _ = self._runner.run(config, **kwargs)
             costs += [cost]
 
         np_costs = np.array(costs)
@@ -600,5 +611,7 @@ class SMBO:
             f"--- Used wallclock time: {round(self.used_walltime)} / {self._scenario.walltime_limit} sec\n"
             "--- Used target function runtime: "
             f"{round(self.used_target_function_walltime, 2)} / {self._scenario.cputime_limit} sec\n"
+            "--- Used target function CPU time: "
+            f"{round(self.used_target_function_cputime, 2)} / {self._scenario.cputime_limit} sec\n"
             f"----------------------------------------------------"
         )

--- a/smac/main/smbo.py
+++ b/smac/main/smbo.py
@@ -140,7 +140,7 @@ class SMBO:
 
     @property
     def used_target_function_cputime(self) -> float:
-        """Returns how much cputime the target function spend so far."""
+        """Returns how much time the target function spend on the hardware so far."""
         return self._used_target_function_cputime
 
     def ask(self) -> TrialInfo:

--- a/smac/runhistory/dataclasses.py
+++ b/smac/runhistory/dataclasses.py
@@ -99,6 +99,7 @@ class TrialValue:
     cost : float | list[float]
     time : float, defaults to 0.0
     cpu_time : float, defaults to 0.0
+        Describes the amount of time the trial spend on hardware.
     status : StatusType, defaults to StatusType.SUCCESS
     starttime : float, defaults to 0.0
     endtime : float, defaults to 0.0

--- a/smac/runhistory/dataclasses.py
+++ b/smac/runhistory/dataclasses.py
@@ -98,6 +98,7 @@ class TrialValue:
     ----------
     cost : float | list[float]
     time : float, defaults to 0.0
+    cpu_time : float, defaults to 0.0
     status : StatusType, defaults to StatusType.SUCCESS
     starttime : float, defaults to 0.0
     endtime : float, defaults to 0.0
@@ -106,6 +107,7 @@ class TrialValue:
 
     cost: float | list[float]
     time: float = 0.0
+    cpu_time: float = 0.0
     status: StatusType = StatusType.SUCCESS
     starttime: float = 0.0
     endtime: float = 0.0

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -193,7 +193,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
         time : float
             How much time was needed to evaluate the trial.
         cpu_time : float
-            How much CPU time was needed to evaluate the trial.
+            How much time was needed on the hardware to evaluate the trial.
         status : StatusType, defaults to StatusType.SUCCESS
             The status of the trial.
         instance : str | None, defaults to none

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -173,6 +173,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
         config: Configuration,
         cost: int | float | list[int | float],
         time: float = 0.0,
+        cpu_time: float = 0.0,
         status: StatusType = StatusType.SUCCESS,
         instance: str | None = None,
         seed: int | None = None,
@@ -191,6 +192,8 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
             Cost of the evaluated trial. Might be a list in case of multi-objective.
         time : float
             How much time was needed to evaluate the trial.
+        cpu_time : float
+            How much CPU time was needed to evaluate the trial.
         status : StatusType, defaults to StatusType.SUCCESS
             The status of the trial.
         instance : str | None, defaults to none
@@ -254,6 +257,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
         v = TrialValue(
             cost=c,
             time=time,
+            cpu_time=cpu_time,
             status=status,
             starttime=starttime,
             endtime=endtime,
@@ -269,6 +273,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
             ("budget", budget),
             ("cost", c),
             ("time", time),
+            ("cpu_time", cpu_time),
             ("status", status),
             ("starttime", starttime),
             ("endtime", endtime),
@@ -310,6 +315,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
             config=info.config,
             cost=value.cost,
             time=value.time,
+            cpu_time=value.cpu_time,
             status=value.status,
             instance=info.instance,
             seed=info.seed,
@@ -331,6 +337,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
             config=trial.config,
             cost=float(MAXINT),
             time=0.0,
+            cpu_time=0.0,
             status=StatusType.RUNNING,
             instance=trial.instance,
             seed=trial.seed,
@@ -771,6 +778,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
                     float(k.budget) if k.budget is not None else None,
                     v.cost,
                     v.time,
+                    v.cpu_time,
                     v.status,
                     v.starttime,
                     v.endtime,
@@ -848,6 +856,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
         self._n_id = len(self._config_ids)
 
         # Important to use add method to use all data structure correctly
+        # NOTE: These hardcoded indices can easily lead to trouble
         for entry in data["data"]:
             # Set n_objectives first
             if self._n_objectives == -1:
@@ -866,13 +875,14 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
                 config=self._ids_config[int(entry[0])],
                 cost=cost,
                 time=float(entry[5]),
-                status=StatusType(entry[6]),
+                cpu_time=float(entry[6]),
+                status=StatusType(entry[7]),
                 instance=entry[1],
                 seed=entry[2],
                 budget=entry[3],
-                starttime=entry[7],
-                endtime=entry[8],
-                additional_info=entry[9],
+                starttime=entry[8],
+                endtime=entry[9],
+                additional_info=entry[10],
             )
 
         # Although adding trials should give us the same stats, the trajectory might be different
@@ -916,6 +926,7 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
                 config=config,
                 cost=value.cost,
                 time=value.time,
+                cpu_time=value.cpu_time,
                 status=value.status,
                 instance=key.instance,
                 starttime=value.starttime,

--- a/smac/runner/abstract_runner.py
+++ b/smac/runner/abstract_runner.py
@@ -211,7 +211,7 @@ class AbstractRunner(ABC):
         runtime : float
             The time the target function took to run.
         cpu_time : float
-            The CPU time the target function took to run.
+            The time the target function took on hardware to run.
         additional_info : dict
             All further additional trial information.
         """

--- a/smac/runner/abstract_runner.py
+++ b/smac/runner/abstract_runner.py
@@ -105,9 +105,9 @@ class AbstractRunner(ABC):
             Contains information about the status/performance of config.
         """
         start = time.time()
-
+        cpu_time = time.process_time()
         try:
-            status, cost, runtime, additional_info = self.run(
+            status, cost, runtime, cpu_time, additional_info = self.run(
                 config=trial_info.config,
                 instance=trial_info.instance,
                 budget=trial_info.budget,
@@ -117,6 +117,7 @@ class AbstractRunner(ABC):
         except Exception as e:
             status = StatusType.CRASHED
             cost = self._crash_cost
+            cpu_time = time.process_time() - cpu_time
             runtime = time.time() - start
 
             # Add context information to the error message
@@ -148,6 +149,7 @@ class AbstractRunner(ABC):
             status=status,
             cost=cost,
             time=runtime,
+            cpu_time=cpu_time,
             additional_info=additional_info,
             starttime=start,
             endtime=end,
@@ -185,7 +187,7 @@ class AbstractRunner(ABC):
         instance: str | None = None,
         budget: float | None = None,
         seed: int | None = None,
-    ) -> tuple[StatusType, float | list[float], float, dict]:
+    ) -> tuple[StatusType, float | list[float], float, float, dict]:
         """Runs the target function with a configuration on a single instance-budget-seed
         combination (aka trial).
 
@@ -208,6 +210,8 @@ class AbstractRunner(ABC):
             Resulting cost(s) of the trial.
         runtime : float
             The time the target function took to run.
+        cpu_time : float
+            The CPU time the target function took to run.
         additional_info : dict
             All further additional trial information.
         """

--- a/smac/runner/dask_runner.py
+++ b/smac/runner/dask_runner.py
@@ -163,7 +163,7 @@ class DaskParallelRunner(AbstractRunner):
         budget: float | None = None,
         seed: int | None = None,
         **dask_data_to_scatter: dict[str, Any],
-    ) -> tuple[StatusType, float | list[float], float, dict]:  # noqa: D102
+    ) -> tuple[StatusType, float | list[float], float, float, dict]:  # noqa: D102
         return self._single_worker.run(
             config=config, instance=instance, seed=seed, budget=budget, **dask_data_to_scatter
         )

--- a/smac/runner/target_function_runner.py
+++ b/smac/runner/target_function_runner.py
@@ -144,7 +144,7 @@ class TargetFunctionRunner(AbstractSerialRunner):
         runtime : float
             The time the target function took to run.
         cpu_time : float
-            The CPU time the target function took to run.
+            The time the target function took on the hardware to run.
         additional_info : dict
             All further additional trial information.
         """

--- a/smac/runner/target_function_runner.py
+++ b/smac/runner/target_function_runner.py
@@ -112,7 +112,7 @@ class TargetFunctionRunner(AbstractSerialRunner):
         budget: float | None = None,
         seed: int | None = None,
         **dask_data_to_scatter: dict[str, Any],
-    ) -> tuple[StatusType, float | list[float], float, dict]:
+    ) -> tuple[StatusType, float | list[float], float, float, dict]:
         """Calls the target function with pynisher if algorithm wall time limit or memory limit is
         set. Otherwise, the function is called directly.
 
@@ -143,6 +143,8 @@ class TargetFunctionRunner(AbstractSerialRunner):
             Resulting cost(s) of the trial.
         runtime : float
             The time the target function took to run.
+        cpu_time : float
+            The CPU time the target function took to run.
         additional_info : dict
             All further additional trial information.
         """
@@ -162,6 +164,7 @@ class TargetFunctionRunner(AbstractSerialRunner):
         # Presetting
         cost: float | list[float] = self._crash_cost
         runtime = 0.0
+        cpu_time = runtime
         additional_info = {}
         status = StatusType.CRASHED
 
@@ -183,7 +186,9 @@ class TargetFunctionRunner(AbstractSerialRunner):
         # Call target function
         try:
             start_time = time.time()
+            cpu_time = time.process_time()
             rval = self(config_copy, target_function, kwargs)
+            cpu_time = time.process_time() - cpu_time
             runtime = time.time() - start_time
             status = StatusType.SUCCESS
         except WallTimeoutException:
@@ -199,7 +204,7 @@ class TargetFunctionRunner(AbstractSerialRunner):
             status = StatusType.CRASHED
 
         if status != StatusType.SUCCESS:
-            return status, cost, runtime, additional_info
+            return status, cost, runtime, cpu_time, additional_info
 
         if isinstance(rval, tuple):
             result, additional_info = rval
@@ -240,7 +245,7 @@ class TargetFunctionRunner(AbstractSerialRunner):
         # We want to get either a float or a list of floats.
         cost = np.asarray(cost).squeeze().tolist()
 
-        return status, cost, runtime, additional_info
+        return status, cost, runtime, cpu_time, additional_info
 
     def __call__(
         self,

--- a/smac/runner/target_function_script_runner.py
+++ b/smac/runner/target_function_script_runner.py
@@ -83,7 +83,7 @@ class TargetFunctionScriptRunner(AbstractSerialRunner):
         instance: str | None = None,
         budget: float | None = None,
         seed: int | None = None,
-    ) -> tuple[StatusType, float | list[float], float, dict]:
+    ) -> tuple[StatusType, float | list[float], float, float, dict]:
         """Calls the target function.
 
         Parameters
@@ -105,6 +105,8 @@ class TargetFunctionScriptRunner(AbstractSerialRunner):
             Resulting cost(s) of the trial.
         runtime : float
             The time the target function took to run.
+        cpu_time : float
+            The CPU time the target function took to run.
         additional_info : dict
             All further additional trial information.
         """
@@ -128,6 +130,7 @@ class TargetFunctionScriptRunner(AbstractSerialRunner):
         # Presetting
         cost: float | list[float] = self._crash_cost
         runtime = 0.0
+        cpu_time = runtime
         additional_info = {}
         status = StatusType.SUCCESS
 
@@ -139,7 +142,9 @@ class TargetFunctionScriptRunner(AbstractSerialRunner):
 
         # Call target function
         start_time = time.time()
+        cpu_time = time.process_time()
         output, error = self(kwargs)
+        cpu_time = time.process_time() - cpu_time
         runtime = time.time() - start_time
 
         # Now we have to parse the std output
@@ -181,6 +186,10 @@ class TargetFunctionScriptRunner(AbstractSerialRunner):
         if "runtime" in outputs:
             runtime = float(outputs["runtime"])
 
+        # Overwrite CPU time
+        if "cpu_time" in outputs:
+            cpu_time = float(outputs["cpu_time"])
+
         # Add additional info
         if "additional_info" in outputs:
             additional_info["additional_info"] = outputs["additional_info"]
@@ -194,7 +203,7 @@ class TargetFunctionScriptRunner(AbstractSerialRunner):
                     "The target function crashed but returned a cost. The cost is ignored and replaced by crash cost."
                 )
 
-        return status, cost, runtime, additional_info
+        return status, cost, runtime, cpu_time, additional_info
 
     def __call__(
         self,

--- a/smac/runner/target_function_script_runner.py
+++ b/smac/runner/target_function_script_runner.py
@@ -106,7 +106,7 @@ class TargetFunctionScriptRunner(AbstractSerialRunner):
         runtime : float
             The time the target function took to run.
         cpu_time : float
-            The CPU time the target function took to run.
+            The time the target function took on the hardware to run.
         additional_info : dict
             All further additional trial information.
         """

--- a/tests/test_runner/test_script_target_algorithm_runner.py
+++ b/tests/test_runner/test_script_target_algorithm_runner.py
@@ -17,7 +17,7 @@ def test_success(configspace, make_scenario):
     runner = TargetFunctionScriptRunner(script, scenario, required_arguments=["seed", "instance"])
 
     config = configspace.get_default_configuration()
-    status, cost, runtime, additional_info = runner.run(config, instance=scenario.instances[0], seed=0)
+    status, cost, runtime, cpu_time, additional_info = runner.run(config, instance=scenario.instances[0], seed=0)
 
     assert status == StatusType.SUCCESS
     assert cost == config["x0"]
@@ -30,7 +30,7 @@ def test_success_multi_objective(configspace, make_scenario):
     runner = TargetFunctionScriptRunner(script, scenario, required_arguments=["seed", "instance"])
 
     config = configspace.get_default_configuration()
-    status, cost, runtime, additional_info = runner.run(config, instance=scenario.instances[0], seed=0)
+    status, cost, runtime, cpu_time, additional_info = runner.run(config, instance=scenario.instances[0], seed=0)
 
     assert status == StatusType.SUCCESS
     assert cost == [config["x0"], config["x0"]]
@@ -43,7 +43,7 @@ def test_exit(configspace, make_scenario):
     runner = TargetFunctionScriptRunner(script, scenario, required_arguments=["seed", "instance"])
 
     config = configspace.get_default_configuration()
-    status, cost, runtime, additional_info = runner.run(config, instance=scenario.instances[0], seed=0)
+    status, cost, runtime, cpu_time, additional_info = runner.run(config, instance=scenario.instances[0], seed=0)
 
     assert status == StatusType.CRASHED
     assert "error" in additional_info
@@ -55,7 +55,7 @@ def test_crashed(configspace, make_scenario):
     runner = TargetFunctionScriptRunner(script, scenario, required_arguments=["seed", "instance"])
 
     config = configspace.get_default_configuration()
-    status, cost, runtime, additional_info = runner.run(config, instance=scenario.instances[0], seed=0)
+    status, cost, runtime, cpu_time, additional_info = runner.run(config, instance=scenario.instances[0], seed=0)
 
     assert status == StatusType.CRASHED
     assert cost == np.inf
@@ -67,7 +67,7 @@ def test_python(configspace, make_scenario):
     runner = TargetFunctionScriptRunner(script, scenario, required_arguments=["seed", "instance"])
 
     config = configspace.get_default_configuration()
-    status, cost, runtime, additional_info = runner.run(config, instance=scenario.instances[0], seed=0)
+    status, cost, runtime, cpu_time, additional_info = runner.run(config, instance=scenario.instances[0], seed=0)
 
     assert status == StatusType.SUCCESS
     assert cost == config["x0"]

--- a/tests/test_runner/test_target_algorithm_runner.py
+++ b/tests/test_runner/test_target_algorithm_runner.py
@@ -148,7 +148,7 @@ def test_call(make_runner: Callable[..., TargetFunctionRunner]) -> None:
     config = runner._scenario.configspace.get_default_configuration()
 
     SEED = 2345
-    status, cost, _, _ = runner.run(config=config, instance=None, seed=SEED, budget=None)
+    status, cost, _, _, _ = runner.run(config=config, instance=None, seed=SEED, budget=None)
 
     assert cost == SEED
     assert status == StatusType.SUCCESS
@@ -163,7 +163,7 @@ def test_multi_objective(make_runner: Callable[..., TargetFunctionRunner]) -> No
         config = runner._scenario.configspace.get_default_configuration()
 
         SEED = 2345
-        status, cost, _, _ = runner.run(config=config, instance=None, seed=SEED, budget=None)
+        status, cost, _, _, _ = runner.run(config=config, instance=None, seed=SEED, budget=None)
 
         assert isinstance(cost, list)
         assert cost == [SEED, SEED]

--- a/tests/test_runner/test_target_algorithm_runner.py
+++ b/tests/test_runner/test_target_algorithm_runner.py
@@ -127,7 +127,12 @@ def test_serial_runs(make_runner: Callable[..., TargetFunctionRunner]) -> None:
     _, first_run_value = first
     _, second_run_value = second
     assert int(first_run_value.endtime) <= int(second_run_value.starttime)
-
+    # For these examples, runtime must be larger or equal to cputime
+    assert first_run_value.time >= first_run_value.cpu_time
+    assert second_run_value.time >= second_run_value.cpu_time
+    # And cpu time must be near zero because the target function just sleeps
+    assert first_run_value.cpu_time < 0.001
+    assert second_run_value.cpu_time < 0.001
 
 def test_fail(make_runner: Callable[..., TargetFunctionRunner]) -> None:
     """Test traceback and error end up in the additional info of a failing run"""


### PR DESCRIPTION
Changed the TrialValue to hold CPU time and have SMBO use this value to calculate its budgets

- Same behaviour as the original 'time' variable, except in its calculation tries to estimate CPU time with process_time instead.
- Added in to TrialValue object, RunHistory and SMBO so it can be recorded and correctly calculate the remaining CPU budget

Pytest are passing (on my machine)