### PR TITLE
Fix PCA preprocessing in marginalized RF prediction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Bugfixes
 - Fix `create_uniform_configspace_copy` not copying forbidden clauses, causing `RandomInitialDesign` to sample configs that violate the original search space's constraints (#1306)
+- Apply fitted PCA preprocessing to instance features when predicting marginalized costs with `RandomForest`.
 
 
 # 2.4.0

--- a/smac/model/random_forest/random_forest.py
+++ b/smac/model/random_forest/random_forest.py
@@ -816,6 +816,10 @@ class RandomForest(AbstractRandomForest):
         X = self._impute_inactive(X)
 
         X_feat = np.asarray(list(self._instance_features.values()))
+        if self._apply_pca:
+            X_feat = self._scaler.transform(X_feat)
+            X_feat = np.nan_to_num(X_feat)
+            X_feat = self._pca.transform(X_feat)
         dat_ = self._rf.predict_marginalized_over_instances_batch(X, X_feat, self._log_y)
         dat_ = np.array(dat_)
 

--- a/tests/test_model/test_rf.py
+++ b/tests/test_model/test_rf.py
@@ -378,7 +378,7 @@ def test_rf_with_log_y():
 
 
 def test_predict_marginalized_with_pca_instance_features():
-    #Test that predict_marginalized() works correctly when PCA is active
+    # Test that predict_marginalized() works correctly when PCA is active
     rs = np.random.RandomState(1)
 
     instance_features = {

--- a/tests/test_model/test_rf.py
+++ b/tests/test_model/test_rf.py
@@ -376,3 +376,33 @@ def test_rf_with_log_y():
     assert np.allclose(mean1, mean2)
     assert np.allclose(var1, var2)
 
+
+def test_predict_marginalized_with_pca_instance_features():
+    #Test that predict_marginalized() works correctly when PCA is active
+    rs = np.random.RandomState(1)
+
+    instance_features = {
+        f"instance-{i}": list(rs.rand(10))
+        for i in range(10)
+    }
+
+    model = RandomForest(
+        configspace=_get_cs(10),
+        instance_features=instance_features,
+        pca_components=4,
+    )
+
+    # 10 configuration dimensions + 10 instance-feature dimensions
+    X_train = rs.rand(80, 20)
+    Y_train = rs.rand(80, 1)
+    model.train(X_train, Y_train)
+
+    assert model._apply_pca
+
+    X_test = rs.rand(5, 10)
+    means, variances = model.predict_marginalized(X_test)
+
+    assert means.shape == (5, 1)
+    assert variances.shape == (5, 1)
+    assert np.isfinite(means).all()
+    assert np.isfinite(variances).all()


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1323.

#### Description, Motivation and Context

When PCA is active for instance features, the random forest is trained using PCA-reduced instance features.

However, `RandomForest.predict_marginalized()` passed the original instance features directly to the fitted random forest. This caused a dimensional mismatch between the representation used during training and marginalized prediction.

#### Changes

* Apply the fitted scaler and PCA transformation to instance features before marginalized random-forest prediction.
* Add a regression test covering `predict_marginalized()` with active PCA and instance features.
* Add a corresponding entry to `CHANGELOG.md`.

#### Type Of Changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### What is Missing?

Nothing currently known.

#### Checklist

* [x] My change is based on the latest stage of the `develop` branch.
* [ ] My change required a change of the documentation, which has been done.
  Not applicable: no user-facing documentation changes are required.
* [ ] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
  Not applicable: no documentation files were changed.
* [x] I have added/adapted tests to cover my changes.
* [x] The tests can be executed successfully.
* [x] I have added a description of the changes to `CHANGELOG.rst`.

#### Any other comments?

The repository currently uses `CHANGELOG.md`; the checklist still refers to `CHANGELOG.rst`.
