### PR TITLE
Prevent model failure due to non-finite objective values from crashed runs

### DIFF
--- a/smac/runhistory/encoder/eips_encoder.py
+++ b/smac/runhistory/encoder/eips_encoder.py
@@ -25,6 +25,11 @@ class RunHistoryEIPSEncoder(AbstractRunHistoryEncoder):
         trials: Mapping[TrialKey, TrialValue],
         store_statistics: bool = False,
     ) -> tuple[np.ndarray, np.ndarray]:
+        if len(trials) == 0:
+            X = np.empty((0, self._n_params + self._n_features))
+            y = np.empty((0, 2))
+            return X, y
+
         if store_statistics:
             # store_statistics is currently not necessary
             pass
@@ -33,7 +38,9 @@ class RunHistoryEIPSEncoder(AbstractRunHistoryEncoder):
         n_rows = len(trials)
         n_cols = self._n_params
         X = np.ones([n_rows, n_cols + self._n_features]) * np.nan
-        y = np.ones([n_rows, 2])
+
+        n_obj = self._n_objectives
+        y_raw = np.zeros([n_rows, n_obj + 1], dtype=float)
 
         # Then populate matrix
         for row, (key, run) in enumerate(trials.items()):
@@ -47,19 +54,46 @@ class RunHistoryEIPSEncoder(AbstractRunHistoryEncoder):
             else:
                 X[row, :] = conf_vector
 
-            if self._n_objectives > 1:
-                assert self._multi_objective_algorithm is not None
-                assert isinstance(run.cost, list)
-
-                # Let's normalize y here
-                # We use the objective_bounds calculated by the runhistory
-                y_ = normalize_costs(run.cost, self.runhistory.objective_bounds)
-                y_agg = self._multi_objective_algorithm(y_)
-                y[row, 0] = y_agg
+            if n_obj == 1:
+                y_raw[row, 0] = run.cost
             else:
-                y[row, 0] = run.cost
+                y_raw[row, :n_obj] = np.asarray(run.cost, dtype=float)
 
-            y[row, 1] = run.time
+            y_raw[row, -1] = float(run.time)
+
+        obj_matrix = y_raw[:, :n_obj]
+
+        finite_mask = np.isfinite(obj_matrix)
+
+        # compute per-objective max finite
+        max_finite = np.where(finite_mask, obj_matrix, -np.inf).max(axis=0)
+
+        # fail if any objective is completely invalid
+        if np.any(~finite_mask.any(axis=0)):
+            bad = np.where(~finite_mask.any(axis=0))[0]
+            raise ValueError(f"No finite values found for objectives {bad}")
+
+        # replace invalid values
+        obj_matrix = np.where(finite_mask, obj_matrix, max_finite)
+
+        # write back
+        y_raw[:, :n_obj] = obj_matrix
+
+        y = np.zeros((n_rows, 2), dtype=float)
+
+        if n_obj == 1:
+            y[:, 0] = y_raw[:, 0]
+            y[:, 1] = y_raw[:, -1]
+
+        else:
+            assert self._multi_objective_algorithm is not None
+
+            bounds = self.runhistory.objective_bounds
+
+            for row in range(n_rows):
+                y_norm = normalize_costs(y_raw[row, :n_obj], bounds)
+                y[row, 0] = self._multi_objective_algorithm(y_norm)
+                y[row, 1] = y_raw[row, -1]
 
         y_transformed = self.transform_response_values(values=y)
 

--- a/smac/runhistory/encoder/eips_encoder.py
+++ b/smac/runhistory/encoder/eips_encoder.py
@@ -65,16 +65,14 @@ class RunHistoryEIPSEncoder(AbstractRunHistoryEncoder):
 
         finite_mask = np.isfinite(obj_matrix)
 
-        # compute per-objective max finite
-        max_finite = np.where(finite_mask, obj_matrix, -np.inf).max(axis=0)
+        # Worst observed finite value per objective.
+        max_finite = np.array([self.runhistory.objective_bounds[o][1] for o in range(n_obj)], dtype=float)
 
-        # fail if any objective is completely invalid
-        if np.any(~finite_mask.any(axis=0)):
-            bad = np.where(~finite_mask.any(axis=0))[0]
-            raise ValueError(f"No finite values found for objectives {bad}")
-
-        # replace invalid values
-        obj_matrix = np.where(finite_mask, obj_matrix, max_finite)
+        # Replace inf/nan objective values (e.g. from crashed runs)
+        if not np.any(finite_mask):
+            obj_matrix[:] = max_finite
+        else:
+            obj_matrix = np.where(finite_mask, obj_matrix, max_finite)
 
         # write back
         y_raw[:, :n_obj] = obj_matrix

--- a/smac/runhistory/encoder/encoder.py
+++ b/smac/runhistory/encoder/encoder.py
@@ -23,14 +23,18 @@ class RunHistoryEncoder(AbstractRunHistoryEncoder):
         trials: Mapping[TrialKey, TrialValue],
         store_statistics: bool = False,
     ) -> tuple[np.ndarray, np.ndarray]:
+        if len(trials) == 0:
+            X = np.empty((0, self._n_params + self._n_features))
+            y = np.empty((0, 1))
+            return X, y
+
         # First build nan-matrix of size #configs x #params+1
         n_rows = len(trials)
         n_cols = self._n_params
         X = np.ones([n_rows, n_cols + self._n_features]) * np.nan
 
-        # For now we keep it as 1
-        # TODO: Extend for native multi-objective
-        y = np.ones([n_rows, 1])
+        n_obj = self._n_objectives
+        y_raw = np.zeros((n_rows, n_obj), dtype=float) if n_obj > 1 else np.zeros((n_rows, 1))
 
         # Then populate matrix
         for row, (key, run) in enumerate(trials.items()):
@@ -45,17 +49,38 @@ class RunHistoryEncoder(AbstractRunHistoryEncoder):
             else:
                 X[row, :] = conf_vector
 
-            if self._n_objectives > 1:
-                assert self._multi_objective_algorithm is not None
-                assert isinstance(run.cost, list)
-
-                # Let's normalize y here
-                # We use the objective_bounds calculated by the runhistory
-                y_ = normalize_costs(run.cost, self.runhistory.objective_bounds)
-                y_agg = self._multi_objective_algorithm(y_)
-                y[row] = y_agg
+            if n_obj == 1:
+                y_raw[row, 0] = run.cost
             else:
-                y[row] = run.cost
+                cost = np.array(run.cost, dtype=float)
+                y_raw[row, :] = cost
+
+        finite_mask = np.isfinite(y_raw)
+
+        # compute per-objective max finite
+        max_finite = np.where(finite_mask, y_raw, -np.inf).max(axis=0)
+
+        # fail if any objective is completely invalid
+        if np.any(~finite_mask.any(axis=0)):
+            bad = np.where(~finite_mask.any(axis=0))[0]
+            raise ValueError(f"No finite values found for objectives {bad}")
+
+        # replace invalid values
+        y_raw = np.where(finite_mask, y_raw, max_finite)
+
+        y = np.zeros((n_rows, 1), dtype=float)
+
+        if n_obj == 1:
+            y = y_raw
+
+        else:
+            assert self._multi_objective_algorithm is not None
+
+            bounds = self.runhistory.objective_bounds
+
+            for row in range(n_rows):
+                y_norm = normalize_costs(y_raw[row], bounds)
+                y[row] = self._multi_objective_algorithm(y_norm)
 
         if y.size > 0:
             if store_statistics:

--- a/smac/runhistory/encoder/encoder.py
+++ b/smac/runhistory/encoder/encoder.py
@@ -57,16 +57,14 @@ class RunHistoryEncoder(AbstractRunHistoryEncoder):
 
         finite_mask = np.isfinite(y_raw)
 
-        # compute per-objective max finite
-        max_finite = np.where(finite_mask, y_raw, -np.inf).max(axis=0)
+        # Worst observed finite value per objective.
+        max_finite = np.array([self.runhistory.objective_bounds[o][1] for o in range(n_obj)], dtype=float)
 
-        # fail if any objective is completely invalid
-        if np.any(~finite_mask.any(axis=0)):
-            bad = np.where(~finite_mask.any(axis=0))[0]
-            raise ValueError(f"No finite values found for objectives {bad}")
-
-        # replace invalid values
-        y_raw = np.where(finite_mask, y_raw, max_finite)
+        # Replace inf/nan objective values (e.g. from crashed runs)
+        if not np.any(finite_mask):
+            y_raw[:] = max_finite
+        else:
+            y_raw = np.where(finite_mask, y_raw, max_finite)
 
         y = np.zeros((n_rows, 1), dtype=float)
 


### PR DESCRIPTION
This PR improves robustness of the surrogate model training by preventing non-finite objective values (e.g. from crashed runs) from propagating into the model pipeline. Previously, crashed runs could produce `inf` values that were passed through the runhistory encoder step and eventually caused failures during model fitting.

To address this, this PR:
- Detects non-finite objective values during runhistory encoding.
- Replaces them with the (per-objective) maximum observed value from `runhistory.objective_bounds`.
- Ensures consistent handling across different RunhistoryEncoders for single- and multi-objective cases.