### PR TITLE
Fix kwargs for DifferentialEvolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Correct intensifier for Algorithm Configuration Facade (#1162, #1165)
 - Migrate sphinx docs to mkdocs (#1155)
 
+## Bugfixes
+- Fix kwargs for DifferentialEvolution (#1187)
+
 # 2.2.1
 
 ## Improvements

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
     python_requires=">=3.8",
     install_requires=[
         "numpy",
-        "scipy>=1.15.1",
+        "scipy>=1.9.2",
         "psutil",
         "pynisher>=1.0.0",
         "ConfigSpace>=1.0.0",


### PR DESCRIPTION
From the version change of scipy's `1.14.x` to `1.15.x` `DifferentialEvolution` now takes `rng` instead of `seed`.
In the code, check the signature and pass the kwarg accordingly. This should allow backwards compatibility with earlier python versions.