### PR TITLE
Handle exhausted configuration spaces gracefully in intensifiers

### DIFF
--- a/smac/intensifier/intensifier.py
+++ b/smac/intensifier/intensifier.py
@@ -9,6 +9,7 @@ import numpy as np
 from ConfigSpace import Configuration
 
 from smac.intensifier.abstract_intensifier import AbstractIntensifier
+from smac.main.exceptions import ConfigurationSpaceExhaustedException
 from smac.runhistory import TrialInfo
 from smac.runhistory.dataclasses import InstanceSeedBudgetKey, InstanceSeedKey, TrialKey
 from smac.scenario import Scenario
@@ -260,6 +261,12 @@ class Intensifier(AbstractIntensifier):
                     logger.warning(
                         "If you assume your configspace was not yet exhausted, try to "
                         "increase the number of retries in the config selector."
+                    )
+                    return
+                except ConfigurationSpaceExhaustedException:
+                    logger.info(
+                        "Configuration space exhausted. No further challenger configurations "
+                        "can be generated. Finishing optimization"
                     )
                     return
             else:

--- a/smac/intensifier/successive_halving.py
+++ b/smac/intensifier/successive_halving.py
@@ -10,6 +10,7 @@ from ConfigSpace import Configuration
 
 from smac.constants import MAXINT
 from smac.intensifier.abstract_intensifier import AbstractIntensifier
+from smac.main.exceptions import ConfigurationSpaceExhaustedException
 from smac.runhistory import RunHistory, TrialInfo
 from smac.runhistory.dataclasses import InstanceSeedBudgetKey
 from smac.runhistory.errors import NotEvaluatedError
@@ -369,6 +370,10 @@ class SuccessiveHalving(AbstractIntensifier):
                     except StopIteration:
                         # We stop if we don't find any configuration anymore
                         return
+                    except ConfigurationSpaceExhaustedException as e:
+                        raise RuntimeError(
+                            "Configuration space exhausted while creating the initial " "Successive Halving population."
+                        ) from e
 
                 seed = self._get_next_order_seed()
                 self._tracker[(bracket, stage)].append((seed, configs))
@@ -456,6 +461,12 @@ class SuccessiveHalving(AbstractIntensifier):
                     logger.warning(
                         "If you assume your configspace was not yet exhausted, try to "
                         "increase the number of max_new_config_tries in the config selector."
+                    )
+                    return
+                except ConfigurationSpaceExhaustedException:
+                    logger.info(
+                        "Configuration space exhausted. No further challenger configurations "
+                        "can be generated. Finishing optimization"
                     )
                     return
 

--- a/tests/test_main/test_config_selector.py
+++ b/tests/test_main/test_config_selector.py
@@ -7,6 +7,7 @@ from smac import HyperparameterOptimizationFacade, Scenario
 
 def test_exhausted_configspace():
     cs = ConfigurationSpace()
+    # The configuration space contains only 3 possible configurations.
     cs.add(Categorical("x", [1, 2, 3]))
 
     def objective_function(x, seed):
@@ -23,5 +24,7 @@ def test_exhausted_configspace():
         overwrite=True,
     )
 
-    with pytest.raises(ConfigurationSpaceExhaustedException):
-        smac.optimize()
+    smac.optimize()
+
+    # SMAC should stop gracefully after evaluating all 3 configurations.
+    assert len(smac.runhistory.get_configs()) == 3


### PR DESCRIPTION
This PR fixes the handling of exhausted configuration spaces in intensifiers.

Previously, `ConfigurationSpaceExhaustedException` was propagated and stopped the optimization with an error. While this behavior was usually not an issue for scenarios without instances, it becomes problematic for instance-based scenarios where the racing mechanism evaluates configurations on a varying number of instances. As a result, the total number of trials required before exhausting the configuration space cannot be determined beforehand, making it difficult to choose a safe `n_trials` value.

Now, exhausted configuration spaces are treated as a normal stopping condition, allowing SMAC to terminate gracefully.

Changes include:
- Catch `ConfigurationSpaceExhaustedException` in intensifiers.
- Stop optimization gracefully when no further configurations can be generated.
- Update the exhausted configuration space test to reflect the new behavior.