### PR TITLE
#946 Purely operating Ask & Tell removes requirement for target_function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - New SMAC logo
 - Fix doc link in README
 
+## Improvements
+- `target_function` becomes optional in Facade when using ask and tell exclusively (#946)
+
 # 2.3.0
 
 ## Documentation

--- a/docs/advanced_usage/5_ask_and_tell.md
+++ b/docs/advanced_usage/5_ask_and_tell.md
@@ -15,5 +15,7 @@ and report the results of the trial.
     different budgets, they, obviously, can not be considered. However, all user-provided configurations will flow 
     into the intensification process.
 
+Notice: if you are exclusively using the ask-and-tell interface and do not use `smac.optimize()`, then smac no longer
+is responsible for the evaluation of the trials and therefor the Facade no longer will require a specified `target_algorithm` argument.
 
 Please have a look at our [ask-and-tell example](../examples/1%20Basics/3_ask_and_tell.md).

--- a/docs/advanced_usage/5_ask_and_tell.md
+++ b/docs/advanced_usage/5_ask_and_tell.md
@@ -16,6 +16,6 @@ and report the results of the trial.
     into the intensification process.
 
 Notice: if you are exclusively using the ask-and-tell interface and do not use `smac.optimize()`, then smac no longer
-is responsible for the evaluation of the trials and therefor the Facade no longer will require a specified `target_algorithm` argument.
+is responsible for the evaluation of the trials and therefore the Facade no longer will require a specified `target_algorithm` argument.
 
 Please have a look at our [ask-and-tell example](../examples/1%20Basics/3_ask_and_tell.md).

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -108,8 +108,8 @@ class AbstractFacade:
     def __init__(
         self,
         scenario: Scenario,
-        *,
         target_function: Callable | str | AbstractRunner | None = None,
+        *,
         model: AbstractModel | None = None,
         acquisition_function: AbstractAcquisitionFunction | None = None,
         acquisition_maximizer: AbstractAcquisitionMaximizer | None = None,


### PR DESCRIPTION
when using purely `ask` and `tell` instead of `optimize`, then smac does not need to know about the `target_function` and we can just drop the requirement by setting it to `None`. Should the user then however decide to call optimize, this must raise an ValueError. A few type checks and raises are necessary to ensure proper flow.