### PR TITLE
Add ommitted forbidden relations to uniform copy of config space

### DIFF
--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -278,4 +278,6 @@ def create_uniform_configspace_copy(
         new_configuration_space.add(new_hyperparameter)
     conditions = configspace.conditions
     new_configuration_space.add(conditions)
+    forbidden_clauses = configspace.forbidden_clauses
+    new_configuration_space.add(forbidden_clauses)
     return new_configuration_space


### PR DESCRIPTION
Add forbidden clauses from original config space to newly created instance with uniformly distributed hyperparameters during initial random sampling.

#### Reference Issues/PRs
Fixes #1306 

#### Description, Motivation and Context
I was getting crashes when running smac3 v2.4.0 because the configs generated during the initial random sampling phase weren't satisfying the forbidden clauses.

#### Changes
The code does the same thing for forbidden clauses that is already being done for conditions.

#### Type Of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### What is Missing?
- code review

#### Checklist
- [x] My change is based on the latest stage of the `develop` branch.
- [ ] My change required a change of the documentation, which has been done.
- [ ] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
- [ ] I have added/adapted tests to cover my changes.
- [ ] The tests can be executed successfully.
- [ ] I have added a description of the changes to `CHANGELOG.rst`.

#### Any other comments?
Not sure, since this is a bugfix, am I supposed to also make a pull request on the main branch?