### PR TITLE
Angrimson bug fix collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.4.1
+## Bugfixes
+- Scikit-learn 1.9 deprecated an alias for np.float32 called DTYPE. Change removes references to deprecated alias (#1314)
+- Forbidden clauses weren't being preserved. Change fixes that and adds a test (#1306)
+- Tests were failing due to an incompatibility between pytest and pytest-cases.  Pytest-cases is a dead stub, so simplest fix is to remove it.
+
 # 2.4.0
 ## Improvements
 - Replace random forest from pyrfr with random forest from sklearn (#1246)

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,6 @@ extras_require = {
         "pillow",
         "cairosvg",
         "black",                # This allows mkdocstrings to format signatures in the docs
-        "pytest<8",
-        "pytest-coverage",
-        "pytest-cases>=3.8",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,9 @@ extras_require = {
         "pillow",
         "cairosvg",
         "black",                # This allows mkdocstrings to format signatures in the docs
-        "pytest",
+        "pytest<8",
         "pytest-coverage",
-        "pytest-cases",
+        "pytest-cases>=3.8",
     ],
 }
 

--- a/smac/model/random_forest/random_forest.py
+++ b/smac/model/random_forest/random_forest.py
@@ -11,7 +11,6 @@ from scipy.sparse import issparse
 from sklearn.ensemble._base import _partition_estimators
 from sklearn.ensemble._forest import ForestRegressor
 from sklearn.tree import DecisionTreeRegressor
-from sklearn.tree._tree import DTYPE
 from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import check_is_fitted, validate_data
 
@@ -624,7 +623,7 @@ class EPMRandomForest(ForestRegressor):
         X = validate_data(
             self,
             X,
-            dtype=DTYPE,
+            dtype=np.float32,
             accept_sparse="csr",
             reset=False,
             ensure_all_finite=ensure_all_finite,

--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -250,6 +250,10 @@ def create_uniform_configspace_copy(
 ) -> ConfigurationSpace:
     """Creates a copy of the given configuration space with uniform transformed hyperparameters.
 
+    Conditions and forbidden clauses are carried over as well. Forbidden clauses hold references
+    to the original hyperparameter objects, so they are rebuilt to point at the corresponding
+    hyperparameters in the new configuration space instead.
+
     Parameters
     ----------
     configspace : ConfigurationSpace

--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -278,4 +278,11 @@ def create_uniform_configspace_copy(
         new_configuration_space.add(new_hyperparameter)
     conditions = configspace.conditions
     new_configuration_space.add(conditions)
+    forbiddens = configspace.forbidden_clauses
+    if forbiddens:
+        new_configuration_space.add(
+            ConfigurationSpace.substitute_hyperparameters_in_forbiddens(
+                forbiddens, new_configuration_space
+            )
+        )
     return new_configuration_space

--- a/smac/utils/configspace.py
+++ b/smac/utils/configspace.py
@@ -281,8 +281,6 @@ def create_uniform_configspace_copy(
     forbiddens = configspace.forbidden_clauses
     if forbiddens:
         new_configuration_space.add(
-            ConfigurationSpace.substitute_hyperparameters_in_forbiddens(
-                forbiddens, new_configuration_space
-            )
+            ConfigurationSpace.substitute_hyperparameters_in_forbiddens(forbiddens, new_configuration_space)
         )
     return new_configuration_space

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,16 +25,6 @@ tests according to each avenue. See `test/test_automl` for example as the `autom
 module is quite complicated to test and all tests in a single file become difficult to
 follow and change.
 
-**pytest_cases**
-Using pytest_cases, we seperate a `case`, something that defines the state of the
-object, from the actual `test`, which tests properties of these cases.
-
-A complicated example can be seen at `test/test_automl/cases.py` where we have
-autoML instances that are classifier/regressor, fitted or not, with cv or holdout,
-or fitted with no ensemble. TODO: Easier example.
-
-Docs: https://smarie.github.io/python-pytest-cases/
-
 **Fixtures**
 All fixtures in "test/fixtures" are known in every test file. We try to make use
 of fixture `factories` which can be used to construct objects in complicated ways,

--- a/tests/test_utils/test_configspace.py
+++ b/tests/test_utils/test_configspace.py
@@ -5,6 +5,8 @@ from ConfigSpace import (
     CategoricalHyperparameter,
     ConfigurationSpace,
     Constant,
+    ForbiddenAndConjunction,
+    ForbiddenEqualsClause,
     NormalFloatHyperparameter,
     NormalIntegerHyperparameter,
     UniformFloatHyperparameter,
@@ -127,3 +129,20 @@ def test_create_uniform_configspace_copy(
 ):
     adapted_configspace = create_uniform_configspace_copy(non_uniform_configspace)
     assert adapted_configspace == uniform_configspace
+
+
+def test_create_uniform_configspace_copy_preserves_forbiddens():
+    cs = ConfigurationSpace(seed=42)
+    x = NormalFloatHyperparameter("x", mu=0.0, sigma=1.0, lower=-3.0, upper=3.0)
+    # default is "b", so the default config doesn't violate the forbidden clause
+    y = CategoricalHyperparameter("y", choices=["a", "b", "c"], default_value="b")
+    cs.add([x, y])
+    cs.add(ForbiddenAndConjunction(ForbiddenEqualsClause(x, -3.0), ForbiddenEqualsClause(y, "a")))
+
+    adapted = create_uniform_configspace_copy(cs)
+
+    assert len(adapted.forbidden_clauses) == 1
+    for _ in range(100):
+        config = adapted.sample_configuration()
+        config.check_valid_configuration()
+        assert not (config["x"] == -3.0 and config["y"] == "a")


### PR DESCRIPTION
2 bug fixes cherry-picked from dev branch.

#### Reference Issues/PRs
> Fixes #1306 and #1314

#### Problem Description and Changes
> Two bugs collected from dev.
> - scikit-learn 1.9 deprecated an alias for `np.float32` called `DTYPE`.  Change removes references to deprecated alias.
> - forbidden clauses weren't being preserved.  Change fixes that and adds a test.

#### Type Of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### What is Missing?
> n/a

#### Checklist
> Go over all the following points, and put an `x` in all the boxes that apply.
> Should there be a good argument to differ, please provide a reasoned explanation.
- [ ] My change is based on the latest stage of the `develop` branch.
- [ ] My change required a change of the documentation, which has been done.
- [ ] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
- [ ] I have added/adapted tests to cover my changes.
- [ ] The tests can be executed successfully.
- [ ] I have added a description of the changes to `CHANGELOG.rst`.

#### Any other comments?
I suggest updating version number to v2.4.1