### PR TITLE
Batch predictions when selecting x best

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.4.1
 ## Improvements
 - Include a new multi-objective method based on hypervolume
+- Batch model predictions when selecting the best predicted configuration.
 
 ## Examples
 - An example on the new multi-objective method

--- a/smac/main/config_selector.py
+++ b/smac/main/config_selector.py
@@ -429,18 +429,13 @@ class ConfigSelector:
         """
         if self._predict_x_best:
             model = self._model
-            costs = list(
-                map(
-                    lambda x: (
-                        model.predict_marginalized(x.reshape((1, -1)))[0][0][0],  # type: ignore
-                        x,
-                    ),
-                    X,
-                )
-            )
-            costs = sorted(costs, key=lambda t: t[0])
-            x_best_array = costs[0][1]
-            best_observation = costs[0][0]
+            assert model is not None
+
+            means, _ = model.predict_marginalized(X)
+            costs = means[:, 0]
+            best_index = int(np.argmin(costs))
+            x_best_array = X[best_index]
+            best_observation = float(costs[best_index])
 
         # else:
         #    all_configs = self._runhistory.get_configs_per_budget(budget_subset=self._considered_budgets)

--- a/tests/test_main/test_config_selector.py
+++ b/tests/test_main/test_config_selector.py
@@ -1,8 +1,12 @@
+from unittest import mock
+
+import numpy as np
 import pytest
 
 from smac.main.exceptions import ConfigurationSpaceExhaustedException
 from ConfigSpace import ConfigurationSpace, Categorical
 from smac import HyperparameterOptimizationFacade, Scenario
+from smac.main.config_selector import ConfigSelector
 
 
 def test_exhausted_configspace():
@@ -25,3 +29,23 @@ def test_exhausted_configspace():
 
     with pytest.raises(ConfigurationSpaceExhaustedException):
         smac.optimize()
+
+
+def test_get_x_best_predicts_configurations_in_one_batch():
+    scenario = Scenario(ConfigurationSpace())
+    selector = ConfigSelector(scenario)
+    X = np.array([[0.3, 1.0], [0.1, 2.0], [0.1, 3.0]])
+
+    model = mock.Mock()
+    model.predict_marginalized.return_value = (
+        np.array([[0.3], [0.1], [0.1]]),
+        np.ones((3, 1)),
+    )
+    selector._model = model
+
+    x_best, best_observation = selector._get_x_best(X)
+
+    model.predict_marginalized.assert_called_once()
+    np.testing.assert_array_equal(model.predict_marginalized.call_args.args[0], X)
+    np.testing.assert_array_equal(x_best, X[1])
+    assert best_observation == pytest.approx(0.1)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1328

#### Description, Motivation and Context

`ConfigSelector._get_x_best()` previously called
`model.predict_marginalized()` separately for every evaluated configuration.
As the runhistory grew, this resulted in an increasing number of individual
model calls whenever the surrogate was retrained.

This PR passes all evaluated configurations to `predict_marginalized()` in one
batch. This reduces the number of model calls from one per configuration to one
per `_get_x_best()` invocation while preserving the selected configuration and
tie-breaking behavior.

#### Performance Evaluation

We evaluated the change using the ACLib `cplex_regions200_surrogate`
benchmark. To isolate the performance of SMAC itself, the reported wall-clock
times exclude time spent evaluating target configurations. The measurements
therefore cover SMAC overhead such as surrogate prediction, surrogate training,
acquisition-function handling, and configuration selection.

The original and batched implementations used the same benchmark setup,
hardware, and random seeds. Values are averages over 2 smac seeds.

Trial interval | Original SMAC average | Batched SMAC average | Speedup | Time reduction
-- | -- | -- | -- | --
0–500 | 6.180 min | 5.630 min | 1.098× | 8.910%
500–1,000 | 18.469 min | 13.723 min | 1.346× | 25.701%
1,000–1,500 | 86.302 min | 41.268 min | 2.091× | 52.181%
1,500–2,000 | 133.465 min | 48.539 min | 2.750× | 63.632%
2,000–2,500 | 123.641 min | 42.665 min | 2.898× | 65.492%
2,500–3,000 | 150.143 min | 43.183 min | 3.477× | 71.238%

The performance benefit increases as the runhistory grows, reaching a <strong>3.477× speedup</strong> and a <strong>71.238% reduction in SMAC overhead</strong> between trials 2,500 and 3,000.

#### Changes

- Call `model.predict_marginalized(X)` once with the complete configuration
  matrix.
- Extract the predicted costs for the first objective from the returned mean
  matrix.
- Select the best configuration using `numpy.argmin`.
- Preserve the previous tie behavior by selecting the first configuration with
  the minimum predicted cost.
- Add a regression test verifying that:

  * all configurations are passed to the model in a single call;
  * the configuration with the lowest predicted cost is returned;
  * the corresponding predicted cost is returned;
  * the first configuration is selected when multiple predictions share the minimum.

- Add an entry to `CHANGELOG.md`.

#### Type Of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This is a non-breaking performance improvement. 

#### What is Missing?

Nothing.

#### Checklist

- [x] My change is based on the latest stage of the `develop` branch.
- [ ] My change required a change of the documentation, which has been done.
- [ ] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
- [x] I have added/adapted tests to cover my changes.
- [x] The tests can be executed successfully.
- [x] I have added a description of the changes to `CHANGELOG.rst`.

#### Any other comments?

No.
