### PR TITLE
Update copyright from 2022 to 2025, update institution name

### DIFF
--- a/examples/1_basics/1_quadratic_function.py
+++ b/examples/1_basics/1_quadratic_function.py
@@ -16,7 +16,7 @@ from matplotlib import pyplot as plt
 from smac.facade.hyperparameter_optimization_facade import HyperparameterOptimizationFacade as HPOFacade
 from smac import RunHistory, Scenario
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/1_basics/2_svm_cv.py
+++ b/examples/1_basics/2_svm_cv.py
@@ -15,7 +15,7 @@ from sklearn.model_selection import cross_val_score
 
 from smac import HyperparameterOptimizationFacade, Scenario
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/1_basics/3_ask_and_tell.py
+++ b/examples/1_basics/3_ask_and_tell.py
@@ -9,7 +9,7 @@ from ConfigSpace import Configuration, ConfigurationSpace, Float
 from smac import HyperparameterOptimizationFacade, Scenario
 from smac.runhistory.dataclasses import TrialValue
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/1_basics/4_callback.py
+++ b/examples/1_basics/4_callback.py
@@ -16,7 +16,7 @@ from smac import HyperparameterOptimizationFacade as HPOFacade
 from smac import Scenario
 from smac.runhistory import TrialInfo, TrialValue
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/1_basics/5_continue.py
+++ b/examples/1_basics/5_continue.py
@@ -23,7 +23,7 @@ from smac import Scenario
 from smac.main.smbo import SMBO
 from smac.runhistory import TrialInfo, TrialValue
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/1_basics/6_priors.py
+++ b/examples/1_basics/6_priors.py
@@ -30,7 +30,7 @@ from sklearn.neural_network import MLPClassifier
 from smac import HyperparameterOptimizationFacade, Scenario
 from smac.acquisition.function import PriorAcquisitionFunction
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/1_basics/7_parallelization_cluster.py
+++ b/examples/1_basics/7_parallelization_cluster.py
@@ -32,7 +32,7 @@ from dask_jobqueue import SLURMCluster
 
 from smac import BlackBoxFacade, Scenario
 
-__copyright__ = "Copyright 2023, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/2_multi_fidelity/1_mlp_epochs.py
+++ b/examples/2_multi_fidelity/1_mlp_epochs.py
@@ -41,7 +41,7 @@ from smac.facade import AbstractFacade
 from smac.intensifier.hyperband import Hyperband
 from smac.intensifier.successive_halving import SuccessiveHalving
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/2_multi_fidelity/2_sgd_datasets.py
+++ b/examples/2_multi_fidelity/2_sgd_datasets.py
@@ -27,7 +27,7 @@ from sklearn.model_selection import StratifiedKFold, cross_val_score
 from smac import MultiFidelityFacade as MFFacade
 from smac import Scenario
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/2_multi_fidelity/3_specify_HB_via_total_budget.py
+++ b/examples/2_multi_fidelity/3_specify_HB_via_total_budget.py
@@ -20,7 +20,7 @@ from matplotlib import pyplot as plt
 from smac import MultiFidelityFacade, RunHistory, Scenario
 from smac.intensifier.hyperband_utils import get_n_trials_for_hyperband_multifidelity
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/3_multi_objective/1_schaffer.py
+++ b/examples/3_multi_objective/1_schaffer.py
@@ -18,7 +18,7 @@ from smac import HyperparameterOptimizationFacade as HPOFacade
 from smac import Scenario
 from smac.facade import AbstractFacade
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/3_multi_objective/2_parego.py
+++ b/examples/3_multi_objective/2_parego.py
@@ -33,7 +33,7 @@ from smac import Scenario
 from smac.facade.abstract_facade import AbstractFacade
 from smac.multi_objective.parego import ParEGO
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/4_advanced_optimizer/3_metadata_callback.py
+++ b/examples/4_advanced_optimizer/3_metadata_callback.py
@@ -26,7 +26,7 @@ from smac import HyperparameterOptimizationFacade as HPOFacade
 from smac import Scenario
 from smac.callback.metadata_callback import MetadataCallback
 
-__copyright__ = "Copyright 2023, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/examples/4_advanced_optimizer/4_intensify_crossvalidation.py
+++ b/examples/4_advanced_optimizer/4_intensify_crossvalidation.py
@@ -11,7 +11,7 @@ is found to be worse than the incumbent configuration. This is especially useful
 of a configuration is expensive, e.g., if we have to train a neural network or if we have to
 evaluate the configuration on a large dataset.
 """
-__copyright__ = "Copyright 2023, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 N_FOLDS = 10  # Global variable that determines the number of folds

--- a/examples/5_commandline/1_call_target_function_script.py
+++ b/examples/5_commandline/1_call_target_function_script.py
@@ -30,7 +30,7 @@ from ConfigSpace import ConfigurationSpace
 
 from smac import BlackBoxFacade, Scenario
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/scripts/update_files.py
+++ b/scripts/update_files.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         if filename == "smac/__init__.py":
             continue
 
-        replace_if_starts_with(filename, "__copyright__ =", '__copyright__ = "Copyright 2022, automl.org"')
+        replace_if_starts_with(filename, "__copyright__ =", '__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"')
         replace_if_starts_with(filename, "__author__ =")
         replace_if_starts_with(filename, "__maintainer__ =")
         replace_if_starts_with(filename, "__version__ =")

--- a/smac/acquisition/function/abstract_acquisition_function.py
+++ b/smac/acquisition/function/abstract_acquisition_function.py
@@ -10,7 +10,7 @@ from smac.model.abstract_model import AbstractModel
 from smac.utils.configspace import convert_configurations_to_array
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/acquisition/function/confidence_bound.py
+++ b/smac/acquisition/function/confidence_bound.py
@@ -9,7 +9,7 @@ from smac.acquisition.function.abstract_acquisition_function import (
 )
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/acquisition/function/expected_improvement.py
+++ b/smac/acquisition/function/expected_improvement.py
@@ -10,7 +10,7 @@ from smac.acquisition.function.abstract_acquisition_function import (
 )
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/acquisition/function/integrated_acquisition_function.py
+++ b/smac/acquisition/function/integrated_acquisition_function.py
@@ -12,7 +12,7 @@ from smac.acquisition.function.abstract_acquisition_function import (
 from smac.model.abstract_model import AbstractModel
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/acquisition/function/prior_acquisition_function.py
+++ b/smac/acquisition/function/prior_acquisition_function.py
@@ -18,7 +18,7 @@ from smac.model.abstract_model import AbstractModel
 from smac.model.random_forest.abstract_random_forest import AbstractRandomForest
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/acquisition/function/probability_improvement.py
+++ b/smac/acquisition/function/probability_improvement.py
@@ -10,7 +10,7 @@ from smac.acquisition.function.abstract_acquisition_function import (
 )
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/acquisition/function/thompson.py
+++ b/smac/acquisition/function/thompson.py
@@ -7,7 +7,7 @@ from smac.acquisition.function.abstract_acquisition_function import (
 )
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/acquisition/maximizer/abstract_acquisition_maximizer.py
+++ b/smac/acquisition/maximizer/abstract_acquisition_maximizer.py
@@ -13,7 +13,7 @@ from smac.acquisition.maximizer.helpers import ChallengerList
 from smac.random_design.abstract_random_design import AbstractRandomDesign
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/acquisition/maximizer/differential_evolution.py
+++ b/smac/acquisition/maximizer/differential_evolution.py
@@ -12,7 +12,7 @@ from smac.acquisition.function.abstract_acquisition_function import (
 from smac.acquisition.maximizer import AbstractAcquisitionMaximizer
 from smac.utils.configspace import transform_continuous_designs
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/acquisition/maximizer/local_and_random_search.py
+++ b/smac/acquisition/maximizer/local_and_random_search.py
@@ -12,7 +12,7 @@ from smac.acquisition.maximizer.local_search import LocalSearch
 from smac.acquisition.maximizer.random_search import RandomSearch
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/acquisition/maximizer/local_search.py
+++ b/smac/acquisition/maximizer/local_search.py
@@ -19,7 +19,7 @@ from smac.utils.configspace import (
 )
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/acquisition/maximizer/random_search.py
+++ b/smac/acquisition/maximizer/random_search.py
@@ -7,7 +7,7 @@ from smac.acquisition.maximizer.abstract_acquisition_maximizer import (
 )
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/callback/callback.py
+++ b/smac/callback/callback.py
@@ -5,7 +5,7 @@ from ConfigSpace import Configuration
 import smac
 from smac.runhistory import TrialInfo, TrialValue
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/callback/metadata_callback.py
+++ b/smac/callback/metadata_callback.py
@@ -9,7 +9,7 @@ from smac.callback.callback import Callback
 from smac.main.smbo import SMBO
 from smac.utils.numpyencoder import NumpyEncoder
 
-__copyright__ = "Copyright 2023, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/constants.py
+++ b/smac/constants.py
@@ -1,5 +1,5 @@
 """Constants used in SMAC, e.g. maximum number of cutoffs, very small number, etc."""
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -39,7 +39,7 @@ from smac.utils.logging import get_logger, setup_logging
 
 logger = get_logger(__name__)
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/facade/algorithm_configuration_facade.py
+++ b/smac/facade/algorithm_configuration_facade.py
@@ -16,7 +16,7 @@ from smac.runhistory.encoder.encoder import RunHistoryEncoder
 from smac.scenario import Scenario
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/facade/blackbox_facade.py
+++ b/smac/facade/blackbox_facade.py
@@ -30,7 +30,7 @@ from smac.runhistory.encoder.encoder import RunHistoryEncoder
 from smac.scenario import Scenario
 from smac.utils.configspace import get_types
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/facade/hyperband_facade.py
+++ b/smac/facade/hyperband_facade.py
@@ -4,7 +4,7 @@ from smac.facade.random_facade import RandomFacade
 from smac.intensifier.hyperband import Hyperband
 from smac.scenario import Scenario
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/facade/hyperparameter_optimization_facade.py
+++ b/smac/facade/hyperparameter_optimization_facade.py
@@ -15,7 +15,7 @@ from smac.random_design.probability_design import ProbabilityRandomDesign
 from smac.runhistory.encoder.log_scaled_encoder import RunHistoryLogScaledEncoder
 from smac.scenario import Scenario
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/facade/multi_fidelity_facade.py
+++ b/smac/facade/multi_fidelity_facade.py
@@ -9,7 +9,7 @@ from smac.initial_design.random_design import RandomInitialDesign
 from smac.intensifier.hyperband import Hyperband
 from smac.scenario import Scenario
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/facade/random_facade.py
+++ b/smac/facade/random_facade.py
@@ -16,7 +16,7 @@ from smac.random_design import AbstractRandomDesign
 from smac.runhistory.encoder.encoder import RunHistoryEncoder
 from smac.scenario import Scenario
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/initial_design/abstract_initial_design.py
+++ b/smac/initial_design/abstract_initial_design.py
@@ -11,7 +11,7 @@ from ConfigSpace.configuration_space import Configuration
 from smac.scenario import Scenario
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/initial_design/default_design.py
+++ b/smac/initial_design/default_design.py
@@ -4,7 +4,7 @@ from ConfigSpace import Configuration
 
 from smac.initial_design.abstract_initial_design import AbstractInitialDesign
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/initial_design/factorial_design.py
+++ b/smac/initial_design/factorial_design.py
@@ -14,7 +14,7 @@ from ConfigSpace.util import deactivate_inactive_hyperparameters
 
 from smac.initial_design.abstract_initial_design import AbstractInitialDesign
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/initial_design/latin_hypercube_design.py
+++ b/smac/initial_design/latin_hypercube_design.py
@@ -7,7 +7,7 @@ from scipy.stats.qmc import LatinHypercube
 from smac.initial_design.abstract_initial_design import AbstractInitialDesign
 from smac.utils.configspace import transform_continuous_designs
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/initial_design/random_design.py
+++ b/smac/initial_design/random_design.py
@@ -4,7 +4,7 @@ from ConfigSpace import Configuration
 
 from smac.initial_design.abstract_initial_design import AbstractInitialDesign
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/initial_design/sobol_design.py
+++ b/smac/initial_design/sobol_design.py
@@ -11,7 +11,7 @@ from scipy.stats.qmc import Sobol
 from smac.initial_design.abstract_initial_design import AbstractInitialDesign
 from smac.utils.configspace import transform_continuous_designs
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/intensifier/abstract_intensifier.py
+++ b/smac/intensifier/abstract_intensifier.py
@@ -29,7 +29,7 @@ from smac.utils.logging import get_logger
 from smac.utils.numpyencoder import NumpyEncoder
 from smac.utils.pareto_front import calculate_pareto_front, sort_by_crowding_distance
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/intensifier/intensifier.py
+++ b/smac/intensifier/intensifier.py
@@ -11,7 +11,7 @@ from smac.scenario import Scenario
 from smac.utils.configspace import get_config_hash
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/intensifier/successive_halving.py
+++ b/smac/intensifier/successive_halving.py
@@ -19,7 +19,7 @@ from smac.utils.data_structures import batch
 from smac.utils.logging import get_logger
 from smac.utils.pareto_front import calculate_pareto_front, sort_by_crowding_distance
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/main/config_selector.py
+++ b/smac/main/config_selector.py
@@ -22,7 +22,7 @@ from smac.runhistory.runhistory import RunHistory
 from smac.scenario import Scenario
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/main/old/_boing.py
+++ b/smac/main/old/_boing.py
@@ -28,7 +28,7 @@
 # from smac.utils.subspaces.boing_subspace import BOinGSubspace
 # from smac.utils.subspaces.turbo_subspace import TuRBOSubSpace
 
-# __copyright__ = "Copyright 2022, automl.org"
+# __copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 # __license__ = "3-clause BSD"
 
 

--- a/smac/main/smbo.py
+++ b/smac/main/smbo.py
@@ -26,7 +26,7 @@ from smac.utils.data_structures import recursively_compare_dicts
 from smac.utils.logging import get_logger
 from smac.utils.numpyencoder import NumpyEncoder
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/abstract_model.py
+++ b/smac/model/abstract_model.py
@@ -16,7 +16,7 @@ from smac.constants import VERY_SMALL_NUMBER
 from smac.utils.configspace import get_types
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/abstract_gaussian_process.py
+++ b/smac/model/gaussian_process/abstract_gaussian_process.py
@@ -13,7 +13,7 @@ from smac.model.abstract_model import AbstractModel
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 from smac.model.gaussian_process.priors.tophat_prior import SoftTopHatPrior, TophatPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/gaussian_process.py
+++ b/smac/model/gaussian_process/gaussian_process.py
@@ -16,7 +16,7 @@ from smac.model.gaussian_process.abstract_gaussian_process import (
 )
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/kernels/base_kernels.py
+++ b/smac/model/gaussian_process/kernels/base_kernels.py
@@ -11,7 +11,7 @@ import sklearn.gaussian_process.kernels as kernels
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 from smac.utils.configspace import get_conditional_hyperparameters
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/kernels/hamming_kernel.py
+++ b/smac/model/gaussian_process/kernels/hamming_kernel.py
@@ -8,7 +8,7 @@ import sklearn.gaussian_process.kernels as kernels
 from smac.model.gaussian_process.kernels.base_kernels import AbstractKernel
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/kernels/matern_kernel.py
+++ b/smac/model/gaussian_process/kernels/matern_kernel.py
@@ -11,7 +11,7 @@ import sklearn.gaussian_process.kernels as kernels
 from smac.model.gaussian_process.kernels.base_kernels import AbstractKernel
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/kernels/rbf_kernel.py
+++ b/smac/model/gaussian_process/kernels/rbf_kernel.py
@@ -9,7 +9,7 @@ import sklearn.gaussian_process.kernels as kernels
 from smac.model.gaussian_process.kernels.base_kernels import AbstractKernel
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/kernels/white_kernel.py
+++ b/smac/model/gaussian_process/kernels/white_kernel.py
@@ -6,7 +6,7 @@ import sklearn.gaussian_process.kernels as kernels
 from smac.model.gaussian_process.kernels.base_kernels import AbstractKernel
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/mcmc_gaussian_process.py
+++ b/smac/model/gaussian_process/mcmc_gaussian_process.py
@@ -18,7 +18,7 @@ from smac.model.gaussian_process.abstract_gaussian_process import (
 from smac.model.gaussian_process.gaussian_process import GaussianProcess
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/priors/abstract_prior.py
+++ b/smac/model/gaussian_process/priors/abstract_prior.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import numpy as np
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/priors/gamma_prior.py
+++ b/smac/model/gaussian_process/priors/gamma_prior.py
@@ -7,7 +7,7 @@ import scipy.stats as sps
 
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/priors/horseshoe_prior.py
+++ b/smac/model/gaussian_process/priors/horseshoe_prior.py
@@ -9,7 +9,7 @@ import numpy as np
 from smac.constants import VERY_SMALL_NUMBER
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/priors/log_normal_prior.py
+++ b/smac/model/gaussian_process/priors/log_normal_prior.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/gaussian_process/priors/tophat_prior.py
+++ b/smac/model/gaussian_process/priors/tophat_prior.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/multi_objective_model.py
+++ b/smac/model/multi_objective_model.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from smac.model.abstract_model import AbstractModel
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/random_forest/abstract_random_forest.py
+++ b/smac/model/random_forest/abstract_random_forest.py
@@ -13,7 +13,7 @@ from ConfigSpace import (
 
 from smac.model.abstract_model import AbstractModel
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/random_forest/random_forest.py
+++ b/smac/model/random_forest/random_forest.py
@@ -11,7 +11,7 @@ from pyrfr.regression import default_data_container as DataContainer
 from smac.constants import N_TREES, VERY_SMALL_NUMBER
 from smac.model.random_forest import AbstractRandomForest
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/model/random_model.py
+++ b/smac/model/random_model.py
@@ -5,7 +5,7 @@ import numpy as np
 from smac.model.abstract_model import AbstractModel
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/multi_objective/abstract_multi_objective_algorithm.py
+++ b/smac/multi_objective/abstract_multi_objective_algorithm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/random_design/abstract_random_design.py
+++ b/smac/random_design/abstract_random_design.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/random_design/annealing_design.py
+++ b/smac/random_design/annealing_design.py
@@ -7,7 +7,7 @@ import numpy as np
 from smac.random_design.abstract_random_design import AbstractRandomDesign
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/random_design/modulus_design.py
+++ b/smac/random_design/modulus_design.py
@@ -7,7 +7,7 @@ import numpy as np
 from smac.random_design.abstract_random_design import AbstractRandomDesign
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/random_design/probability_design.py
+++ b/smac/random_design/probability_design.py
@@ -5,7 +5,7 @@ from typing import Any
 from smac.random_design.abstract_random_design import AbstractRandomDesign
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/runhistory/dataclasses.py
+++ b/smac/runhistory/dataclasses.py
@@ -8,7 +8,7 @@ from ConfigSpace import Configuration
 
 from smac.runhistory.enumerations import StatusType
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/encoder/abstract_encoder.py
+++ b/smac/runhistory/encoder/abstract_encoder.py
@@ -12,7 +12,7 @@ from smac.scenario import Scenario
 from smac.utils.configspace import convert_configurations_to_array
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/encoder/boing_encoder.py
+++ b/smac/runhistory/encoder/boing_encoder.py
@@ -9,7 +9,7 @@
 # from smac.runhistory.runhistory import RunHistory
 # from smac.utils.logging import get_logger
 
-# __copyright__ = "Copyright 2022, automl.org"
+# __copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 # __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/encoder/eips_encoder.py
+++ b/smac/runhistory/encoder/eips_encoder.py
@@ -10,7 +10,7 @@ from smac.utils.configspace import convert_configurations_to_array
 from smac.utils.logging import get_logger
 from smac.utils.multi_objective import normalize_costs
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/encoder/encoder.py
+++ b/smac/runhistory/encoder/encoder.py
@@ -10,7 +10,7 @@ from smac.utils.configspace import convert_configurations_to_array
 from smac.utils.logging import get_logger
 from smac.utils.multi_objective import normalize_costs
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/encoder/inverse_scaled_encoder.py
+++ b/smac/runhistory/encoder/inverse_scaled_encoder.py
@@ -8,7 +8,7 @@ from smac import constants
 from smac.runhistory.encoder.encoder import RunHistoryEncoder
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/encoder/log_encoder.py
+++ b/smac/runhistory/encoder/log_encoder.py
@@ -6,7 +6,7 @@ from smac import constants
 from smac.runhistory.encoder.encoder import RunHistoryEncoder
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/encoder/log_scaled_encoder.py
+++ b/smac/runhistory/encoder/log_scaled_encoder.py
@@ -8,7 +8,7 @@ from smac import constants
 from smac.runhistory.encoder.encoder import RunHistoryEncoder
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/encoder/scaled_encoder.py
+++ b/smac/runhistory/encoder/scaled_encoder.py
@@ -6,7 +6,7 @@ from smac import constants
 from smac.runhistory.encoder.encoder import RunHistoryEncoder
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/encoder/sqrt_scaled_encoder.py
+++ b/smac/runhistory/encoder/sqrt_scaled_encoder.py
@@ -8,7 +8,7 @@ from smac import constants
 from smac.runhistory.encoder.encoder import RunHistoryEncoder
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/enumerations.py
+++ b/smac/runhistory/enumerations.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import IntEnum
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -26,7 +26,7 @@ from smac.utils.logging import get_logger
 from smac.utils.multi_objective import normalize_costs
 from smac.utils.numpyencoder import NumpyEncoder
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/runner/abstract_runner.py
+++ b/smac/runner/abstract_runner.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runner/dask_runner.py
+++ b/smac/runner/dask_runner.py
@@ -13,7 +13,7 @@ from smac.runhistory import StatusType, TrialInfo, TrialValue
 from smac.runner.abstract_runner import AbstractRunner
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/runner/target_function_runner.py
+++ b/smac/runner/target_function_runner.py
@@ -18,7 +18,7 @@ from smac.runner.abstract_serial_runner import AbstractSerialRunner
 from smac.scenario import Scenario
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/runner/target_function_script_runner.py
+++ b/smac/runner/target_function_script_runner.py
@@ -12,7 +12,7 @@ from smac.runner.abstract_serial_runner import AbstractSerialRunner
 from smac.scenario import Scenario
 from smac.utils.logging import get_logger
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 logger = get_logger(__name__)

--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -25,7 +25,7 @@ from ConfigSpace.util import (
     get_one_exchange_neighbourhood,
 )
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/smac/utils/logging.py
+++ b/smac/utils/logging.py
@@ -9,7 +9,7 @@ from typing_extensions import Literal
 
 import smac
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -8,7 +8,7 @@ from ConfigSpace import Categorical, Configuration, ConfigurationSpace, Float
 from sklearn.linear_model import SGDClassifier
 from sklearn.model_selection import StratifiedKFold, cross_val_score
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_acquisition/test_functions.py
+++ b/tests/test_acquisition/test_functions.py
@@ -13,7 +13,7 @@ from smac.acquisition.function import (
     PriorAcquisitionFunction,
 )
 
-__copyright__ = "Copyright 2022, automl.org"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_acquisition/test_maximizers.py
+++ b/tests/test_acquisition/test_maximizers.py
@@ -38,7 +38,7 @@ from smac.model.random_forest.random_forest import RandomForest
 from smac.runhistory.runhistory import RunHistory
 from smac.runner.abstract_runner import StatusType
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_ask_and_tell/test_ask_and_tell_intensifier.py
+++ b/tests/test_ask_and_tell/test_ask_and_tell_intensifier.py
@@ -5,7 +5,7 @@ import pytest
 from smac import HyperparameterOptimizationFacade, Scenario
 from smac.runhistory.dataclasses import TrialInfo, TrialValue
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_ask_and_tell/test_ask_and_tell_successive_halving.py
+++ b/tests/test_ask_and_tell/test_ask_and_tell_successive_halving.py
@@ -5,7 +5,7 @@ import pytest
 from smac import MultiFidelityFacade, Scenario
 from smac.runhistory.dataclasses import TrialInfo, TrialValue
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_initial_design/test_factorical_design.py
+++ b/tests/test_initial_design/test_factorical_design.py
@@ -9,7 +9,7 @@ from ConfigSpace import (
 
 from smac.initial_design.factorial_design import FactorialInitialDesign
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_initial_design/test_initial_design.py
+++ b/tests/test_initial_design/test_initial_design.py
@@ -3,7 +3,7 @@ import pytest
 from smac.initial_design import AbstractInitialDesign
 from smac.initial_design.default_design import DefaultInitialDesign
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_initial_design/test_latin_hypercube_design.py
+++ b/tests/test_initial_design/test_latin_hypercube_design.py
@@ -1,6 +1,6 @@
 from smac.initial_design.latin_hypercube_design import LatinHypercubeInitialDesign
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_initial_design/test_random_design.py
+++ b/tests/test_initial_design/test_random_design.py
@@ -1,6 +1,6 @@
 from smac.initial_design.random_design import RandomInitialDesign
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_initial_design/test_sobol_design.py
+++ b/tests/test_initial_design/test_sobol_design.py
@@ -3,7 +3,7 @@ from ConfigSpace import ConfigurationSpace, Float
 
 from smac.initial_design.sobol_design import SobolInitialDesign
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_model/_test_util_funcs.py
+++ b/tests/test_model/_test_util_funcs.py
@@ -12,7 +12,7 @@ from ConfigSpace.hyperparameters import (
 
 from smac.model.utils import check_subspace_points, get_types
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_model/test_abstract_model.py
+++ b/tests/test_model/test_abstract_model.py
@@ -4,7 +4,7 @@ import pytest
 from smac.model.abstract_model import AbstractModel
 from smac.utils.configspace import convert_configurations_to_array
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_model/test_gp.py
+++ b/tests/test_model/test_gp.py
@@ -16,7 +16,7 @@ from smac.model.gaussian_process.gaussian_process import GaussianProcess
 from smac.model.gaussian_process.priors import HorseshoePrior, LogNormalPrior
 from smac.utils.configspace import convert_configurations_to_array
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_model/test_gp_mcmc.py
+++ b/tests/test_model/test_gp_mcmc.py
@@ -9,7 +9,7 @@ from ConfigSpace import ConfigurationSpace, UniformFloatHyperparameter
 from smac.model.gaussian_process.mcmc_gaussian_process import MCMCGaussianProcess
 from smac.model.gaussian_process.priors import HorseshoePrior, LogNormalPrior
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_model/test_gp_priors.py
+++ b/tests/test_model/test_gp_priors.py
@@ -13,7 +13,7 @@ from smac.model.gaussian_process.priors import (
     TophatPrior,
 )
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_model/test_mo.py
+++ b/tests/test_model/test_mo.py
@@ -7,7 +7,7 @@ from ConfigSpace import ConfigurationSpace, UniformFloatHyperparameter
 from smac.model.multi_objective_model import MultiObjectiveModel
 from smac.model.random_forest.random_forest import RandomForest
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_model/test_rf.py
+++ b/tests/test_model/test_rf.py
@@ -12,7 +12,7 @@ from ConfigSpace import (
 from smac.model.random_forest.random_forest import RandomForest
 from smac.utils.configspace import convert_configurations_to_array
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_multi_objective/test_combined_function.py
+++ b/tests/test_multi_objective/test_combined_function.py
@@ -21,7 +21,7 @@ from smac.scenario import Scenario
 
 FACADES = [BBFacade, HPOFacade, MFFacade, RFacade, HBFacade, ACFacade]
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_multi_objective/test_multi_objective.py
+++ b/tests/test_multi_objective/test_multi_objective.py
@@ -2,7 +2,7 @@ import pytest
 
 from smac.utils.multi_objective import normalize_costs
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_random_design/test_annealing_design.py
+++ b/tests/test_random_design/test_annealing_design.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from smac.random_design.annealing_design import CosineAnnealingRandomDesign
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_random_design/test_modulus_design.py
+++ b/tests/test_random_design/test_modulus_design.py
@@ -3,7 +3,7 @@ from smac.random_design.modulus_design import (
     ModulusRandomDesign,
 )
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_random_design/test_probability_design.py
+++ b/tests/test_random_design/test_probability_design.py
@@ -5,7 +5,7 @@ from smac.random_design.probability_design import (
     ProbabilityRandomDesign,
 )
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_random_design/test_random_design.py
+++ b/tests/test_random_design/test_random_design.py
@@ -5,7 +5,7 @@ from smac.random_design.modulus_design import (
 )
 from smac.random_design.probability_design import ProbabilityRandomDesign
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_runhistory/test_runhistory.py
+++ b/tests/test_runhistory/test_runhistory.py
@@ -9,7 +9,7 @@ import pytest
 from smac.runhistory.runhistory import RunHistory, TrialKey
 from smac.runner.abstract_runner import StatusType
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_runhistory/test_runhistory_multi_objective.py
+++ b/tests/test_runhistory/test_runhistory_multi_objective.py
@@ -7,7 +7,7 @@ from smac.multi_objective.aggregation_strategy import MeanAggregationStrategy
 from smac.runner.abstract_runner import StatusType
 from smac.scenario import Scenario
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_runner/test_dask_runner.py
+++ b/tests/test_runner/test_dask_runner.py
@@ -17,7 +17,7 @@ from smac.scenario import Scenario
 # https://github.com/dask/distributed/issues/4168
 # import multiprocessing.popen_spawn_posix  # noqa
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 

--- a/tests/test_runner/test_target_algorithm_runner.py
+++ b/tests/test_runner/test_target_algorithm_runner.py
@@ -12,7 +12,7 @@ from smac.runner.abstract_runner import StatusType
 from smac.runner.target_function_runner import TargetFunctionRunner
 from smac.scenario import Scenario
 
-__copyright__ = "Copyright 2021, AutoML.org Freiburg-Hannover"
+__copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
 
 


### PR DESCRIPTION
Update Copyright to 2025
- Updated all copyright statements to 2025.
- Changed organization name where applicable.