### PR TITLE
Feature/1321 initial warmup variants

### DIFF
--- a/smac/main/config_selector.py
+++ b/smac/main/config_selector.py
@@ -177,8 +177,24 @@ class ConfigSelector:
         logger.debug("Search for the next configuration...")
         self._call_callbacks_on_start()
 
+        # Configurations that are already in the runhistory at this point can be related
+        # to the initial design's own configurations in different ways depending on the warmstart mode.
+        initial_design_configs = self._initial_design_configs
+        n_warmstarted = len(self._processed_configs)
+
+        if n_warmstarted > 0:
+            mode = self._scenario.initial_design_warmstart_mode
+            if mode == "reduce_budget":
+                # The already-evaluated configs count against the initial design's budget: we only
+                # propose as many (still missing) configs as are needed to reach the original budget.
+                initial_design_configs = initial_design_configs[n_warmstarted:]
+            elif mode == "replace":
+                # The already-evaluated configs *are* the complete initial design.
+                initial_design_configs = []
+            # "additional" (default): the initial design is not affected at all.
+
         # First: We return the initial configurations
-        for config in self._initial_design_configs:
+        for config in initial_design_configs:
             if config not in self._processed_configs:
                 self._processed_configs.append(config)
                 self._call_callbacks_on_end(config)

--- a/smac/scenario.py
+++ b/smac/scenario.py
@@ -69,6 +69,19 @@ class Scenario:
         For historic benchmark reasons, this is False by default.
         Notice, that this will result in n_configs + 1 for the initial design. Respecting n_trials,
         this will result in one fewer evaluated configuration in the optimization.
+    initial_design_warmstart_mode : str, defaults to "additional"
+        Controls how configurations that are already in the runhistory before the first `ask()` call
+        (e.g. because they were passed via `tell()` for warmstarting, or because a previous run is being
+        continued) relate to the initial design's own configurations:
+        * ``"additional"``: The already-evaluated configurations are treated as pure extra information.
+          The initial design is not affected and still proposes its full, configured number of
+          configurations.
+        * ``"reduce_budget"``: The already-evaluated configurations count against the initial design's
+          budget. The initial design proposes only as many additional configurations as are still
+          missing to reach its originally configured number of configurations.
+        * ``"replace"``: The already-evaluated configurations are treated as the complete initial design.
+          The initial design does not propose any additional configurations of its own; SMAC moves on
+          directly to model-based optimization.
     instances : list[str] | None, defaults to None
         Names of the instances to use. If None, no instances are used.
         Instances could be dataset names, seeds, subsets, etc.
@@ -114,6 +127,7 @@ class Scenario:
     trial_memory_limit: int | None = None
     n_trials: int = 100
     use_default_config: bool = False
+    initial_design_warmstart_mode: str = "additional"
 
     # Algorithm Configuration
     instances: list[str] | None = None
@@ -150,6 +164,13 @@ class Scenario:
         # Validate that we have a runtime cutoff set if adaptive capping slackfactor is given
         if self.adaptive_capping_slackfactor is not None and self.runtime_cutoff is None:
             raise ValueError("If adaptive_capping_slackfactor is set, then runtime_cutoff must be set as well.")
+
+        valid_warmstart_modes = ("additional", "reduce_budget", "replace")
+        if self.initial_design_warmstart_mode not in valid_warmstart_modes:
+            raise ValueError(
+                f"`initial_design_warmstart_mode` must be one of {valid_warmstart_modes}, "
+                f"got {self.initial_design_warmstart_mode!r}."
+            )
 
         if self.objective_weights is not None:
             n_objectives = self.count_objectives()


### PR DESCRIPTION
> Thanks for contributing a pull request! Please ensure you have taken a look at the contribution guidelines: https://github.com/automl/SMAC3/blob/main/CONTRIBUTING.md

#### Reference Issues/PRs
> Implementation of Feature described in #1321

#### Description, Motivation and Context
As a data scientist, I want my already-calculated initial configuration to be included / to be taken note of / to be the only initial design in the HPO so that I can save compute resources.

#### Changes
> added additional feature into scenarios:  initial_design_warmstart_mode with the modes "additional", "reduce_budget", "replace".
> also, adjusted the config_selector for the warmstart informations

#### Type Of Changes
> What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### What is Missing?

#### Checklist
> Go over all the following points, and put an `x` in all the boxes that apply.
> Should there be a good argument to differ, please provide a reasoned explanation.
- [X] My change is based on the latest stage of the `develop` branch.
- [ ] My change required a change of the documentation, which has been done.
- [X] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
- [ ] I have added/adapted tests to cover my changes.
- [ ] The tests can be executed successfully.
- [ ] I have added a description of the changes to `CHANGELOG.rst`.

#### Any other comments?

> We appreciate your effort, but please be aware that we are not working full-time on this project. We welcome any contribution and value your effort, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
> 
> Thanks for contributing!