### PR TITLE
Fix random forest import with scikit-learn 1.9

### DIFF
--- a/smac/model/random_forest/random_forest.py
+++ b/smac/model/random_forest/random_forest.py
@@ -11,7 +11,6 @@ from scipy.sparse import issparse
 from sklearn.ensemble._base import _partition_estimators
 from sklearn.ensemble._forest import ForestRegressor
 from sklearn.tree import DecisionTreeRegressor
-from sklearn.tree._tree import DTYPE
 from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import check_is_fitted, validate_data
 
@@ -624,7 +623,7 @@ class EPMRandomForest(ForestRegressor):
         X = validate_data(
             self,
             X,
-            dtype=DTYPE,
+            dtype=np.float32,
             accept_sparse="csr",
             reset=False,
             ensure_all_finite=ensure_all_finite,


### PR DESCRIPTION
#### Reference Issues/PRs
See scikit-learn/scikit-learn#33948.
Related downstream report: automl/mighty_dr_example#1.

#### Description, Motivation and Context
scikit-learn 1.9 removed the private `sklearn.tree._tree.DTYPE` alias. SMAC's sklearn-based random forest currently imports that private symbol, so importing SMAC fails with scikit-learn 1.9:

`ImportError: cannot import name 'DTYPE' from 'sklearn.tree._tree'`

scikit-learn replaced this internal alias with direct `np.float32` usage, so this PR does the same in SMAC.

#### Changes
- Remove the private `from sklearn.tree._tree import DTYPE` import.
- Use `np.float32` directly when validating random forest prediction input.

#### Type Of Changes
> What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### What is Missing?
Nothing known.

#### Checklist
> Go over all the following points, and put an `x` in all the boxes that apply.
> Should there be a good argument to differ, please provide a reasoned explanation.
- [x] My change is based on the latest stage of the `develop` branch.
- [ ] My change required a change of the documentation, which has been done.
- [ ] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
- [ ] I have added/adapted tests to cover my changes.
- [x] The tests can be executed successfully.
- [ ] I have added a description of the changes to `CHANGELOG.rst`.

#### Any other comments?
None