### PR TITLE
v.2.4.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ date-released: "2016-08-17"
 url: "https://automl.github.io/SMAC3/master/index.html"
 repository-code: "https://github.com/automl/SMAC3"
 
-version: "2.4.0"
+version: "2.4.1"
 
 type: "software"
 keywords:

--- a/docs/devnotes/test_package.sh
+++ b/docs/devnotes/test_package.sh
@@ -1,4 +1,4 @@
-export SMACVERSION="2.4.0"
+export SMACVERSION="2.4.1"
 make clean 
 make build
 pip install uv

--- a/smac/__init__.py
+++ b/smac/__init__.py
@@ -8,7 +8,7 @@ author = (
     "Difan Deng,\n\tCarolin Benjamins, Tim Ruhkopf, René Sass and Frank Hutter"
 )
 
-author_email = "fh@cs.uni-freiburg.de"
+author_email = "smac@ai.uni-hannover.de"
 description = "SMAC3, a Python implementation of 'Sequential Model-based Algorithm Configuration'."
 url = "https://www.automl.org/"
 project_urls = {
@@ -20,7 +20,7 @@ copyright = (
     "Matthias Feurer, André Biedenkapp, Difan Deng, Carolin Benjamins, Tim Ruhkopf, René Sass "
     "and Frank Hutter"
 )
-version = "2.4.0"
+version = "2.4.1"
 
 
 try:


### PR DESCRIPTION
# 2.4.1
## Bugfixes
- Scikit-learn 1.9 deprecated an alias for np.float32 called DTYPE. Change removes references to deprecated alias (#1314)
- Forbidden clauses weren't being preserved. Change fixes that and adds a test (#1306)
- Tests were failing due to an incompatibility between pytest and pytest-cases.  Pytest-cases is a dead stub, so simplest fix is to remove it.