### PR TITLE
Validate instance features for non-finite values before optimization

### DIFF
--- a/smac/scenario.py
+++ b/smac/scenario.py
@@ -146,6 +146,7 @@ class Scenario:
         if self.instance_features is not None:
             instance_features = {str(instance): features for instance, features in self.instance_features.items()}
             object.__setattr__(self, "instance_features", instance_features)
+            self._check_instance_features(instance_features)
 
         # Validate that we have a runtime cutoff set if adaptive capping slackfactor is given
         if self.adaptive_capping_slackfactor is not None and self.runtime_cutoff is None:
@@ -184,6 +185,16 @@ class Scenario:
         Meta data are set when the facade is initialized.
         """
         return self._meta  # type: ignore
+
+    @staticmethod
+    def _check_instance_features(instance_features: dict[str, list[float]]) -> None:
+        """Checks whether instance features contain only finite values."""
+        for instance, features in instance_features.items():
+            if not np.isfinite(features).all():
+                raise ValueError(
+                    f"Instance features for instance '{instance}' contain non-finite values. "
+                    "Please provide finite numerical instance features before passing them to SMAC."
+                )
 
     def count_objectives(self) -> int:
         """Counts the number of objectives."""


### PR DESCRIPTION
This PR validate instance features when creating a `Scenario`.

Previously, non-finite instance features (e.g. `NaN` or `±inf`) were only detected later by downstream preprocessing or surrogate models, often resulting in cryptic warnings or errors. Now, SMAC validates instance features upfront and raises a clear `ValueError` if non-finite values are present, allowing users to correct their data before the optimization starts.