### PR TITLE
Refactor surrogate models to use centralized preprocessing via SurrogateTransformer

### DIFF
--- a/smac/facade/abstract_facade.py
+++ b/smac/facade/abstract_facade.py
@@ -178,6 +178,8 @@ class AbstractFacade:
         self._callbacks = callbacks
         self._overwrite = overwrite
 
+        self._model.set_y_transform(func=self._runhistory_encoder.transform_response_values)
+
         # Prepare the algorithm executer
         runner: AbstractRunner | None
         if isinstance(target_function, AbstractRunner) or target_function is None:

--- a/smac/model/abstract_model.py
+++ b/smac/model/abstract_model.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, TypeVar
+from typing import Any, Callable, TypeVar
 
 import copy
 import warnings
 
 import numpy as np
 from ConfigSpace import ConfigurationSpace
-from sklearn.decomposition import PCA
-from sklearn.exceptions import NotFittedError
-from sklearn.preprocessing import MinMaxScaler
 
 from smac.constants import VERY_SMALL_NUMBER
+from smac.model.surrogate_transformer import SurrogateTransformer
 from smac.utils.configspace import get_types
 from smac.utils.logging import get_logger
 
@@ -57,6 +55,7 @@ class AbstractModel:
         self._rng = np.random.RandomState(self._seed)
         self._instance_features = instance_features
         self._pca_components = pca_components
+        self.transformer: SurrogateTransformer
 
         n_features = 0
         if self._instance_features is not None:
@@ -70,10 +69,6 @@ class AbstractModel:
         self._n_features = n_features
         self._n_hps = len(list(self._configspace.values()))
 
-        self._pca = PCA(n_components=self._pca_components)
-        self._scaler = MinMaxScaler()
-        self._apply_pca = False
-
         # Never use a lower variance than this.
         # If estimated variance < var_threshold, set to var_threshold
         self._var_threshold = VERY_SMALL_NUMBER
@@ -81,6 +76,32 @@ class AbstractModel:
 
         # Initial types array which is used to reset the type array at every call to `self.train()`
         self._initial_types = copy.deepcopy(self._types)
+
+    @abstractmethod
+    def build_transformer(self, normalize_y: bool = False) -> SurrogateTransformer:
+        """Creates and returns the preprocessing transformer for this model.
+
+        Parameters
+        ----------
+        normalize_y : bool
+            Whether the transformer should normalize target values (y).
+
+        Returns
+        -------
+        SurrogateTransformer
+            Configured transformer for preprocessing inputs/outputs.
+        """
+        raise NotImplementedError
+
+    def set_y_transform(self, func: Callable[[np.ndarray], np.ndarray] | None) -> None:
+        """Sets the target transformation function used by the transformer.
+
+        Parameters
+        ----------
+        func : Callable | None
+            Function applied to target values before training.
+        """
+        self.transformer.y_transform = func
 
     @property
     def meta(self) -> dict[str, Any]:
@@ -106,48 +127,19 @@ class AbstractModel:
         -------
         self : AbstractModel
         """
-        if len(X.shape) != 2:
-            raise ValueError("Expected 2d array, got %dd array!" % len(X.shape))
-
-        if X.shape[1] != self._n_hps + self._n_features:
-            raise ValueError(
-                f"Feature mismatch: X should have {self._n_hps} hyperparameters + {self._n_features} features, "
-                f"but has {X.shape[1]} in total."
-            )
-
         if X.shape[0] != Y.shape[0]:
             raise ValueError("X.shape[0] ({}) != y.shape[0] ({})".format(X.shape[0], Y.shape[0]))
 
-        # Reduce dimensionality of features if larger than PCA_DIM
-        if (
-            self._pca_components is not None
-            and X.shape[0] > self._pca.n_components
-            and self._n_features >= self._pca_components
-        ):
-            X_feats = X[:, -self._n_features :]
+        X, Y = self.transformer.fit_transform(X, Y)
 
-            # Scale features
-            X_feats = self._scaler.fit_transform(X_feats)
-            X_feats = np.nan_to_num(X_feats)  # if features with max == min
-
-            # PCA
-            X_feats = self._pca.fit_transform(X_feats)
-            X = np.hstack((X[:, : self._n_hps], X_feats))
-
-            if hasattr(self, "_types"):
-                # For RF, adapt types list
-                # if X_feats.shape[0] < self._pca, X_feats.shape[1] == X_feats.shape[0]
-                self._types = np.array(
-                    np.hstack((self._types[: self._n_hps], np.zeros(X_feats.shape[1]))),
-                    dtype=np.uint,
-                )  # type: ignore
-
-            self._apply_pca = True
-        else:
-            self._apply_pca = False
-
-            if hasattr(self, "_types"):
-                self._types = copy.deepcopy(self._initial_types)
+        if hasattr(self, "_types"):
+            n_transformed_features = X.shape[1] - self._n_hps
+            # For RF, adapt types list
+            # if X_feats.shape[0] < self._pca, X_feats.shape[1] == X_feats.shape[0]
+            self._types = np.array(
+                np.hstack((self._types[: self._n_hps], np.zeros(n_transformed_features))),
+                dtype=np.uint,
+            )  # type: ignore
 
         return self._train(X, Y)
 
@@ -194,25 +186,7 @@ class AbstractModel:
         vars : np.ndarray [#samples, #objectives] or [#samples, #samples] | None
             Predictive variance or standard deviation.
         """
-        if len(X.shape) != 2:
-            raise ValueError("Expected 2d array, got %dd array!" % len(X.shape))
-
-        if X.shape[1] != self._n_hps + self._n_features:
-            raise ValueError(
-                f"Feature mismatch: X should have {self._n_hps} hyperparameters + {self._n_features} features, "
-                f"but has {X.shape[1]} in total."
-            )
-
-        if self._apply_pca:
-            try:
-                X_feats = X[:, -self._n_features :]
-                X_feats = self._scaler.transform(X_feats)
-                X_feats = self._pca.transform(X_feats)
-                X = np.hstack((X[:, : self._n_hps], X_feats))
-            except NotFittedError:
-                # PCA not fitted if only one training sample
-                pass
-
+        X = self.transformer.transform_X(X)
         if X.shape[1] != len(self._types):
             raise ValueError("Rows in X should have %d entries but have %d!" % (len(self._types), X.shape[1]))
 
@@ -294,26 +268,17 @@ class AbstractModel:
             return mean, var
         else:
             n_instances = len(self._instance_features)
+            X_marg = self.transformer.build_marginalized_X(X)
 
-            mean = np.zeros(X.shape[0])
-            var = np.zeros(X.shape[0])
-            for i, x in enumerate(X):
-                features = np.array(list(self._instance_features.values()))
-                x_tiled = np.tile(x, (n_instances, 1))
-                X_ = np.hstack((x_tiled, features))
+            means, vars = self.predict(X_marg)
+            assert vars is not None
 
-                means, vars = self.predict(X_)
-                assert vars is not None
+            means = means.reshape(len(X), n_instances)
+            vars = vars.reshape(len(X), n_instances)
 
-                # VAR[1/n (X_1 + ... + X_n)] =
-                # 1/n^2 * ( VAR(X_1) + ... + VAR(X_n))
-                # for independent X_1 ... X_n
-                var_x = np.sum(vars) / (len(vars) ** 2)
-                if var_x < self._var_threshold:
-                    var_x = self._var_threshold
-
-                var[i] = var_x
-                mean[i] = np.mean(means)
+            mean = np.mean(means, axis=1)
+            var = np.sum(vars, axis=1) / (n_instances**2)
+            var[var < self._var_threshold] = self._var_threshold
 
             if len(mean.shape) == 1:
                 mean = mean.reshape((-1, 1))

--- a/smac/model/gaussian_process/abstract_gaussian_process.py
+++ b/smac/model/gaussian_process/abstract_gaussian_process.py
@@ -12,6 +12,7 @@ from sklearn.gaussian_process.kernels import Kernel, KernelOperator
 from smac.model.abstract_model import AbstractModel
 from smac.model.gaussian_process.priors.abstract_prior import AbstractPrior
 from smac.model.gaussian_process.priors.tophat_prior import SoftTopHatPrior, TophatPrior
+from smac.model.surrogate_transformer import SurrogateTransformer
 
 __copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
@@ -31,6 +32,8 @@ class AbstractGaussianProcess(AbstractModel):
     pca_components : float, defaults to 7
         Number of components to keep when using PCA to reduce dimensionality of instance features.
     seed : int
+    normalize_y : bool, defaults to True
+        Zero mean unit variance normalization of the output values.
     """
 
     def __init__(
@@ -40,6 +43,7 @@ class AbstractGaussianProcess(AbstractModel):
         instance_features: dict[str, list[int | float]] | None = None,
         pca_components: int | None = 7,
         seed: int = 0,
+        normalize_y: bool = True,
     ):
         super().__init__(
             configspace=configspace,
@@ -50,6 +54,7 @@ class AbstractGaussianProcess(AbstractModel):
 
         self._kernel = kernel
         self._gp = self._get_gaussian_process()
+        self.transformer = self.build_transformer(normalize_y)
 
     @property
     def meta(self) -> dict[str, Any]:  # noqa: D102
@@ -58,61 +63,20 @@ class AbstractGaussianProcess(AbstractModel):
 
         return meta
 
+    def build_transformer(self, normalize_y: bool = False) -> SurrogateTransformer:  # noqa: D102
+        return SurrogateTransformer(
+            n_hps=self._n_hps,
+            n_features=self._n_features,
+            instance_features=self._instance_features,
+            impute_inactive=self._impute_inactive,
+            normalize_y=normalize_y,
+            pca_components=self._pca_components,
+        )
+
     @abstractmethod
     def _get_gaussian_process(self) -> GaussianProcessRegressor:
         """Generates a Gaussian process."""
         raise NotImplementedError()
-
-    def _normalize(self, y: np.ndarray) -> np.ndarray:
-        """Normalize data to zero mean unit standard deviation.
-
-        Parameters
-        ----------
-        y : np.ndarray
-            Target values for the Gaussian process.
-
-        Returns
-        -------
-        normalized_y : np.ndarray
-            Normalized y values.
-        """
-        self.mean_y_ = np.mean(y)
-        self.std_y_ = np.std(y)
-
-        if self.std_y_ == 0:
-            self.std_y_ = 1
-
-        return (y - self.mean_y_) / self.std_y_
-
-    def _untransform_y(
-        self,
-        y: np.ndarray,
-        var: np.ndarray | None = None,
-    ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
-        """Transform zero mean unit standard deviation data into the regular space.
-
-        Warning
-        -------
-        This function should be used after a prediction with the Gaussian process which was
-        trained on normalized data.
-
-        Parameters
-        ----------
-        y : np.ndarray
-            Normalized data.
-        var : np.ndarray | None, defaults to None
-            Normalized variance.
-
-        Returns
-        -------
-        untransformed_y : np.ndarray | tuple[np.ndarray, np.ndarray]
-        """
-        y = y * self.std_y_ + self.mean_y_
-        if var is not None:
-            var = var * self.std_y_**2
-            return y, var  # type: ignore
-
-        return y
 
     def _get_all_priors(
         self,

--- a/smac/model/gaussian_process/gaussian_process.py
+++ b/smac/model/gaussian_process/gaussian_process.py
@@ -68,9 +68,9 @@ class GaussianProcess(AbstractGaussianProcess):
             kernel=kernel,
             instance_features=instance_features,
             pca_components=pca_components,
+            normalize_y=normalize_y,
         )
 
-        self._normalize_y = normalize_y
         self._n_restarts = n_restarts
 
         # Internal variables
@@ -83,7 +83,7 @@ class GaussianProcess(AbstractGaussianProcess):
     @property
     def meta(self) -> dict[str, Any]:  # noqa: D102
         meta = super().meta
-        meta.update({"n_restarts": self._n_restarts, "normalize_y": self._normalize_y})
+        meta.update({"n_restarts": self._n_restarts})
 
         return meta
 
@@ -107,10 +107,6 @@ class GaussianProcess(AbstractGaussianProcess):
             If set to true, the hyperparameters are optimized, otherwise the default hyperparameters of the kernel are
             used.
         """
-        if self._normalize_y:
-            y = self._normalize(y)
-
-        X = self._impute_inactive(X)
         y = y.flatten()
 
         n_tries = 10
@@ -241,20 +237,17 @@ class GaussianProcess(AbstractGaussianProcess):
         if not self._is_trained:
             raise Exception("Model has to be trained first!")
 
-        X_test = self._impute_inactive(X)
-
         if covariance_type is None:
-            mu = self._gp.predict(X_test)
+            mu = self._gp.predict(X)
             var = None
 
-            if self._normalize_y:
-                mu = self._untransform_y(mu)
+            mu = self.transformer.untransform_y(mu)
         else:
             predict_kwargs = {"return_cov": False, "return_std": True}
             if covariance_type == "full":
                 predict_kwargs = {"return_cov": True, "return_std": False}
 
-            mu, var = self._gp.predict(X_test, **predict_kwargs)
+            mu, var = self._gp.predict(X, **predict_kwargs)
 
             if covariance_type != "full":
                 var = var**2  # Since we get standard deviation for faster computation
@@ -263,8 +256,7 @@ class GaussianProcess(AbstractGaussianProcess):
             # positive float value
             var = np.clip(var, VERY_SMALL_NUMBER, np.inf)
 
-            if self._normalize_y:
-                mu, var = self._untransform_y(mu, var)
+            mu, var = self.transformer.untransform_y(mu, var)
 
             if covariance_type == "std":
                 var = np.sqrt(var)  # Converting variance to std deviation if specified
@@ -289,11 +281,13 @@ class GaussianProcess(AbstractGaussianProcess):
         if not self._is_trained:
             raise Exception("Model has to be trained first.")
 
-        X_test = self._impute_inactive(X_test)
+        if self.transformer.impute_inactive:
+            X_test = self.transformer.impute_inactive(X_test)
+        else:
+            raise ValueError("Surrogate Transformers impute_inactive not defined")
         funcs = self._gp.sample_y(X_test, n_samples=n_funcs, random_state=self._rng)
 
-        if self._normalize_y:
-            funcs = self._untransform_y(funcs)
+        funcs = self.transformer.untransform_y(funcs)
 
         if len(funcs.shape) == 1:
             return funcs[None, :]

--- a/smac/model/gaussian_process/mcmc_gaussian_process.py
+++ b/smac/model/gaussian_process/mcmc_gaussian_process.py
@@ -85,13 +85,13 @@ class MCMCGaussianProcess(AbstractGaussianProcess):
             instance_features=instance_features,
             pca_components=pca_components,
             seed=seed,
+            normalize_y=normalize_y,
         )
 
         self._n_mcmc_walkers = n_mcmc_walkers
         self._chain_length = chain_length
         self._burning_steps = burning_steps
         self._models: list[GaussianProcess] = []
-        self._normalize_y = normalize_y
         self._mcmc_sampler = mcmc_sampler
         self._average_samples = average_samples
         self._set_has_conditions()
@@ -112,7 +112,6 @@ class MCMCGaussianProcess(AbstractGaussianProcess):
                 "burning_steps": self._burning_steps,
                 "mcmc_sampler": self._mcmc_sampler,
                 "average_samples": self._average_samples,
-                "normalize_y": self._normalize_y,
             }
         )
 
@@ -141,16 +140,6 @@ class MCMCGaussianProcess(AbstractGaussianProcess):
         optimize_hyperparameters: boolean
             If set to true, we perform MCMC sampling. Otherwise, we just use the hyperparameter specified in the kernel.
         """
-        X = self._impute_inactive(X)
-        if self._normalize_y:
-            # A note on normalization for the Gaussian process with MCMC:
-            # Scikit-learn uses a different "normalization" than we use in SMAC3. Scikit-learn normalizes the data to
-            # have zero mean, while we normalize it to have zero mean unit variance. To make sure the scikit-learn GP
-            # behaves the same when we use it directly or indirectly (through the gaussian_process.py file), we
-            # normalize the data here. Then, after the individual GPs are fit, we inject the statistics into them, so
-            # they unnormalize the data at prediction time.
-            y = self._normalize(y)
-
         self._gp = self._get_gaussian_process()
 
         if optimize_hyperparameters:
@@ -279,13 +268,15 @@ class MCMCGaussianProcess(AbstractGaussianProcess):
             model._train(X, y, optimize_hyperparameters=False)
             self._models.append(model)
 
-        if self._normalize_y:
+        print(f"normalize: {self.transformer.normalize_y}, mean_y: {self.transformer.mean_y_}")
+
+        if self.transformer.normalize_y:
             # Inject the normalization statistics into the individual models. Setting normalize_y to True makes the
             # individual GPs unnormalize the data at predict time.
             for model in self._models:
-                model._normalize_y = True
-                model.mean_y_ = self.mean_y_
-                model.std_y_ = self.std_y_
+                model.transformer.normalize_y = True
+                model.transformer.mean_y_ = self.transformer.mean_y_
+                model.transformer.std_y_ = self.transformer.std_y_
 
         self._is_trained = True
         return self
@@ -397,12 +388,10 @@ class MCMCGaussianProcess(AbstractGaussianProcess):
         if covariance_type != "diagonal":
             raise ValueError("`covariance_type` can only take `diagonal` for this model.")
 
-        X_test = self._impute_inactive(X)
-
-        mu = np.zeros([len(self._models), X_test.shape[0]])
-        var = np.zeros([len(self._models), X_test.shape[0]])
+        mu = np.zeros([len(self._models), X.shape[0]])
+        var = np.zeros([len(self._models), X.shape[0]])
         for i, model in enumerate(self._models):
-            mu_tmp, var_tmp = model.predict(X_test)
+            mu_tmp, var_tmp = model.predict(X)
             assert var_tmp is not None
             mu[i] = mu_tmp.flatten()
             var[i] = var_tmp.flatten()

--- a/smac/model/multi_objective_model.py
+++ b/smac/model/multi_objective_model.py
@@ -5,6 +5,7 @@ from typing import TypeVar
 import numpy as np
 
 from smac.model.abstract_model import AbstractModel
+from smac.model.surrogate_transformer import SurrogateTransformer
 
 __copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
@@ -51,6 +52,17 @@ class MultiObjectiveModel(AbstractModel):
             instance_features=None,
             pca_components=None,
             seed=seed,
+        )
+        self.transformer = self.build_transformer()
+
+    def build_transformer(self, normalize_y: bool = False) -> SurrogateTransformer:  # noqa: D102
+        return SurrogateTransformer(
+            n_hps=self._n_hps,
+            n_features=self._n_features,
+            instance_features=self._instance_features,
+            impute_inactive=None,
+            normalize_y=normalize_y,
+            pca_components=None,
         )
 
     @property

--- a/smac/model/random_forest/abstract_random_forest.py
+++ b/smac/model/random_forest/abstract_random_forest.py
@@ -12,6 +12,7 @@ from ConfigSpace import (
 )
 
 from smac.model.abstract_model import AbstractModel
+from smac.model.surrogate_transformer import SurrogateTransformer
 
 __copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
@@ -25,6 +26,18 @@ class AbstractRandomForest(AbstractModel):
 
         self._conditional: dict[int, bool] = dict()
         self._impute_values: dict[int, float] = dict()
+
+        self.transformer = self.build_transformer()
+
+    def build_transformer(self, normalize_y: bool = False) -> SurrogateTransformer:  # noqa: D102
+        return SurrogateTransformer(
+            n_hps=self._n_hps,
+            n_features=self._n_features,
+            instance_features=self._instance_features,
+            impute_inactive=self._impute_inactive,
+            pca_components=self._pca_components,
+            normalize_y=normalize_y,
+        )
 
     def _impute_inactive(self, X: np.ndarray) -> np.ndarray:
         X = X.copy()

--- a/smac/model/random_forest/pyrfr/random_forest_pyrfr.py
+++ b/smac/model/random_forest/pyrfr/random_forest_pyrfr.py
@@ -150,7 +150,6 @@ class PyrfrRandomForest(AbstractRandomForest):
         return meta
 
     def _train(self, X: np.ndarray, y: np.ndarray) -> PyrfrRandomForest:
-        X = self._impute_inactive(X)
         y = y.flatten()
 
         # self.X = X
@@ -213,7 +212,6 @@ class PyrfrRandomForest(AbstractRandomForest):
             raise ValueError("`covariance_type` can only take `diagonal` for this model.")
 
         assert self._rf is not None
-        X = self._impute_inactive(X)
 
         if self._log_y:
             all_preds = []
@@ -288,9 +286,13 @@ class PyrfrRandomForest(AbstractRandomForest):
             raise ValueError("Rows in X should have %d entries but have %d!" % (len(self._bounds), X.shape[1]))
 
         assert self._rf is not None
-        X = self._impute_inactive(X)
+        X_feat = np.ndarray(list(self._instance_features.values()))
 
-        X_feat = list(self._instance_features.values())
+        # applies PCA to X (if enabled)
+        X_feat = self.transformer.transform_instance_features(X_feat)
+        # applies inactive imputation to X
+        X = self.transformer.transform_configs(X)
+
         dat_ = self._rf.predict_marginalized_over_instances_batch(X, X_feat, self._log_y)
         dat_ = np.array(dat_)
 

--- a/smac/model/random_forest/random_forest.py
+++ b/smac/model/random_forest/random_forest.py
@@ -741,7 +741,6 @@ class RandomForest(AbstractRandomForest):
         return meta
 
     def _train(self, X: np.ndarray, y: np.ndarray) -> RandomForest:
-        X = self._impute_inactive(X)
         y = y.flatten()
 
         self._rf = EPMRandomForest(**self._rf_opts)  # type: ignore
@@ -765,7 +764,6 @@ class RandomForest(AbstractRandomForest):
             raise ValueError("`covariance_type` can only take `diagonal` for this model.")
 
         assert self._rf is not None
-        X = self._impute_inactive(X)
         means, vars_ = self._rf.predict(X)
         return means.reshape((-1, 1)), vars_.reshape((-1, 1))
 
@@ -814,9 +812,14 @@ class RandomForest(AbstractRandomForest):
             raise ValueError("Rows in X should have %d entries but have %d!" % (len(self._bounds), X.shape[1]))
 
         assert self._rf is not None
-        X = self._impute_inactive(X)
 
         X_feat = np.asarray(list(self._instance_features.values()))
+
+        # applies PCA to X (if enabled)
+        X_feat = self.transformer.transform_instance_features(X_feat)
+        # applies inactive imputation to X
+        X = self.transformer.transform_configs(X)
+
         dat_ = self._rf.predict_marginalized_over_instances_batch(X, X_feat, self._log_y)
         dat_ = np.array(dat_)
 

--- a/smac/model/random_model.py
+++ b/smac/model/random_model.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 
 from smac.model.abstract_model import AbstractModel
+from smac.model.surrogate_transformer import SurrogateTransformer
 from smac.utils.logging import get_logger
 
 __copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
@@ -13,6 +16,20 @@ logger = get_logger(__name__)
 
 class RandomModel(AbstractModel):
     """AbstractModel which returns random values on a call to `fit`."""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.transformer = self.build_transformer()
+
+    def build_transformer(self, normalize_y: bool = False) -> SurrogateTransformer:  # noqa: D102
+        return SurrogateTransformer(
+            n_hps=self._n_hps,
+            n_features=self._n_features,
+            instance_features=self._instance_features,
+            impute_inactive=None,
+            normalize_y=normalize_y,
+            pca_components=None,
+        )
 
     def _train(self, X: np.ndarray, Y: np.ndarray) -> RandomModel:
         if not isinstance(X, np.ndarray):

--- a/smac/model/surrogate_transformer.py
+++ b/smac/model/surrogate_transformer.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+from sklearn.decomposition import PCA
+from sklearn.preprocessing import MinMaxScaler
+
+
+class SurrogateTransformer:
+    """
+    Preprocessing pipeline for the surrogate models.
+
+    Handles feature preprocessing (inactive imputation, scaling, PCA)
+    and target preprocessing (normalization and optional transformation).
+
+    Designed to be model-agnostic with pluggable transformation strategies.
+
+    Parameters
+    ----------
+    n_hps : int
+        Number of hyperparameters in input X.
+    n_features: int
+        Number of instance features in input X.
+    impute_inactive : Callable | None, defaults to None
+        Function that replaces inactive hyperparameter values.
+    y_transform : Callable | None, defaults to None
+        Additional transformation applied to target values before optional normalization.
+    pca_components : int | None, defaults to 7
+        Number of PCA components for feature reduction.
+    normalize_y : bool
+        Whether to standardize target values (zero mean, unit variance).
+    """
+
+    def __init__(
+        self,
+        n_hps: int,
+        n_features: int,
+        instance_features: dict[str, list[int | float]] | None,
+        impute_inactive: Callable[[np.ndarray], np.ndarray] | None = None,
+        y_transform: Callable[[np.ndarray], np.ndarray] | None = None,
+        pca_components: int | None = 7,
+        normalize_y: bool = True,
+    ):
+        self._n_hps = n_hps
+        self._n_features = n_features
+        self._instance_features = instance_features
+
+        self.normalize_y = normalize_y
+        self.impute_inactive = impute_inactive
+        self.y_transform = y_transform
+
+        self._pca_components = pca_components
+        self.pca_ = PCA(n_components=self._pca_components)
+        self._pca_active = False
+
+        self.scaler_ = MinMaxScaler()
+
+        self.mean_y_: float | None = None
+        self.std_y_: float | None = None
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> "SurrogateTransformer":
+        """
+        Fits preprocessing steps:
+        - Computes y normalization statistics
+        - Fits feature scaler and PCA (if enabled)
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Training inputss [n_samples, n_hps + n_features]
+        y : np.ndarray
+            Target values [n_samples, n_objectives]
+
+        Returns
+        -------
+        self
+        """
+        if len(X.shape) != 2:
+            raise ValueError("Expected 2d array, got %dd array!" % len(X.shape))
+
+        if X.shape[1] != self._n_hps + self._n_features:
+            raise ValueError(
+                f"Feature mismatch: X should have {self._n_hps} hyperparameters + {self._n_features} features, "
+                f"but has {X.shape[1]} in total."
+            )
+
+        y = y.reshape(-1)
+
+        if self.normalize_y:
+            self.mean_y_ = np.mean(y)
+            self.std_y_ = np.std(y)
+            if self.std_y_ == 0:
+                self.std_y_ = 1.0
+
+        if (
+            self._pca_components is not None
+            and X.shape[0] > self._pca_components
+            and self._n_features >= self._pca_components
+        ):
+            X_feats = X[:, -self._n_features :]
+            X_feats = self.scaler_.fit_transform(X_feats)
+            X_feats = np.nan_to_num(X_feats)
+            self.pca_.fit(X_feats)
+
+            self._pca_active = True
+        else:
+            self._pca_active = False
+
+        return self
+
+    def transform_configs(self, X_cfg: np.ndarray) -> np.ndarray:
+        """
+        Applies configuration preprocessing.
+        Handles inactive hyperparamter imputation if enabled.
+
+        Parameters
+        ----------
+        X_cfg : np.ndarray
+            Configuration matrix [n_samples, n_hps]
+
+        Returns
+        -------
+        np.ndarray
+            Transformed configurations
+        """
+        if X_cfg.shape[1] != self._n_hps:
+            raise ValueError(f"Number of configurations should be {self._n_hps} but is {X_cfg.shape[1]}")
+        X_cfg = X_cfg.copy()
+
+        if self.impute_inactive is not None:
+            X_cfg = self.impute_inactive(X_cfg)
+
+        return X_cfg
+
+    def transform_instance_features(self, X_inst: np.ndarray) -> np.ndarray:
+        """
+        Applies instance feature preprocessing.
+        Applies scaling and PCA if enabled and fitted.
+
+        Parameters
+        ----------
+        X_inst : np.ndarray
+            Instance feature matrix [n_samples, n_features]
+
+        Returns
+        -------
+        np.ndarray
+            Transformed instance features
+        """
+        X_inst = X_inst.copy()
+
+        if self._pca_active:
+            if not hasattr(self.pca_, "components_"):
+                raise RuntimeError("Transformer must be fitted before instance feature transformation.")
+            X_inst = self.scaler_.transform(X_inst)
+            X_inst = np.nan_to_num(X_inst)
+
+            X_inst = self.pca_.transform(X_inst)
+
+        return X_inst
+
+    def transform_X(self, X: np.ndarray) -> np.ndarray:
+        """
+        Full feature transformation pipeline.
+
+        Splits input into configurations and instance features,
+        then applies preprocessing steps.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Raw input [n_samples, n_hps + n_features]
+
+        Returns
+        -------
+        np.ndarray
+            Fully transformed feature matrix
+        """
+        if len(X.shape) != 2:
+            raise ValueError("Expected 2d array, got %dd array!" % len(X.shape))
+
+        if X.shape[1] != self._n_hps + self._n_features:
+            raise ValueError(
+                f"Feature mismatch: X should have {self._n_hps} hyperparameters + {self._n_features} features, "
+                f"but has {X.shape[1]} in total."
+            )
+
+        X_cfg = X[:, : self._n_hps]
+        X_inst = X[:, self._n_hps :]
+
+        X_cfg = self.transform_configs(X_cfg)
+        X_inst = self.transform_instance_features(X_inst)
+
+        return np.hstack([X_cfg, X_inst])
+
+    def transform_y(self, y: np.ndarray) -> np.ndarray:
+        """
+        Applies target preprocessing:
+        - Optional custom transformation
+        - Mean/std normalization (if enabled)
+
+        Parameters
+        ----------
+        y : np.ndarray
+            target values
+
+        Returns
+        -------
+        np.ndarray
+            Transformed targets
+        """
+        if self.y_transform is not None:
+            y = self.y_transform(y)
+
+        if self.normalize_y:
+            if self.mean_y_ is None or self.std_y_ is None:
+                raise RuntimeError("Transformer must be fitted before calling transform_y.")
+            y = (y - self.mean_y_) / self.std_y_
+
+        return y
+
+    def transform(self, X: np.ndarray, y: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Applies full preprocessing pipeline to X and y.
+
+        Returns
+        -------
+        (X_transformed, y_transformed)
+        """
+        return self.transform_X(X), self.transform_y(y)
+
+    def fit_transform(self, X: np.ndarray, y: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Convenience method:
+        fits Transformer and immediately transforms inputs.
+
+        Returns
+        -------
+        (X_transformed, y_transformed)
+        """
+        self.fit(X, y)
+        return self.transform_X(X), self.transform_y(y)
+
+    def untransform_y(self, y: np.ndarray, var: np.ndarray | None = None) -> tuple[np.ndarray, np.ndarray] | np.ndarray:
+        """
+        Reverts target preprocessing.
+
+        Parameters
+        ----------
+        y : np.ndarray
+            Transformed predictions
+        var : np.ndarray | None, defaults to None
+            Predictive variance (if available)
+
+        Returns
+        -------
+        y : np.ndarray
+            Original scale predictions
+        var : np.ndarray, optional
+            Rescaled variance (if provided)
+        """
+        if self.normalize_y:
+            if self.mean_y_ is None or self.std_y_ is None:
+                raise RuntimeError("Transformer must be fitted before calling inverse_transform_y.")
+            y = y * self.std_y_ + self.mean_y_
+
+            if var is not None:
+                var = var * (self.std_y_**2)
+
+        if var is not None:
+            return y, var
+
+        return y
+
+    def build_marginalized_X(self, X_cfg: np.ndarray) -> np.ndarray:
+        """
+        Expands configuration-only input into full configuration-instance pairs
+        for marginalized prediction over all available instances.
+
+        This method performs *structural expansion only* and does NOT apply any
+        feature preprocessing or transformations.
+
+        All preprocessing steps are expected to be applied later in
+        `transform_X()` inside `predict()` to ensure a single, consistent
+        transformation pipeline.
+
+        Parameters
+        ----------
+        X_cfg : np.ndarray
+            Array of configurations with shape [n_samples, n_hyperparameters].
+            Must NOT include instance features.
+
+        Returns
+        -------
+        np.ndarray
+            Expanded design matrix of shape
+            [n_samples * n_instances, n_hyperparameters + n_features],
+            where each configuration is paired with all available instance
+            feature vectors in the model.
+        """
+        assert self._instance_features is not None
+        X_inst = np.asarray(list(self._instance_features.values()))
+
+        n_instances = X_inst.shape[0]
+
+        X_cfg_rep = np.repeat(X_cfg, n_instances, axis=0)
+        X_inst_rep = np.tile(X_inst, (X_cfg.shape[0], 1))
+
+        return np.hstack([X_cfg_rep, X_inst_rep])

--- a/smac/runhistory/encoder/encoder.py
+++ b/smac/runhistory/encoder/encoder.py
@@ -63,7 +63,6 @@ class RunHistoryEncoder(AbstractRunHistoryEncoder):
                 self._min_y = np.min(y, axis=0)
                 self._max_y = np.max(y, axis=0)
 
-        y = self.transform_response_values(values=y)
         return X, y
 
     def transform_response_values(self, values: np.ndarray) -> np.ndarray:

--- a/tests/test_model/test_abstract_model.py
+++ b/tests/test_model/test_abstract_model.py
@@ -3,6 +3,7 @@ import pytest
 
 from smac.model.abstract_model import AbstractModel
 from smac.utils.configspace import convert_configurations_to_array
+from smac.model.surrogate_transformer import SurrogateTransformer
 
 __copyright__ = "Copyright 2025, Leibniz University Hanover, Institute of AI"
 __license__ = "3-clause BSD"
@@ -38,11 +39,17 @@ def test_no_pca(configspace_small, make_scenario):
     model = AbstractModel(configspace_small, scenario.instance_features, pca_components=7)
     # We just overwrite the function as mock here
     model._train = _train
+    model.transformer = SurrogateTransformer(
+        n_hps=model._n_hps,
+        n_features=model._n_features,
+        instance_features=scenario.instance_features,
+        normalize_y=False,
+    )
 
     # No PCA
     X, y = get_X_y(configspace_small, n_samples, n_instance_features)
     model.train(X, y)
-    assert not model._apply_pca
+    assert not model.transformer._pca_active
 
     X, y = get_X_y(configspace_small, n_samples, n_instance_features + 1)
     with pytest.raises(ValueError, match="Feature mismatch.*"):
@@ -71,11 +78,17 @@ def test_pca(configspace_small, make_scenario):
     model = AbstractModel(configspace_small, scenario.instance_features, pca_components=7)
     # We just overwrite the function as mock here
     model._train = _train
+    model.transformer = SurrogateTransformer(
+        n_hps=model._n_hps,
+        n_features=model._n_features,
+        instance_features=scenario.instance_features,
+        normalize_y=False,
+    )
 
     # PCA
     X, y = get_X_y(configspace_small, n_samples, n_instance_features)
     model.train(X, y)
-    assert model._apply_pca
+    assert model.transformer._pca_active
 
     X, y = get_X_y(configspace_small, n_samples, n_instance_features + 1)
     with pytest.raises(ValueError, match="Feature mismatch.*"):

--- a/tests/test_model/test_gp.py
+++ b/tests/test_model/test_gp.py
@@ -384,6 +384,7 @@ def test_sampling_shape():
             get_gp(n_dimensions=1, seed=seed, noise=1e-10, normalize_y=False),
             get_gp(n_dimensions=1, seed=seed, noise=1e-10, normalize_y=True),
         ):
+            X, y = gp.transformer.fit_transform(X, y)
             gp._train(X, y)
             func = gp.sample_functions(X_test=X_test, n_funcs=1)
             assert func.shape == (101, 1)
@@ -398,10 +399,12 @@ def test_normalization():
     seed = 1
 
     gp = get_gp(n_dimensions=1, seed=seed, noise=1e-10, normalize_y=False)
+    X, y = gp.transformer.fit_transform(X, y)
     gp._train(X, y, optimize_hyperparameters=False)
     mu_hat, var_hat = gp.predict(X_test)
 
     gp_norm = get_gp(n_dimensions=1, seed=seed, noise=1e-10, normalize_y=True)
+    X, y = gp_norm.transformer.fit_transform(X, y)
     gp_norm._train(X, y, optimize_hyperparameters=False)
     mu_hat_prime, var_hat_prime = gp_norm.predict(X_test)
 

--- a/tests/test_model/test_gp_mcmc.py
+++ b/tests/test_model/test_gp_mcmc.py
@@ -227,15 +227,17 @@ def test_normalization():
     y = np.sin(X)
     seed = 1
     gp = get_gp(n_dimensions=1, seed=seed, noise=1e-10, normalize_y=False)
+    X, y = gp.transformer.fit_transform(X, y)
     gp._train(X, y, optimize_hyperparameters=False)
-    assert not gp.models[0]._normalize_y
-    assert not hasattr(gp.models[0], "mean_y_")
+    assert not gp.models[0].transformer.normalize_y
+    assert gp.models[0].transformer.mean_y_ is None
 
     mu_hat, var_hat = gp.predict(X_test)
     gp_norm = get_gp(n_dimensions=1, seed=seed, noise=1e-10, normalize_y=True)
+    X, y = gp_norm.transformer.fit_transform(X, y)
     gp_norm._train(X, y, optimize_hyperparameters=False)
-    assert gp_norm.models[0]._normalize_y
-    assert hasattr(gp_norm.models[0], "mean_y_")
+    assert gp_norm.models[0].transformer.normalize_y
+    assert gp_norm.models[0].transformer.mean_y_ is not None
 
     mu_hat_prime, var_hat_prime = gp_norm.predict(X_test)
     np.testing.assert_array_almost_equal(mu_hat, mu_hat_prime, decimal=4)

--- a/tests/test_model/test_rf.py
+++ b/tests/test_model/test_rf.py
@@ -74,8 +74,8 @@ def test_train_with_pca():
 
     assert model._n_features == 10
     assert model._n_hps == 10
-    assert model._pca is not None
-    assert model._scaler is not None
+    assert model.transformer.pca_ is not None
+    assert model.transformer.scaler_ is not None
 
 
 def test_predict_marginalized_over_instances_wrong_X_dimensions():

--- a/tests/test_runhistory/test_runhistory_encoder.py
+++ b/tests/test_runhistory/test_runhistory_encoder.py
@@ -71,36 +71,42 @@ def test_transform(runhistory, make_scenario, configspace_small, configs):
     encoder = RunHistoryLogEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
+    Y = encoder.transform_response_values(Y)
     assert Y.tolist() != Y1.tolist()
     assert ((X <= upper) & (X >= lower)).all()
 
     encoder = RunHistoryLogScaledEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
+    Y = encoder.transform_response_values(Y)
     assert Y.tolist() != Y1.tolist()
     assert ((X <= upper) & (X >= lower)).all()
 
     encoder = RunHistoryScaledEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
+    Y = encoder.transform_response_values(Y)
     assert Y.tolist() != Y1.tolist()
     assert ((X <= upper) & (X >= lower)).all()
 
     encoder = RunHistoryInverseScaledEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
+    Y = encoder.transform_response_values(Y)
     assert Y.tolist() != Y1.tolist()
     assert ((X <= upper) & (X >= lower)).all()
 
     encoder = RunHistorySqrtScaledEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
+    Y = encoder.transform_response_values(Y)
     assert Y.tolist() != Y1.tolist()
     assert ((X <= upper) & (X >= lower)).all()
 
     encoder = RunHistoryEIPSEncoder(scenario=scenario, considered_states=[StatusType.SUCCESS])
     encoder.runhistory = runhistory
     X, Y = encoder.transform()
+    Y = encoder.transform_response_values(Y)
     assert Y.tolist() != Y1.tolist()
     assert ((X <= upper) & (X >= lower)).all()
 


### PR DESCRIPTION
This PR introduces `SurrogateTransformer`, a centralized preprocessing pipeline for surrogate models.

Previously, preprocessing logic was distributed across individual surrogate models and multiple locations in the codebase, making it difficult to understand, reproduce, and modify the applied transformations.

`SurrogateTransformer` consolidates preprocessing into a single component handling:
- configuration preprocessing (e.g., inactive hyperparameter imputation)
- instance feature preprocessing (scaling and optional PCA)
- target preprocessing (transformations and normalization)
- inverse target transformations
- preprocessing for marginalized predictions

Surrogate models now delegate preprocessing to `SurrogateTransformer` instead of implementing their own logic, providing a consistent and easier-to-maintain preprocessing pipeline.

Additionally, this fixes an issue in the random forest surrogate where PCA and scaling were applied during `train` and `predict`, but not during `predict_marginalized`, causing inconsistent input dimensions and failures. See issue [#1323](https://github.com/automl/SMAC3/issues/1323).