### PR TITLE
Fix duplicate step IDs in release workflow #1341

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -20,7 +20,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel build twine
 
       - name: Determine package version
-        id: vars
+        id: package-version
         run: |
           echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
@@ -29,7 +29,7 @@ jobs:
           python -m build --sdist --wheel
 
       - name: Export tag
-        id: vars
+        id: export-tag
         run: echo tag=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
         if: ${{ github.event_name == 'release' }}
 
@@ -37,7 +37,7 @@ jobs:
         run: |
           sed -i "s/^version = \".*\"/version = \"$RELEASE_VERSION\"/" pyproject.toml
         env:
-          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.export-tag.outputs.tag }}
         if: ${{ github.event_name == 'release' }}
 
       - name: Upload updated pyproject.toml


### PR DESCRIPTION
The release workflow used `vars` as the ID for two different steps, which caused GitHub Actions to reject the workflow.