### PR TITLE
Actual PR for docs/mkdocs-migration-cleanup

### DIFF
--- a/examples/4_advanced_optimizer/4_intensify_crossvalidation.py
+++ b/examples/4_advanced_optimizer/4_intensify_crossvalidation.py
@@ -2,7 +2,7 @@
 # Flags: doc-Runnable
 
 An example of optimizing a simple support vector machine on the digits dataset. In contrast to the
-[simple example](../../1_basics/2_svm_cv), in which all cross-validation folds are executed
+[simple example](/examples/1%20Basics/2_svm_cv/), in which all cross-validation folds are executed
 at once, we use the intensification mechanism described in the original 
 [SMAC paper](https://link.springer.com/chapter/10.1007/978-3-642-25566-3_40) as also demonstrated
 by [Auto-WEKA](https://dl.acm.org/doi/10.1145/2487575.2487629). This mechanism allows us to

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -153,7 +153,7 @@ plugins:
         python:
           paths: [smac]
           # Extra objects which allow for linking to external docs
-          import:
+          inventories:
             - 'https://docs.python.org/3/objects.inv'
             - 'https://numpy.org/doc/stable/objects.inv'
             - 'https://pandas.pydata.org/docs/objects.inv'
@@ -197,12 +197,14 @@ nav:
   - Installation: "1_installation.md"
   - Package Overview: "2_package_overview.md"
   - Getting Started: "3_getting_started.md"
+  - Minimal Example: "4_minimal_example.md"
   - Advanced Usage:
     - "advanced_usage/1_components.md"
     - "advanced_usage/2_multi_fidelity.md"
     - "advanced_usage/3_multi_objective.md"
     - "advanced_usage/4_instances.md"
     - "advanced_usage/5_ask_and_tell.md"
+    - "advanced_usage/5.1_warmstarting.md"
     - "advanced_usage/6_commandline.md"
     - "advanced_usage/7_stopping_criteria.md"
     - "advanced_usage/8_logging.md"
@@ -219,6 +221,9 @@ nav:
     - "6_references.md"
     - "7_glossary.md"
     - "8_faq.md"
+    - "9_license.md"
+    - "10_experimental.md"
+    - "images/README.md"
   # - Contributing:
   #   - "contributing/index.md"
   #   - "contributing/contributing-a-benchmark.md"

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,8 @@
+Problem: Parameters and :math: not working properly
+
+Hypothesis: These seem to be sphinx (.rst) type, so that means SMAC might have at some point changed from 
+sphinx to mkdocs, which is causing the problem.
+
+Solution: That actually turned out to be true, SMAC changed from sphinx to mkdocs in v2.3.0 (commit 64058a9).
+So the most straight forward option seems to be to change docstring_type to numpy (from google), and replace 
+:math: with $$ which is supported in mkdocs.

--- a/smac/acquisition/function/confidence_bound.py
+++ b/smac/acquisition/function/confidence_bound.py
@@ -21,7 +21,7 @@ class AbstractConfidenceBound(AbstractAcquisitionFunction):
 
     Example for LCB (UCB adds the variance term instead of subtracting it):
 
-    $LCB(X) = \mu(\mathbf{X}) - \sqrt{\beta_t}\sigma(\mathbf{X})$ [SKKS10](../../../docs/6_references).
+    $LCB(X) = \mu(\mathbf{X}) - \sqrt{\beta_t}\sigma(\mathbf{X})$ [SKKS10](/6_references/#SKKS10).
 
     with
 

--- a/smac/acquisition/function/probability_improvement.py
+++ b/smac/acquisition/function/probability_improvement.py
@@ -19,10 +19,9 @@ logger = get_logger(__name__)
 class PI(AbstractAcquisitionFunction):
     r"""Probability of Improvement
 
-    $$
-    P(f_{t+1}(\mathbf{X})\geq f(\mathbf{X^+})) := \Phi\left(\frac{ \mu(\mathbf{X})-f(\mathbf{X^+}) }{ \sigma(\mathbf{X}) }\right)
-    $$
-    with $f(X^+)$ as the incumbent and $\Phi$ the cdf of the standard normal.
+    :math:`P(f_{t+1}(\mathbf{X})\geq f(\mathbf{X^+}))` :math:`:=`
+    :math:`\Phi(\\frac{ \mu(\mathbf{X})-f(\mathbf{X^+}) }{ \sigma(\mathbf{X}) })`
+    with :math:`f(X^+)` as the incumbent and :math:`\Phi` the cdf of the standard normal.
 
     Parameters
     ----------

--- a/smac/acquisition/function/thompson.py
+++ b/smac/acquisition/function/thompson.py
@@ -23,11 +23,6 @@ class TS(AbstractAcquisitionFunction):
 
     $TS(X) \sim \mathcal{N}(\mu(\mathbf{X}),\sigma(\mathbf{X}))$
     Returns -TS(X) as the acquisition_function optimizer maximizes the acquisition value.
-
-    Parameters
-    ----------
-    xi : float, defaults to 0.0
-        TS does not require xi here, we only wants to make it consistent with other acquisition functions.
     """
 
     @property

--- a/smac/acquisition/maximizer/abstract_acquisition_maximizer.py
+++ b/smac/acquisition/maximizer/abstract_acquisition_maximizer.py
@@ -27,10 +27,15 @@ class AbstractAcquisitionMaximizer:
 
     Parameters
     ----------
-    configspace : ConfigurationSpace acquisition_function : AbstractAcquisitionFunction
-    challengers : int, defaults to 5000 Number of configurations sampled during the optimization process,
-    details depend on the used maximizer. Also, the number of configurations that is returned by calling `maximize`.
+    configspace : ConfigurationSpace
+        Configuration space used for sampling.
+    acquisition_function : AbstractAcquisitionFunction | None, defaults to None
+        Acquisition function to maximize.
+    challengers : int, defaults to 5000
+        Number of configurations sampled during the optimization process. Details depend on the used maximizer.
+        Also, the number of configurations that is returned by calling `maximize`.
     seed : int, defaults to 0
+        Random seed.
     """
 
     def __init__(

--- a/smac/acquisition/maximizer/differential_evolution.py
+++ b/smac/acquisition/maximizer/differential_evolution.py
@@ -22,13 +22,15 @@ def check_kwarg(cls: type, kwarg_name: str) -> bool:
 
     Parameters
     ----------
-        cls (type): The class to inspect.
-        kwarg_name (str): The name of the keyword argument to check.
+    cls : type
+        The class to inspect.
+    kwarg_name : str
+        The name of the keyword argument to check.
 
     Returns
     -------
-        bool: True if the class's __init__ method accepts the keyword argument,
-              otherwise False.
+    bool
+        True if the class's __init__ method accepts the keyword argument, otherwise False.
     """
     # Get the signature of the class's __init__ method
     init_signature = inspect.signature(cls.__init__)  # type: ignore[misc]

--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -347,9 +347,6 @@ class AbstractFacade:
         ----------
         config : Configuration
             Configuration to validate
-        instances : list[str] | None, defaults to None
-            Which instances to validate. If None, all instances specified in the scenario are used.
-            In case that the budget type is real-valued, this argument is ignored.
         seed : int | None, defaults to None
             If None, the seed from the scenario is used.
 

--- a/smac/facade/blackbox_facade.py
+++ b/smac/facade/blackbox_facade.py
@@ -239,7 +239,7 @@ class BlackBoxFacade(AbstractFacade):
         scenario: Scenario,
         *,
         n_configs: int | None = None,
-        n_configs_per_hyperparamter: int = 8,
+        n_configs_per_hyperparameter: int = 8,
         max_ratio: float = 0.25,
         additional_configs: list[Configuration] = None,
     ) -> SobolInitialDesign:
@@ -257,7 +257,7 @@ class BlackBoxFacade(AbstractFacade):
         max_ratio: float, defaults to 0.25
             Use at most ``scenario.n_trials`` * ``max_ratio`` number of configurations in the initial design.
             Additional configurations are not affected by this parameter.
-        additional_configs: list[Configuration], defaults to []
+        additional_configs: list[Configuration], defaults to None
             Adds additional configurations to the initial design.
         """
         if additional_configs is None:
@@ -265,7 +265,7 @@ class BlackBoxFacade(AbstractFacade):
         return SobolInitialDesign(
             scenario=scenario,
             n_configs=n_configs,
-            n_configs_per_hyperparameter=n_configs_per_hyperparamter,
+            n_configs_per_hyperparameter=n_configs_per_hyperparameter,
             max_ratio=max_ratio,
             additional_configs=additional_configs,
             seed=scenario.seed,

--- a/smac/facade/hyperparameter_optimization_facade.py
+++ b/smac/facade/hyperparameter_optimization_facade.py
@@ -136,7 +136,7 @@ class HyperparameterOptimizationFacade(AbstractFacade):
         scenario: Scenario,
         *,
         n_configs: int | None = None,
-        n_configs_per_hyperparamter: int = 10,
+        n_configs_per_hyperparameter: int = 10,
         max_ratio: float = 0.25,
         additional_configs: list[Configuration] | None = None,
     ) -> SobolInitialDesign:
@@ -154,13 +154,13 @@ class HyperparameterOptimizationFacade(AbstractFacade):
         max_ratio: float, defaults to 0.25
             Use at most ``scenario.n_trials`` * ``max_ratio`` number of configurations in the initial design.
             Additional configurations are not affected by this parameter.
-        additional_configs: list[Configuration], defaults to []
+        additional_configs: list[Configuration], defaults to None
             Adds additional configurations to the initial design.
         """
         return SobolInitialDesign(
             scenario=scenario,
             n_configs=n_configs,
-            n_configs_per_hyperparameter=n_configs_per_hyperparamter,
+            n_configs_per_hyperparameter=n_configs_per_hyperparameter,
             max_ratio=max_ratio,
             additional_configs=additional_configs,
         )

--- a/smac/facade/multi_fidelity_facade.py
+++ b/smac/facade/multi_fidelity_facade.py
@@ -72,7 +72,7 @@ class MultiFidelityFacade(HyperparameterOptimizationFacade):
         scenario: Scenario,
         *,
         n_configs: int | None = None,
-        n_configs_per_hyperparamter: int = 10,
+        n_configs_per_hyperparameter: int = 10,
         max_ratio: float = 0.25,
         additional_configs: list[Configuration] = None,
     ) -> RandomInitialDesign:
@@ -90,7 +90,7 @@ class MultiFidelityFacade(HyperparameterOptimizationFacade):
         max_ratio: float, defaults to 0.25
             Use at most ``scenario.n_trials`` * ``max_ratio`` number of configurations in the initial design.
             Additional configurations are not affected by this parameter.
-        additional_configs: list[Configuration], defaults to []
+        additional_configs: list[Configuration], defaults to None
             Adds additional configurations to the initial design.
         """
         if additional_configs is None:
@@ -98,7 +98,7 @@ class MultiFidelityFacade(HyperparameterOptimizationFacade):
         return RandomInitialDesign(
             scenario=scenario,
             n_configs=n_configs,
-            n_configs_per_hyperparameter=n_configs_per_hyperparamter,
+            n_configs_per_hyperparameter=n_configs_per_hyperparameter,
             max_ratio=max_ratio,
             additional_configs=additional_configs,
         )

--- a/smac/model/gaussian_process/gaussian_process.py
+++ b/smac/model/gaussian_process/gaussian_process.py
@@ -101,7 +101,7 @@ class GaussianProcess(AbstractGaussianProcess):
         ----------
         X : np.ndarray [#samples, #hyperparameters + #features]
             Input data points.
-        Y : np.ndarray [#samples, #objectives]
+        y : np.ndarray [#samples, #objectives]
             The corresponding target values.
         optimize_hyperparameters: boolean
             If set to true, the hyperparameters are optimized, otherwise the default hyperparameters of the kernel are
@@ -276,9 +276,9 @@ class GaussianProcess(AbstractGaussianProcess):
 
         Parameters
         ----------
-        X : np.ndarray [#samples, #hyperparameters + #features]
+        X_test : np.ndarray [#samples, #hyperparameters + #features]
             Input data points.
-        n_funcs: int
+        n_funcs : int
             Number of function values that are drawn at each test point.
 
         Returns

--- a/smac/model/random_forest/random_forest.py
+++ b/smac/model/random_forest/random_forest.py
@@ -113,11 +113,11 @@ class EPMRandomForest(ForestRegressor):
         Parameters
         ----------
         n_estimators : int, default=100
-        The number of trees in the forest.
+            The number of trees in the forest.
 
-        .. versionchanged:: 0.22
-           The default value of ``n_estimators`` changed from 10 to 100
-           in 0.22.
+            .. versionchanged:: 0.22
+                The default value of ``n_estimators`` changed from 10 to 100
+                in 0.22.
 
         criterion : {"squared_error", "absolute_error", "friedman_mse", "poisson"}, \
                 default="squared_error"

--- a/smac/random_design/modulus_design.py
+++ b/smac/random_design/modulus_design.py
@@ -51,15 +51,15 @@ class DynamicModulusRandomDesign(AbstractRandomDesign):
     Parameters
     ----------
     start_modulus : float, defaults to 2.0
-       Initially, every modulus-th configuration will be at random.
+          Initially, every modulus-th configuration will be at random.
     modulus_increment : float, defaults to 0.3
-       Increase modulus by this amount in every iteration.
+          Increase modulus by this amount in every iteration.
     end_modulus : float, defaults to np.inf
-       The maximum modulus ever used. If the value is reached before the optimization
-       is over, it is not further increased. If it is not reached before the optimization is over,
-       there will be no adjustment to make sure that the `end_modulus` is reached.
+          The maximum modulus ever used. If the value is reached before the optimization
+          is over, it is not further increased. If it is not reached before the optimization is over,
+          there will be no adjustment to make sure that the `end_modulus` is reached.
     seed : int, defaults to 0
-        Integer used to initialize the random state. This class does not use the seed.
+          Integer used to initialize the random state. This class does not use the seed.
     """
 
     def __init__(

--- a/smac/runhistory/runhistory.py
+++ b/smac/runhistory/runhistory.py
@@ -307,8 +307,10 @@ class RunHistory(Mapping[TrialKey, TrialValue]):
 
         Parameters
         ----------
-        trial : TrialInfo
+        info : TrialInfo
             The ``TrialInfo`` object of the running trial.
+        value : TrialValue
+            The ``TrialValue`` object of the running trial.
         """
         self.add(
             config=info.config,


### PR DESCRIPTION
Cleanup documentation after mkdocs migration.

In particular, this pull request fixes issues in the documentation with unformatted mathematical formulas and malformatted parameter lists.

Originally opened by @sagar1sharma 