### PR TITLE
Fix stale doc links

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ message: "If you used SMAC in one of your research projects, please cite us:"
 title: "SMAC3"
 date-released: "2016-08-17"
 
-url: "https://automl.github.io/SMAC3/master/index.html"
+url: "https://automl.github.io/SMAC3/latest/index.html"
 repository-code: "https://github.com/automl/SMAC3"
 
 version: "2.4.0"

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ clean-build:
 clean-data:
 	# remove all files that could have been left by test cases or by manual runs
 	# feel free to add more lines
-	find . -maxdepth 3 -iname 'smac3-output_*-*-*_*' | tac | while read -r TESTDIR ; do rm -Rf "$${TESTDIR}" ; done
+	find . -maxdepth 3 -iname 'smac3-output_*-*-*_*' -exec rm -Rf {} \;
 	find . -maxdepth 3 -iname '*.lock' -exec rm {} \;
 	rm -Rf run_*
 	rm -Rf test/test_files/scenario_test/tmp_output_*

--- a/docs/devnotes/release_flow.md
+++ b/docs/devnotes/release_flow.md
@@ -38,12 +38,26 @@ If you do not use `uv`, remove `uv` from the commands.
 1. Create a PR to merge branch `v${VERSION}` into `main`. As description you can use the changelog notes.
 1. Test installation with a fresh environment, see `test_package.sh`.
 1. Merge PR if tests are fine and installation is fine.
-1. Create release, add notes from changelog.
-1. Update doc link.
-1. Deploy github pages (replace version in the following command):
+1. Create release, add notes from changelog:
+    - On GitHub, go to **Releases → Draft a new release**.
+    - Tag `v${VERSION}`, targeting `main` (the commit the PR was just merged into).
+    - Title: `v${VERSION}`.
+    - Paste the corresponding `CHANGELOG.md` section as the release notes.
+    - Publish.
+
+1. Update doc link. Check the repo's **Website** field (GitHub Settings → General → Website) still points at `https://automl.github.io/SMAC3/latest/`.
+
+1. Deploy github pages (uses `${VERSION}` exported above):
     ```bash
     mike deploy "v${VERSION}" latest -u -p --title "v${VERSION} (latest)"
     ```
+    This only touches the `gh-pages` branch (builds and pushes the docs site, moves the `latest` alias). After pushing, GitHub Pages can take a few minutes to actually serve the update — a stale-looking site right after deploy isn't necessarily a failed deploy; check `https://automl.github.io/SMAC3/versions.json` for the new version before assuming something's wrong.
+
+1. Build the distribution:
+    ```bash
+    make build
+    ```
+    (Run `make clean-build` first if `dist/` might still contain artifacts from a previous release — `twine upload dist/*` below uploads everything it finds there.)
 
 1. Upload to testpypi:
     ```bash
@@ -53,7 +67,7 @@ If you do not use `uv`, remove `uv` from the commands.
 1. Test from testpypi:
     ```bash
     uv pip uninstall smac
-    uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ smac==${VERSION}
+    uv pip install --index-strategy unsafe-best-match --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ smac==${VERSION}
     python -c 'import smac'
     ```
     If this is fine, proceed.

--- a/smac/__init__.py
+++ b/smac/__init__.py
@@ -12,7 +12,7 @@ author_email = "fh@cs.uni-freiburg.de"
 description = "SMAC3, a Python implementation of 'Sequential Model-based Algorithm Configuration'."
 url = "https://www.automl.org/"
 project_urls = {
-    "Documentation": "https://automl.github.io/SMAC3/main",
+    "Documentation": "https://automl.github.io/SMAC3/latest",
     "Source Code": "https://github.com/automl/SMAC3",
 }
 copyright = (


### PR DESCRIPTION
I updated soem doc on the release workflow, and the building process to make it independent on the machine SMAC is being built on. Also update some repo metadata